### PR TITLE
Reduce public API surface: 613 → 252 symbols (59% reduction)

### DIFF
--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -1,19 +1,5 @@
 #nullable enable
-abstract Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.Name.get -> string!
-abstract Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.BaseExporterAsync<T>.ExportAsync(System.Collections.Generic.IReadOnlyCollection<T!>! batch, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-const Microsoft.OpenTelemetry.Agent365.DTOs.SpanKindConstants.Client = "Client" -> string!
-const Microsoft.OpenTelemetry.Agent365.DTOs.SpanKindConstants.Consumer = "Consumer" -> string!
-const Microsoft.OpenTelemetry.Agent365.DTOs.SpanKindConstants.Internal = "Internal" -> string!
-const Microsoft.OpenTelemetry.Agent365.DTOs.SpanKindConstants.Producer = "Producer" -> string!
-const Microsoft.OpenTelemetry.Agent365.DTOs.SpanKindConstants.Server = "Server" -> string!
-const Microsoft.OpenTelemetry.Agent365.Etw.Constants.EtwCategoryPrefix = "A365.Observability.Etw." -> string!
-const Microsoft.OpenTelemetry.Agent365.Extensions.AgentFramework.BuilderExtensions.AgentFrameworkAgentSource = "Experimental.Microsoft.Agents.AI.Agent" -> string!
-const Microsoft.OpenTelemetry.Agent365.Extensions.AgentFramework.BuilderExtensions.AgentFrameworkChatClientSource = "Experimental.Microsoft.Agents.AI.ChatClient" -> string!
-const Microsoft.OpenTelemetry.Agent365.Extensions.AgentFramework.BuilderExtensions.AgentFrameworkSource = "Experimental.Microsoft.Agents.AI" -> string!
-const Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.OutputLoggingMiddleware.A365ParentTraceparentKey = "A365ParentTraceparent" -> string!
 const Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions.DefaultEndpointHost = "agent365.svc.cloud.microsoft" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.AutoInstrumentationConstants.GenAiInvocationInputKey = "gen_ai.agent.invocation_input" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.AutoInstrumentationConstants.GenAiInvocationOutputKey = "gen_ai.agent.invocation_output" -> string!
 const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope.OperationName = "execute_tool" -> string!
 const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope.OperationName = "invoke_agent" -> string!
 const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.AgentAUIDKey = "microsoft.agent.user.id" -> string!
@@ -77,12 +63,6 @@ const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.Use
 const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.UserIdKey = "user.id" -> string!
 const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.UserNameKey = "user.name" -> string!
 const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OutputScope.OperationName = "output_messages" -> string!
-Microsoft.OpenTelemetry.Agent365.Builder
-Microsoft.OpenTelemetry.Agent365.Builder.Build() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-Microsoft.OpenTelemetry.Agent365.Builder.Builder(Microsoft.Extensions.DependencyInjection.IServiceCollection! services, Microsoft.Extensions.Configuration.IConfiguration? configuration, bool useOpenTelemetryBuilder = true, Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType agent365ExporterType = Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType.Agent365Exporter) -> void
-Microsoft.OpenTelemetry.Agent365.Builder.Configuration.get -> Microsoft.Extensions.Configuration.IConfiguration?
-Microsoft.OpenTelemetry.Agent365.Builder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-Microsoft.OpenTelemetry.Agent365.Common.ActivityExtensions
 Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder
 Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder.AgentBlueprintId(string? v) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
 Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder.AgentDescription(string? v) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
@@ -109,171 +89,6 @@ Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder.UserClientIp(System.Net.I
 Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder.UserEmail(string? v) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
 Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder.UserId(string? v) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
 Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder.UserName(string? v) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
-Microsoft.OpenTelemetry.Agent365.Common.EnvironmentUtils
-Microsoft.OpenTelemetry.Agent365.Common.EnvironmentUtils.EnvironmentUtils() -> void
-Microsoft.OpenTelemetry.Agent365.Common.ExportFormatter
-Microsoft.OpenTelemetry.Agent365.Common.ExportFormatter.ExportFormatter(Microsoft.Extensions.Logging.ILogger<Microsoft.OpenTelemetry.Agent365.Common.ExportFormatter!>! logger) -> void
-Microsoft.OpenTelemetry.Agent365.Common.ExportFormatter.FormatLogData(System.Collections.Generic.IDictionary<string!, object?>! data) -> string!
-Microsoft.OpenTelemetry.Agent365.Common.ExportFormatter.FormatMany(System.Collections.Generic.IEnumerable<System.Diagnostics.Activity!>! activities, OpenTelemetry.Resources.Resource! resource) -> string!
-Microsoft.OpenTelemetry.Agent365.Common.ExportFormatter.FormatSingle(System.Diagnostics.Activity! activity, OpenTelemetry.Resources.Resource! resource) -> string!
-Microsoft.OpenTelemetry.Agent365.Common.PowerPlatformApiDiscovery
-Microsoft.OpenTelemetry.Agent365.Common.PowerPlatformApiDiscovery.GetTenantEndpoint(string! tenantId) -> string!
-Microsoft.OpenTelemetry.Agent365.Common.PowerPlatformApiDiscovery.GetTenantIslandClusterEndpoint(string! tenantId) -> string!
-Microsoft.OpenTelemetry.Agent365.Common.PowerPlatformApiDiscovery.GetTokenAudience() -> string!
-Microsoft.OpenTelemetry.Agent365.Common.PowerPlatformApiDiscovery.GetTokenEndpointHost() -> string!
-Microsoft.OpenTelemetry.Agent365.Common.PowerPlatformApiDiscovery.PowerPlatformApiDiscovery(string! clusterCategory) -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.Attributes.get -> System.Collections.Generic.IDictionary<string!, object?>!
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.BaseData(System.Collections.Generic.IDictionary<string!, object?>? attributes = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, string? spanKind = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.Duration.get -> System.TimeSpan
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.EndTime.get -> System.DateTimeOffset?
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.EndTime.set -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.ParentSpanId.get -> string?
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.SpanId.get -> string!
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.SpanKind.get -> string?
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.StartTime.get -> System.DateTimeOffset?
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.StartTime.set -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.ToDictionary() -> System.Collections.Generic.Dictionary<string!, object?>!
-Microsoft.OpenTelemetry.Agent365.DTOs.BaseData.TraceId.get -> string?
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.BaseDataBuilder() -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.ExecuteInferenceDataBuilder
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.ExecuteInferenceDataBuilder.ExecuteInferenceDataBuilder() -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.ExecuteToolDataBuilder
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.ExecuteToolDataBuilder.ExecuteToolDataBuilder() -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.InvokeAgentDataBuilder
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.InvokeAgentDataBuilder.InvokeAgentDataBuilder() -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.OutputDataBuilder
-Microsoft.OpenTelemetry.Agent365.DTOs.Builders.OutputDataBuilder.OutputDataBuilder() -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.ExecuteInferenceData
-Microsoft.OpenTelemetry.Agent365.DTOs.ExecuteInferenceData.ExecuteInferenceData(System.Collections.Generic.IDictionary<string!, object?>? attributes = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.ExecuteToolData
-Microsoft.OpenTelemetry.Agent365.DTOs.ExecuteToolData.ExecuteToolData(System.Collections.Generic.IDictionary<string!, object?>? attributes = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, string? spanKind = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.InvokeAgentData
-Microsoft.OpenTelemetry.Agent365.DTOs.InvokeAgentData.InvokeAgentData(System.Collections.Generic.IDictionary<string!, object?>? attributes = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, string? spanKind = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.OutputData
-Microsoft.OpenTelemetry.Agent365.DTOs.OutputData.OutputData(System.Collections.Generic.IDictionary<string!, object?>? attributes = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.DTOs.SpanKindConstants
-Microsoft.OpenTelemetry.Agent365.Etw.A365EtwLogger<T>
-Microsoft.OpenTelemetry.Agent365.Etw.A365EtwLogger<T>.A365EtwLogger(Microsoft.Extensions.Logging.ILoggerFactory! factory) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.A365EtwLogger<T>.LogInferenceCall(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InferenceCallDetails! inferenceCallDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string![]? inputMessages, string![]? outputMessages, System.DateTimeOffset? startTime, System.DateTimeOffset? endTime, string? spanId, string? parentSpanId, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails, string? traceId) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.A365EtwLogger<T>.LogInvokeAgent(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InvokeAgentScopeDetails! invokeAgentScopeDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request? request, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails, string![]? inputMessages, string![]? outputMessages, System.DateTimeOffset? startTime, System.DateTimeOffset? endTime, string? spanId, string? parentSpanId, string? traceId) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.A365EtwLogger<T>.LogOutput(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Response! response, string? conversationId = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.A365EtwLogger<T>.LogToolCall(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolCallDetails! toolCallDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string? responseContent, System.DateTimeOffset? startTime, System.DateTimeOffset? endTime, string? spanId, string? parentSpanId, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails, string? traceId) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.Constants
-Microsoft.OpenTelemetry.Agent365.Etw.Constants.Constants() -> void
-Microsoft.OpenTelemetry.Agent365.Etw.EtwEventSource
-Microsoft.OpenTelemetry.Agent365.Etw.EtwEventSource.LogJson(string! message) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.EtwEventSource.SpanStop(string! name, string! spanId, string! traceId, string! parentSpanId, string! content) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.EtwLoggingBuilder
-Microsoft.OpenTelemetry.Agent365.Etw.EtwLoggingBuilder.Build() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-Microsoft.OpenTelemetry.Agent365.Etw.EtwLogProcessor
-Microsoft.OpenTelemetry.Agent365.Etw.EtwLogProcessor.EtwLogProcessor(Microsoft.OpenTelemetry.Agent365.Common.ExportFormatter! formatter, Microsoft.Extensions.Logging.ILogger<Microsoft.OpenTelemetry.Agent365.Etw.EtwLogProcessor!>? logger = null) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.EtwScopeEventProcessor
-Microsoft.OpenTelemetry.Agent365.Etw.EtwScopeEventProcessor.EtwScopeEventProcessor(Microsoft.OpenTelemetry.Agent365.Common.ExportFormatter! formatter, OpenTelemetry.Resources.Resource? resource = null, Microsoft.Extensions.Logging.ILogger<Microsoft.OpenTelemetry.Agent365.Etw.EtwScopeEventProcessor!>? logger = null) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.EtwServiceCollectionExtensions
-Microsoft.OpenTelemetry.Agent365.Etw.EtwTracingBuilder
-Microsoft.OpenTelemetry.Agent365.Etw.EtwTracingBuilder.Build() -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-Microsoft.OpenTelemetry.Agent365.Etw.IA365EtwLogger<T>
-Microsoft.OpenTelemetry.Agent365.Etw.IA365EtwLogger<T>.LogInferenceCall(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InferenceCallDetails! inferenceCallDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string![]? inputMessages = null, string![]? outputMessages = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.IA365EtwLogger<T>.LogInvokeAgent(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InvokeAgentScopeDetails! invokeAgentScopeDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request? request = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, string![]? inputMessages = null, string![]? outputMessages = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.IA365EtwLogger<T>.LogOutput(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Response! response, string? conversationId = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.Etw.IA365EtwLogger<T>.LogToolCall(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolCallDetails! toolCallDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string? responseContent = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, string? traceId = null) -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.AgentFramework.BuilderExtensions
-Microsoft.OpenTelemetry.Agent365.Extensions.OpenAI.BuilderExtensions
-Microsoft.OpenTelemetry.Agent365.Extensions.OpenAI.ChatToolCallExtensions
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.BuilderExtensions
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.ChatCompletionAgentExtensions
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.FunctionInvocationFilter
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.FunctionInvocationFilter.FunctionInvocationFilter() -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.FunctionInvocationFilter.OnFunctionInvocationAsync(Microsoft.SemanticKernel.FunctionInvocationContext! context, System.Func<Microsoft.SemanticKernel.FunctionInvocationContext!, System.Threading.Tasks.Task!>! next) -> System.Threading.Tasks.Task!
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoice
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoice.AiChoice() -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoice.Message.get -> Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceMessage?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoice.Message.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceArguments
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceArguments.AiChoiceArguments() -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceArguments.MessageBody.get -> string?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceArguments.MessageBody.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceFunction
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceFunction.AiChoiceFunction() -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceFunction.Arguments.get -> Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceArguments?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceFunction.Arguments.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceMessage
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceMessage.AiChoiceMessage() -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceMessage.Content.get -> string?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceMessage.Content.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceMessage.Role.get -> string?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceMessage.Role.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceMessage.ToolCalls.get -> System.Collections.Generic.List<Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceToolCall!>?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceMessage.ToolCalls.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceToolCall
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceToolCall.AiChoiceToolCall() -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceToolCall.Function.get -> Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceFunction?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.AiChoiceToolCall.Function.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.MessageContent
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.MessageContent.Content.get -> string?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.MessageContent.Content.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.MessageContent.MessageContent() -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.MessageContent.Name.get -> string?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.MessageContent.Name.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.MessageContent.Role.get -> string?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.MessageContent.Role.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.NestedContent
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.NestedContent.Content.get -> string?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.NestedContent.Content.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.NestedContent.ContentType.get -> string?
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.NestedContent.ContentType.set -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models.NestedContent.NestedContent() -> void
-Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Utils.SemanticKernelSpanProcessorHelper
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.AgenticTokenCache(System.TimeSpan? cleanupInterval = null) -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.Count.get -> int
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.Dispose() -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.GetObservabilityToken(string! agentId, string! tenantId) -> System.Threading.Tasks.Task<string?>!
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.InvalidateAll() -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.InvalidateToken(string! agentId, string! tenantId) -> bool
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.RegisterObservability(string! agentId, string! tenantId, Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct! tokenGenerator, string![]! observabilityScopes) -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.RemoveExpiredTokens() -> int
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct.AgenticTokenStruct(Microsoft.Agents.Builder.App.UserAuth.UserAuthorization! userAuthorization, Microsoft.Agents.Builder.ITurnContext! turnContext, string! authHandlerName, string? connectionName = null) -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct.AuthHandlerName.get -> string!
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct.AuthHandlerName.set -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct.ConnectionName.get -> string?
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct.ConnectionName.set -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct.TurnContext.get -> Microsoft.Agents.Builder.ITurnContext!
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct.TurnContext.set -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct.UserAuthorization.get -> Microsoft.Agents.Builder.App.UserAuth.UserAuthorization!
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenStruct.UserAuthorization.set -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.IExporterTokenCache<T>
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.IExporterTokenCache<T>.GetObservabilityToken(string! agentId, string! tenantId) -> System.Threading.Tasks.Task<string?>!
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.IExporterTokenCache<T>.RegisterObservability(string! agentId, string! tenantId, T! tokenGenerator, string![]! observabilityScopes) -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.Count.get -> int
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.Dispose() -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.GetObservabilityToken(string! agentId, string! tenantId) -> System.Threading.Tasks.Task<string?>!
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.InvalidateAll() -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.InvalidateToken(string! agentId, string! tenantId) -> bool
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.RegisterObservability(string! agentId, string! tenantId, string! token, string![]! observabilityScopes) -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.RegisterObservability(string! agentId, string! tenantId, string! token, string![]! observabilityScopes, System.TimeSpan? expiresIn) -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.RemoveExpiredTokens() -> int
-Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.ServiceTokenCache(System.TimeSpan? defaultExpiration = null, System.TimeSpan? cleanupInterval = null) -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.BaggageBuilderExtensions
-Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.InvokeAgentScopeExtensions
-Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.TurnContextExtensions
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.BaggageTurnMiddleware
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.BaggageTurnMiddleware.BaggageTurnMiddleware() -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.BaggageTurnMiddleware.OnTurnAsync(Microsoft.Agents.Builder.ITurnContext! turnContext, Microsoft.Agents.Builder.NextDelegate! next, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.ObservabilityBaggageMiddleware
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.ObservabilityBaggageMiddleware.InvokeAsync(Microsoft.AspNetCore.Http.HttpContext! ctx) -> System.Threading.Tasks.Task!
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.ObservabilityBaggageMiddleware.ObservabilityBaggageMiddleware(Microsoft.AspNetCore.Http.RequestDelegate! next, System.Func<Microsoft.AspNetCore.Http.HttpContext!, (string? tenant, string? agentId)>? resolver = null, bool tagActivity = true) -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.ObservabilityBaggageMiddlewareExtensions
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.OutputLoggingMiddleware
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.OutputLoggingMiddleware.OnTurnAsync(Microsoft.Agents.Builder.ITurnContext! turnContext, Microsoft.Agents.Builder.NextDelegate! next, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.OutputLoggingMiddleware.OutputLoggingMiddleware() -> void
-Microsoft.OpenTelemetry.Agent365.Hosting.ObservabilityBuilderExtensions
-Microsoft.OpenTelemetry.Agent365.Hosting.ObservabilityServiceCollectionExtensions
-Microsoft.OpenTelemetry.Agent365.ObservabilityBuilderExtensions
 Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails
 Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails.AgentBlueprintId.get -> string?
 Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails.AgentClientIP.get -> System.Net.IPAddress?
@@ -376,17 +191,6 @@ Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails.UserDetails(strin
 Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails.UserEmail.get -> string?
 Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails.UserId.get -> string?
 Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails.UserName.get -> string?
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365Exporter
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365Exporter.Agent365Exporter(Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore! core, Microsoft.Extensions.Logging.ILogger<Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365Exporter!>! logger, Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions! options, OpenTelemetry.Resources.Resource? resource = null, System.Net.Http.HttpClient? httpClient = null) -> void
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterAsync
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterAsync.Agent365ExporterAsync(Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore! core, Microsoft.Extensions.Logging.ILogger<Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365Exporter!>! logger, Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions! options, OpenTelemetry.Resources.Resource? resource = null, System.Net.Http.HttpClient? httpClient = null) -> void
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore.Agent365ExporterCore(Microsoft.OpenTelemetry.Agent365.Common.ExportFormatter! formatter, Microsoft.Extensions.Logging.ILogger<Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore!>! logger) -> void
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore.BuildEndpointPath(string! tenantId, string! agentId, bool useS2SEndpoint) -> string!
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore.BuildRequestUri(string! endpoint, string! endpointPath) -> string!
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore.ExportBatchCoreAsync(System.Collections.Generic.IEnumerable<(string! TenantId, string! AgentId, System.Collections.Generic.List<System.Diagnostics.Activity!>! Activities)>! groups, OpenTelemetry.Resources.Resource! resource, Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions! options, System.Func<string!, string!, System.Threading.Tasks.Task<string?>!>! tokenResolver, System.Func<System.Net.Http.HttpRequestMessage!, System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage!>!>! sendAsync) -> System.Threading.Tasks.Task<OpenTelemetry.ExportResult>!
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore.PartitionByIdentity(in OpenTelemetry.Batch<System.Diagnostics.Activity!> batch) -> System.Collections.Generic.List<(string! TenantId, string! AgentId, System.Collections.Generic.List<System.Diagnostics.Activity!>! Activities)>!
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterCore.PartitionByIdentity(System.Collections.Generic.IEnumerable<System.Diagnostics.Activity!>! batch) -> System.Collections.Generic.List<(string! TenantId, string! AgentId, System.Collections.Generic.List<System.Diagnostics.Activity!>! Activities)>!
 Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions
 Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions.Agent365ExporterOptions() -> void
 Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions.ClusterCategory.get -> string!
@@ -405,21 +209,8 @@ Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions.Token
 Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions.TokenResolver.set -> void
 Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions.UseS2SEndpoint.get -> bool
 Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions.UseS2SEndpoint.set -> void
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType.Agent365Exporter = 0 -> Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType.Agent365ExporterAsync = 1 -> Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType
 Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.AsyncAuthTokenResolver
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.BaseExporterAsync<T>
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.BaseExporterAsync<T>.BaseExporterAsync() -> void
-Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.ObservabilityTracerProviderBuilderExtensions
 Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.TenantDomainResolver
-Microsoft.OpenTelemetry.Agent365.Tracing.Processors.ActivityProcessor
-Microsoft.OpenTelemetry.Agent365.Tracing.Processors.ActivityProcessor.ActivityProcessor() -> void
-Microsoft.OpenTelemetry.Agent365.Tracing.Processors.BatchActivityExportProcessorAsync
-Microsoft.OpenTelemetry.Agent365.Tracing.Processors.BatchActivityExportProcessorAsync.BatchActivityExportProcessorAsync(Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.BaseExporterAsync<System.Diagnostics.Activity!>! exporter, int maxQueueSize = 2048, int scheduledDelayMilliseconds = 5000, int maxExportBatchSize = 512) -> void
-Microsoft.OpenTelemetry.Agent365.Tracing.Processors.BatchActivityExportProcessorAsync.ForceFlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-Microsoft.OpenTelemetry.Agent365.Tracing.Processors.BatchActivityExportProcessorAsync.ShutdownAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.AutoInstrumentationConstants
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope.RecordResponse(string! response) -> void
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope.RecordThreatDiagnosticsSummary(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ThreatDiagnosticsSummary! threatDiagnosticsSummary) -> void
@@ -497,12 +288,6 @@ Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.MicrosoftOpenTelemetryOpti
 Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.OtlpEndpoint.get -> System.Uri?
 Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.OtlpEndpoint.set -> void
 Microsoft.OpenTelemetry.OpenTelemetryBuilderExtensions
-override Microsoft.OpenTelemetry.Agent365.DTOs.ExecuteInferenceData.Name.get -> string!
-override Microsoft.OpenTelemetry.Agent365.DTOs.ExecuteToolData.Name.get -> string!
-override Microsoft.OpenTelemetry.Agent365.DTOs.InvokeAgentData.Name.get -> string!
-override Microsoft.OpenTelemetry.Agent365.DTOs.OutputData.Name.get -> string!
-override Microsoft.OpenTelemetry.Agent365.Etw.EtwLogProcessor.OnEnd(OpenTelemetry.Logs.LogRecord! data) -> void
-override Microsoft.OpenTelemetry.Agent365.Etw.EtwScopeEventProcessor.OnEnd(System.Diagnostics.Activity! data) -> void
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails.Equals(object? obj) -> bool
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails.GetHashCode() -> int
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel.Equals(object? obj) -> bool
@@ -519,67 +304,6 @@ override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolCallDetails.Equa
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolCallDetails.GetHashCode() -> int
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails.Equals(object? obj) -> bool
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails.GetHashCode() -> int
-override Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365Exporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity!> batch) -> OpenTelemetry.ExportResult
-override Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterAsync.ExportAsync(System.Collections.Generic.IReadOnlyCollection<System.Diagnostics.Activity!>! batch, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-override Microsoft.OpenTelemetry.Agent365.Tracing.Processors.ActivityProcessor.OnStart(System.Diagnostics.Activity! activity) -> void
-override Microsoft.OpenTelemetry.Agent365.Tracing.Processors.BatchActivityExportProcessorAsync.Dispose(bool disposing) -> void
-override Microsoft.OpenTelemetry.Agent365.Tracing.Processors.BatchActivityExportProcessorAsync.OnEnd(System.Diagnostics.Activity! data) -> void
-override Microsoft.OpenTelemetry.Agent365.Tracing.Processors.BatchActivityExportProcessorAsync.ToString() -> string!
-static Microsoft.OpenTelemetry.Agent365.Common.ActivityExtensions.CoalesceTag(this System.Diagnostics.Activity! activity, string! key, params string?[]! values) -> void
-static Microsoft.OpenTelemetry.Agent365.Common.ActivityExtensions.GetAttributeOrBaggage(this System.Diagnostics.Activity! activity, string! key) -> string?
-static Microsoft.OpenTelemetry.Agent365.Common.EnvironmentUtils.GetObservabilityAuthenticationScope() -> string![]!
-static Microsoft.OpenTelemetry.Agent365.Common.EnvironmentUtils.GetObservabilityAuthenticationScope(string! clusterCategory = "prod") -> string![]!
-static Microsoft.OpenTelemetry.Agent365.Common.EnvironmentUtils.GetObservabilityClusterCategory() -> string!
-static Microsoft.OpenTelemetry.Agent365.Common.EnvironmentUtils.GetObservabilityClusterCategory(string! clusterCategory = "prod") -> string!
-static Microsoft.OpenTelemetry.Agent365.Common.EnvironmentUtils.IsDevelopmentEnvironment() -> bool
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddAgentDetails(System.Collections.Generic.IDictionary<string!, object?>! attributes, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddCallerAgentDetails(System.Collections.Generic.IDictionary<string!, object?>! attributes, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails? callerAgentDetails) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddCallerDetails(System.Collections.Generic.IDictionary<string!, object?>! attributes, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddChannelAttributes(System.Collections.Generic.IDictionary<string!, object?>! attributes, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddEndpointDetails(System.Collections.Generic.IDictionary<string!, object?>! attributes, System.Uri? endpoint) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddExtraAttributes(System.Collections.Generic.IDictionary<string!, object?>! attributes, System.Collections.Generic.IDictionary<string!, object?>? extraAttributes) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddIfNotNull(System.Collections.Generic.IDictionary<string!, object?>! attributes, string! key, object? value) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddInputMessagesAttributes(System.Collections.Generic.IDictionary<string!, object?>! attributes, string![]? messages) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddOutputMessagesAttributes(System.Collections.Generic.IDictionary<string!, object?>! attributes, string![]? messages) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.BaseDataBuilder<T>.AddRequestDetails(System.Collections.Generic.IDictionary<string!, object?>! attributes, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request? request) -> void
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.ExecuteInferenceDataBuilder.Build(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InferenceCallDetails! inferenceCallDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string![]? inputMessages = null, string![]? outputMessages = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel = null, string? thoughtProcess = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, System.Collections.Generic.IDictionary<string!, object?>? extraAttributes = null, string? traceId = null) -> Microsoft.OpenTelemetry.Agent365.DTOs.ExecuteInferenceData!
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.ExecuteToolDataBuilder.Build(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolCallDetails! toolCallDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string? responseContent = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, System.Collections.Generic.IDictionary<string!, object?>? extraAttributes = null, string? spanKind = null, string? traceId = null) -> Microsoft.OpenTelemetry.Agent365.DTOs.ExecuteToolData!
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.InvokeAgentDataBuilder.Build(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InvokeAgentScopeDetails! invokeAgentScopeDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request? request = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, string![]? inputMessages = null, string![]? outputMessages = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, System.Collections.Generic.IDictionary<string!, object?>? extraAttributes = null, string? spanKind = null, string? traceId = null) -> Microsoft.OpenTelemetry.Agent365.DTOs.InvokeAgentData!
-static Microsoft.OpenTelemetry.Agent365.DTOs.Builders.OutputDataBuilder.Build(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Response! response, string? conversationId = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel? channel = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? parentSpanId = null, System.Collections.Generic.IDictionary<string!, object?>? extraAttributes = null, string? traceId = null) -> Microsoft.OpenTelemetry.Agent365.DTOs.OutputData!
-static Microsoft.OpenTelemetry.Agent365.Etw.EtwServiceCollectionExtensions.AddLoggingWithEtw(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.OpenTelemetry.Agent365.Etw.EtwLoggingBuilder!>? configure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.OpenTelemetry.Agent365.Etw.EtwServiceCollectionExtensions.AddTracingWithEtw(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<Microsoft.OpenTelemetry.Agent365.Etw.EtwTracingBuilder!>? configure = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.OpenTelemetry.Agent365.Extensions.AgentFramework.BuilderExtensions.WithAgentFramework(this Microsoft.OpenTelemetry.Agent365.Builder! builder, bool enableRelatedSources = true, params string![]! additionalSources) -> Microsoft.OpenTelemetry.Agent365.Builder!
-static Microsoft.OpenTelemetry.Agent365.Extensions.OpenAI.BuilderExtensions.WithOpenAI(this Microsoft.OpenTelemetry.Agent365.Builder! builder, bool enableRelatedSources = true) -> Microsoft.OpenTelemetry.Agent365.Builder!
-static Microsoft.OpenTelemetry.Agent365.Extensions.OpenAI.ChatToolCallExtensions.Trace(this OpenAI.Chat.ChatToolCall! chatToolCall, string! agentId, string? tenantId = null) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope?
-static Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.BuilderExtensions.WithSemanticKernel(this Microsoft.OpenTelemetry.Agent365.Builder! builder, bool enableRelatedSources = true) -> Microsoft.OpenTelemetry.Agent365.Builder!
-static Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.ChatCompletionAgentExtensions.WithTracing(this Microsoft.SemanticKernel.Agents.ChatCompletionAgent! agent) -> Microsoft.SemanticKernel.Agents.ChatCompletionAgent!
-static Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Utils.SemanticKernelSpanProcessorHelper.GetGenAiUserAndChoiceMessageContent(System.Diagnostics.Activity! activity) -> System.Collections.Generic.Dictionary<string!, System.Collections.Generic.List<string!>!>!
-static Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Utils.SemanticKernelSpanProcessorHelper.ProcessInvocationInputOutputTag(System.Diagnostics.Activity! activity, bool suppressInvocationInput = false) -> void
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.BaggageBuilderExtensions.FromTurnContext(this Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder! baggageBuilder, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.BaggageBuilderExtensions.SetCallerBaggage(this Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder! baggageBuilder, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.BaggageBuilderExtensions.SetChannelBaggage(this Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder! baggageBuilder, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.BaggageBuilderExtensions.SetConversationIdBaggage(this Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder! baggageBuilder, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.BaggageBuilderExtensions.SetTargetAgentBaggage(this Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder! baggageBuilder, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.BaggageBuilderExtensions.SetTenantIdBaggage(this Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder! baggageBuilder, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.InvokeAgentScopeExtensions.FromTurnContext(this Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope! invokeAgentScope, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.InvokeAgentScopeExtensions.SetCallerTags(this Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope! invokeAgentScope, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.InvokeAgentScopeExtensions.SetChannelTags(this Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope! invokeAgentScope, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.InvokeAgentScopeExtensions.SetConversationIdTags(this Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope! invokeAgentScope, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.InvokeAgentScopeExtensions.SetInputMessageTags(this Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope! invokeAgentScope, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.InvokeAgentScopeExtensions.SetTargetAgentTags(this Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope! invokeAgentScope, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.InvokeAgentScopeExtensions.SetTenantIdTags(this Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope! invokeAgentScope, Microsoft.Agents.Builder.ITurnContext! turnContext) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.TurnContextExtensions.GetCallerBaggagePairs(this Microsoft.Agents.Builder.ITurnContext! turnContext) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.TurnContextExtensions.GetChannelBaggagePairs(this Microsoft.Agents.Builder.ITurnContext! turnContext) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.TurnContextExtensions.GetConversationIdAndItemLinkPairs(this Microsoft.Agents.Builder.ITurnContext! turnContext) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.TurnContextExtensions.GetTargetAgentBaggagePairs(this Microsoft.Agents.Builder.ITurnContext! turnContext) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.TurnContextExtensions.GetTenantIdPair(this Microsoft.Agents.Builder.ITurnContext! turnContext) -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>!
-static Microsoft.OpenTelemetry.Agent365.Hosting.Extensions.TurnContextExtensions.InjectObservabilityContext(this Microsoft.Agents.Builder.ITurnContext! turnContext, Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryScope! observabilityScope) -> void
-static Microsoft.OpenTelemetry.Agent365.Hosting.Middleware.ObservabilityBaggageMiddlewareExtensions.UseObservabilityRequestContext(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, System.Func<Microsoft.AspNetCore.Http.HttpContext!, (string? tenant, string? agentId)>? resolver) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
-static Microsoft.OpenTelemetry.Agent365.Hosting.ObservabilityBuilderExtensions.AddA365Tracing(this Microsoft.AspNetCore.Hosting.IWebHostBuilder! webHostBuilder, System.Action<Microsoft.OpenTelemetry.Agent365.Builder!>? configure = null, bool useOpenTelemetryBuilder = true, Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType agent365ExporterType = Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType.Agent365Exporter) -> Microsoft.AspNetCore.Hosting.IWebHostBuilder!
-static Microsoft.OpenTelemetry.Agent365.Hosting.ObservabilityBuilderExtensions.AddA365Tracing(this Microsoft.Extensions.Hosting.IHostBuilder! builder, System.Action<Microsoft.OpenTelemetry.Agent365.Builder!>? configure = null, bool useOpenTelemetryBuilder = true, Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType agent365ExporterType = Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType.Agent365Exporter) -> Microsoft.Extensions.Hosting.IHostBuilder!
-static Microsoft.OpenTelemetry.Agent365.Hosting.ObservabilityServiceCollectionExtensions.AddAgenticTracingExporter(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string? clusterCategory = "production") -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.OpenTelemetry.Agent365.Hosting.ObservabilityServiceCollectionExtensions.AddServiceTracingExporter(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string? clusterCategory = "production") -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
-static Microsoft.OpenTelemetry.Agent365.ObservabilityBuilderExtensions.AddA365Tracing<TBuilder>(this TBuilder builder, System.Action<Microsoft.OpenTelemetry.Agent365.Builder!>? configure = null, bool useOpenTelemetryBuilder = true, Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType agent365ExporterType = Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterType.Agent365Exporter) -> TBuilder
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope.Start(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request! request, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolCallDetails! details, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails? userDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.SpanDetails? spanDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ThreatDiagnosticsSummary? threatDiagnosticsSummary = null) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope!
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InferenceScope.Start(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request! request, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InferenceCallDetails! details, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails? userDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.SpanDetails? spanDetails = null) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InferenceScope!
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope.Start(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request! request, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InvokeAgentScopeDetails! scopeDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.SpanDetails? spanDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ThreatDiagnosticsSummary? threatDiagnosticsSummary = null) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope!
@@ -595,17 +319,9 @@ static Microsoft.OpenTelemetry.MicrosoftOpenTelemetryBuilderExtensions.UseMicros
 static Microsoft.OpenTelemetry.MicrosoftOpenTelemetryBuilderExtensions.UseMicrosoftOpenTelemetry<TBuilder>(this TBuilder builder, System.Action<Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions!>! configure) -> TBuilder
 static Microsoft.OpenTelemetry.OpenTelemetryBuilderExtensions.UseAzureMonitor(this OpenTelemetry.IOpenTelemetryBuilder! builder) -> OpenTelemetry.IOpenTelemetryBuilder!
 static Microsoft.OpenTelemetry.OpenTelemetryBuilderExtensions.UseAzureMonitor(this OpenTelemetry.IOpenTelemetryBuilder! builder, System.Action<Microsoft.OpenTelemetry.AzureMonitorOptions!>! configureAzureMonitor) -> OpenTelemetry.IOpenTelemetryBuilder!
-static readonly Microsoft.OpenTelemetry.Agent365.Etw.EtwEventSource.Log -> Microsoft.OpenTelemetry.Agent365.Etw.EtwEventSource!
-static readonly Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.DefaultCleanupInterval -> System.TimeSpan
-static readonly Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.DefaultCleanupInterval -> System.TimeSpan
 static readonly Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolType.Datastore -> string!
 static readonly Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolType.Extension -> string!
 static readonly Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolType.Function -> string!
-virtual Microsoft.OpenTelemetry.Agent365.Hosting.Caching.AgenticTokenCache.Dispose(bool disposing) -> void
-virtual Microsoft.OpenTelemetry.Agent365.Hosting.Caching.ServiceTokenCache.Dispose(bool disposing) -> void
-virtual Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.BaseExporterAsync<T>.Dispose() -> void
-virtual Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.BaseExporterAsync<T>.ForceFlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
-virtual Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.BaseExporterAsync<T>.ShutdownAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 ~Microsoft.OpenTelemetry.AzureMonitorOptions.ConnectionString.get -> string
 ~Microsoft.OpenTelemetry.AzureMonitorOptions.ConnectionString.set -> void
 ~Microsoft.OpenTelemetry.AzureMonitorOptions.Credential.get -> Azure.Core.TokenCredential

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -2,66 +2,6 @@
 const Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions.DefaultEndpointHost = "agent365.svc.cloud.microsoft" -> string!
 const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope.OperationName = "execute_tool" -> string!
 const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope.OperationName = "invoke_agent" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.AgentAUIDKey = "microsoft.agent.user.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.AgentBlueprintIdKey = "microsoft.a365.agent.blueprint.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.AgentEmailKey = "microsoft.agent.user.email" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.AgentPlatformIdKey = "microsoft.a365.agent.platform.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.CallerAgentAUIDKey = "microsoft.a365.caller.agent.user.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.CallerAgentBlueprintIdKey = "microsoft.a365.caller.agent.blueprint.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.CallerAgentEmailKey = "microsoft.a365.caller.agent.user.email" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.CallerAgentIdKey = "microsoft.a365.caller.agent.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.CallerAgentNameKey = "microsoft.a365.caller.agent.name" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.CallerAgentPlatformIdKey = "microsoft.a365.caller.agent.platform.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.CallerAgentVersionKey = "microsoft.a365.caller.agent.version" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.CallerClientIpKey = "client.address" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.ChannelLinkKey = "microsoft.channel.link" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.ChannelNameKey = "microsoft.channel.name" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.EnableOpenTelemetrySwitch = "Azure.Experimental.EnableActivitySource" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.ErrorMessageKey = "error.message" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.ErrorTypeKey = "error.type" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiAgentDescriptionKey = "gen_ai.agent.description" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiAgentIdKey = "gen_ai.agent.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiAgentInvocationInputKey = "gen_ai.agent.invocation_input" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiAgentInvocationOutputKey = "gen_ai.agent.invocation_output" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiAgentNameKey = "gen_ai.agent.name" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiAgentThoughtProcessKey = "microsoft.a365.agent.thought.process" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiAgentVersionKey = "gen_ai.agent.version" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiChoiceEventName = "gen_ai.choice" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiClientOperationDurationMetricName = "gen_ai.client.operation.duration" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiConversationIdKey = "gen_ai.conversation.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiConversationItemLinkKey = "microsoft.conversation.item.link" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiInputMessagesKey = "gen_ai.input.messages" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiOperationNameKey = "gen_ai.operation.name" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiOutputMessagesKey = "gen_ai.output.messages" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiProviderNameKey = "gen_ai.provider.name" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiRequestModelKey = "gen_ai.request.model" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiResponseFinishReasonsKey = "gen_ai.response.finish_reasons" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiToolArgumentsKey = "gen_ai.tool.arguments" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiToolCallIdKey = "gen_ai.tool.call.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiToolCallResultKey = "gen_ai.tool.call.result" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiToolDescriptionKey = "gen_ai.tool.description" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiToolNameKey = "gen_ai.tool.name" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiToolServerNameKey = "gen_ai.tool.server.name" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiToolTypeKey = "gen_ai.tool.type" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiUsageInputTokensKey = "gen_ai.usage.input_tokens" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiUsageOutputTokensKey = "gen_ai.usage.output_tokens" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.GenAiUserMessageEventName = "gen_ai.user.message" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.ServerAddressKey = "server.address" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.ServerPortKey = "server.port" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.ServiceNameKey = "service.name" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.SessionDescriptionKey = "microsoft.session.description" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.SessionIdKey = "microsoft.session.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.SourceName = "Agent365Sdk" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.TelemetrySdkLanguageKey = "telemetry.sdk.language" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.TelemetrySdkLanguageValue = "dotnet" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.TelemetrySdkNameKey = "telemetry.sdk.name" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.TelemetrySdkNameValue = "A365ObservabilitySDK" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.TelemetrySdkVersionKey = "telemetry.sdk.version" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.TenantIdKey = "microsoft.tenant.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.ThreatDiagnosticsSummaryKey = "threat.diagnostics.summary" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.UserEmailKey = "user.email" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.UserIdKey = "user.id" -> string!
-const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.UserNameKey = "user.name" -> string!
 const Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OutputScope.OperationName = "output_messages" -> string!
 Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder
 Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder.AgentBlueprintId(string? v) -> Microsoft.OpenTelemetry.Agent365.Common.BaggageBuilder!
@@ -226,12 +166,6 @@ Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope.RecordInputMess
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope.RecordOutputMessages(string![]! messages) -> void
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope.RecordResponse(string! response) -> void
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope.RecordThreatDiagnosticsSummary(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ThreatDiagnosticsSummary! threatDiagnosticsSummary) -> void
-Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants
-Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.OperationNames
-Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.OperationNames.ExecuteInference = 1 -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.OperationNames
-Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.OperationNames.ExecuteTool = 2 -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.OperationNames
-Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.OperationNames.InvokeAgent = 0 -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.OperationNames
-Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.OperationNames.OutputMessages = 3 -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.OperationNames
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryScope
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryScope.AddBaggage(string! key, string! value) -> void
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryScope.Dispose() -> void
@@ -283,8 +217,6 @@ Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.EnableAgentFramework.set -
 Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.Exporters.get -> Microsoft.OpenTelemetry.ExportTarget
 Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.Exporters.set -> void
 Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.MicrosoftOpenTelemetryOptions() -> void
-Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.OtlpEndpoint.get -> System.Uri?
-Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.OtlpEndpoint.set -> void
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails.Equals(object? obj) -> bool
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails.GetHashCode() -> int
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel.Equals(object? obj) -> bool
@@ -304,7 +236,6 @@ override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails.GetHashC
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope.Start(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request! request, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolCallDetails! details, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails? userDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.SpanDetails? spanDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ThreatDiagnosticsSummary? threatDiagnosticsSummary = null) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.ExecuteToolScope!
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InferenceScope.Start(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request! request, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InferenceCallDetails! details, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails? userDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.SpanDetails? spanDetails = null) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InferenceScope!
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope.Start(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request! request, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.InvokeAgentScopeDetails! scopeDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.CallerDetails? callerDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.SpanDetails? spanDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ThreatDiagnosticsSummary? threatDiagnosticsSummary = null) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.InvokeAgentScope!
-static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.TelemetrySdkVersionValue.get -> string!
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OutputScope.Start(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request! request, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Response! response, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails? userDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.SpanDetails? spanDetails = null) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OutputScope!
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.TraceContextHelper.ExtractContextFromHeaders(System.Collections.Generic.IDictionary<string!, string!>! headers) -> System.Diagnostics.ActivityContext
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.TraceContextHelper.GetTraceparent(System.Collections.Generic.IDictionary<string!, string!>! headers) -> string?

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -249,11 +249,9 @@ Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryScope.TraceId.get -
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OutputScope
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OutputScope.RecordOutputMessages(System.Collections.Generic.IEnumerable<string!>! messages) -> void
 Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.TraceContextHelper
-Microsoft.OpenTelemetry.Agent365OpenTelemetryBuilderExtensions
 Microsoft.OpenTelemetry.Agent365Options
 Microsoft.OpenTelemetry.Agent365Options.Agent365Options() -> void
 Microsoft.OpenTelemetry.Agent365Options.Exporter.get -> Microsoft.OpenTelemetry.Agent365.Tracing.Exporters.Agent365ExporterOptions!
-Microsoft.OpenTelemetry.AgentFrameworkOpenTelemetryBuilderExtensions
 Microsoft.OpenTelemetry.AzureMonitorOptions
 Microsoft.OpenTelemetry.AzureMonitorOptions.AzureMonitorOptions() -> void
 Microsoft.OpenTelemetry.AzureMonitorOptions.DisableOfflineStorage.get -> bool
@@ -287,7 +285,6 @@ Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.Exporters.set -> void
 Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.MicrosoftOpenTelemetryOptions() -> void
 Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.OtlpEndpoint.get -> System.Uri?
 Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.OtlpEndpoint.set -> void
-Microsoft.OpenTelemetry.OpenTelemetryBuilderExtensions
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails.Equals(object? obj) -> bool
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails.GetHashCode() -> int
 override Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Channel.Equals(object? obj) -> bool
@@ -311,14 +308,9 @@ static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OpenTelemetryConstants.Te
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OutputScope.Start(Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Request! request, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.Response! response, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.UserDetails? userDetails = null, Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.SpanDetails? spanDetails = null) -> Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.OutputScope!
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.TraceContextHelper.ExtractContextFromHeaders(System.Collections.Generic.IDictionary<string!, string!>! headers) -> System.Diagnostics.ActivityContext
 static Microsoft.OpenTelemetry.Agent365.Tracing.Scopes.TraceContextHelper.GetTraceparent(System.Collections.Generic.IDictionary<string!, string!>! headers) -> string?
-static Microsoft.OpenTelemetry.Agent365OpenTelemetryBuilderExtensions.UseAgent365(this OpenTelemetry.IOpenTelemetryBuilder! builder) -> OpenTelemetry.IOpenTelemetryBuilder!
-static Microsoft.OpenTelemetry.Agent365OpenTelemetryBuilderExtensions.UseAgent365(this OpenTelemetry.IOpenTelemetryBuilder! builder, System.Action<Microsoft.OpenTelemetry.Agent365Options!>! configure) -> OpenTelemetry.IOpenTelemetryBuilder!
-static Microsoft.OpenTelemetry.AgentFrameworkOpenTelemetryBuilderExtensions.UseAgentFramework(this OpenTelemetry.IOpenTelemetryBuilder! builder) -> OpenTelemetry.IOpenTelemetryBuilder!
 static Microsoft.OpenTelemetry.MicrosoftOpenTelemetryBuilderExtensions.UseMicrosoftOpenTelemetry(this OpenTelemetry.IOpenTelemetryBuilder! builder, System.Action<Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions!>! configure) -> OpenTelemetry.IOpenTelemetryBuilder!
 static Microsoft.OpenTelemetry.MicrosoftOpenTelemetryBuilderExtensions.UseMicrosoftOpenTelemetry<TBuilder>(this TBuilder builder) -> TBuilder
 static Microsoft.OpenTelemetry.MicrosoftOpenTelemetryBuilderExtensions.UseMicrosoftOpenTelemetry<TBuilder>(this TBuilder builder, System.Action<Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions!>! configure) -> TBuilder
-static Microsoft.OpenTelemetry.OpenTelemetryBuilderExtensions.UseAzureMonitor(this OpenTelemetry.IOpenTelemetryBuilder! builder) -> OpenTelemetry.IOpenTelemetryBuilder!
-static Microsoft.OpenTelemetry.OpenTelemetryBuilderExtensions.UseAzureMonitor(this OpenTelemetry.IOpenTelemetryBuilder! builder, System.Action<Microsoft.OpenTelemetry.AzureMonitorOptions!>! configureAzureMonitor) -> OpenTelemetry.IOpenTelemetryBuilder!
 static readonly Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolType.Datastore -> string!
 static readonly Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolType.Extension -> string!
 static readonly Microsoft.OpenTelemetry.Agent365.Tracing.Contracts.ToolType.Function -> string!

--- a/src/Microsoft.OpenTelemetry/Agent365/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Agent365OpenTelemetryBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OpenTelemetry;
 /// <summary>
 /// Extension methods for configuring Agent365 observability on <see cref="IOpenTelemetryBuilder"/>.
 /// </summary>
-public static class Agent365OpenTelemetryBuilderExtensions
+internal static class Agent365OpenTelemetryBuilderExtensions
 {
     /// <summary>
     /// Configures Agent365 observability for AI agent tracing, including
@@ -28,7 +28,7 @@ public static class Agent365OpenTelemetryBuilderExtensions
     /// </summary>
     /// <param name="builder">The OpenTelemetry builder.</param>
     /// <returns>The supplied <see cref="IOpenTelemetryBuilder"/> for chaining calls.</returns>
-    public static IOpenTelemetryBuilder UseAgent365(this IOpenTelemetryBuilder builder)
+    internal static IOpenTelemetryBuilder UseAgent365(this IOpenTelemetryBuilder builder)
     {
         return builder.UseAgent365(o => { });
     }
@@ -59,7 +59,7 @@ public static class Agent365OpenTelemetryBuilderExtensions
     ///     });
     /// </code>
     /// </remarks>
-    public static IOpenTelemetryBuilder UseAgent365(this IOpenTelemetryBuilder builder, Action<Agent365Options> configure)
+    internal static IOpenTelemetryBuilder UseAgent365(this IOpenTelemetryBuilder builder, Action<Agent365Options> configure)
     {
         var options = new Agent365Options();
         configure?.Invoke(options);

--- a/src/Microsoft.OpenTelemetry/Agent365/Builder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Builder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OpenTelemetry.Agent365
     /// <summary>
     /// Builder for configuring SDK with OpenTelemetry tracing.
     /// </summary>
-    public sealed class Builder
+    internal sealed class Builder
     {
         private readonly IServiceCollection _services;
         private readonly bool _useOpenTelemetryBuilder;

--- a/src/Microsoft.OpenTelemetry/Agent365/Common/ActivityExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Common/ActivityExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Common
     /// <summary>
     /// Extension methods for Activity.
     /// </summary>
-    public static class ActivityExtensions
+    internal static class ActivityExtensions
     {
         /// <summary>
         /// Gets the value of a tag (takes precedence) or baggage item from the activity.

--- a/src/Microsoft.OpenTelemetry/Agent365/Common/EnvironmentUtils.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Common/EnvironmentUtils.cs
@@ -7,7 +7,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Common
     /// <summary>
     /// Utility logic for environment-related operations.
     /// </summary>
-    public class EnvironmentUtils
+    internal class EnvironmentUtils
     {
         private const string ProdObservabilityScope = "https://api.powerplatform.com/.default";
         private const string ProdObservabilityClusterCategory = "prod";

--- a/src/Microsoft.OpenTelemetry/Agent365/Common/ExportFormatter.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Common/ExportFormatter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Common
     /// Provides functionality to format Activity spans into OTLP JSON payloads.
     /// </summary>
 
-    public class ExportFormatter
+    internal class ExportFormatter
     {
         private const int MaxSpanSizeBytes = 250 * 1024;
         private static readonly string[] LargePayloadAttributeKeys = new[]

--- a/src/Microsoft.OpenTelemetry/Agent365/Common/PowerPlatformApiDiscovery.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Common/PowerPlatformApiDiscovery.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Common
     /// <summary>
     /// Provides discovery and endpoint generation for Power Platform APIs across different cluster categories.
     /// </summary>
-    public class PowerPlatformApiDiscovery
+    internal class PowerPlatformApiDiscovery
     {
         private readonly string clusterCategory;
 

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/BaseData.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/BaseData.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs
     /// <summary>
     /// Encapsulates all telemetry data for an operation, including attributes, timing, and span information.
     /// </summary>
-    public abstract class BaseData
+    internal abstract class BaseData
     {
         /// <summary>
         /// Initializes a new instance

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/BaseDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/BaseDataBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs.Builders
     /// <summary>
     /// Base class for building telemetry data.
     /// </summary>
-    public abstract class BaseDataBuilder<T> where T : BaseData
+    internal abstract class BaseDataBuilder<T> where T : BaseData
     {
         // Reserved attribute keys managed by specific builder methods; extra attributes must NOT override these.
         private static readonly HashSet<string> ReservedAttributeKeys = new HashSet<string>(StringComparer.Ordinal)

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/ExecuteInferenceDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/ExecuteInferenceDataBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs.Builders
     /// <summary>
     /// Builds an ExecuteInferenceData instance.
     /// </summary>
-    public class ExecuteInferenceDataBuilder : BaseDataBuilder<ExecuteInferenceData>
+    internal class ExecuteInferenceDataBuilder : BaseDataBuilder<ExecuteInferenceData>
     {
         /// <summary>
         /// Builds complete data for an inference operation.

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/ExecuteToolDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/ExecuteToolDataBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs.Builders
     /// <summary>
     /// Builds an ExecuteToolData instance.
     /// </summary>
-    public class ExecuteToolDataBuilder : BaseDataBuilder<ExecuteToolData>
+    internal class ExecuteToolDataBuilder : BaseDataBuilder<ExecuteToolData>
     {
         private const string ExecuteToolOperationName = "execute_tool";
 

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/InvokeAgentDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/InvokeAgentDataBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs.Builders
     /// <summary>
     /// Builds an InvokeAgentData instance
     /// </summary>
-    public class InvokeAgentDataBuilder : BaseDataBuilder<InvokeAgentData>
+    internal class InvokeAgentDataBuilder : BaseDataBuilder<InvokeAgentData>
     {
         private const string InvokeAgentOperationName = "invoke_agent";
 

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/OutputDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/Builders/OutputDataBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs.Builders
     /// <summary>
     /// Builds an OutputData instance.
     /// </summary>
-    public class OutputDataBuilder : BaseDataBuilder<OutputData>
+    internal class OutputDataBuilder : BaseDataBuilder<OutputData>
     {
         private const string OutputMessagesOperationName = "output_messages";
 

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/ExecuteInferenceData.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/ExecuteInferenceData.cs
@@ -10,7 +10,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs
     /// <summary>
     /// Encapsulates all telemetry data for an inference execution operation.
     /// </summary>
-    public class ExecuteInferenceData : BaseData
+    internal class ExecuteInferenceData : BaseData
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExecuteInferenceData"/> class.

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/ExecuteToolData.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/ExecuteToolData.cs
@@ -10,7 +10,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs
     /// <summary>
     /// Encapsulates all telemetry data for an execute_tool operation.
     /// </summary>
-    public class ExecuteToolData : BaseData
+    internal class ExecuteToolData : BaseData
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExecuteToolData"/> class.

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/InvokeAgentData.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/InvokeAgentData.cs
@@ -10,7 +10,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs
     /// <summary>
     /// Encapsulates all telemetry data for an invoke_agent operation, including attributes, timing, and span information.
     /// </summary>
-    public class InvokeAgentData : BaseData
+    internal class InvokeAgentData : BaseData
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="InvokeAgentData"/> class.

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/OutputData.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/OutputData.cs
@@ -10,7 +10,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs
     /// <summary>
     /// Encapsulates all telemetry data for an output_messages operation.
     /// </summary>
-    public class OutputData : BaseData
+    internal class OutputData : BaseData
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OutputData"/> class.

--- a/src/Microsoft.OpenTelemetry/Agent365/DTOs/SpanKindConstants.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/DTOs/SpanKindConstants.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OpenTelemetry.Agent365.DTOs
     /// These constants are used in DTOs and Builders to avoid taking a dependency
     /// on <see cref="System.Diagnostics.ActivityKind"/>.
     /// </summary>
-    public static class SpanKindConstants
+    internal static class SpanKindConstants
     {
         /// <summary>
         /// Indicates that the span covers server-side handling of a synchronous RPC or other remote request.

--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/A365EtwLogger.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/A365EtwLogger.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Etw
     /// <summary>
     /// Provides ETW logging functionality for tracing events.
     /// </summary>
-    public class A365EtwLogger<T> : IA365EtwLogger<T>
+    internal class A365EtwLogger<T> : IA365EtwLogger<T>
     {
         private ILogger logger { get; }
         private const string InvokeAgentEventName = "InvokeAgent";

--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/Constants.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/Constants.cs
@@ -5,7 +5,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Etw
     /// <summary>
     /// Constants used in ETW logging.
     /// </summary>
-    public class Constants
+    internal class Constants
     {
         /// <summary>
         /// Category prefix for ETW logs.

--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwEventSource.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwEventSource.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Etw
     /// </list>
     /// </remarks>
     [EventSource(Name = "OpenTelemetry-Microsoft-Agent365-Etw")]
-    public class EtwEventSource : EventSource
+    internal class EtwEventSource : EventSource
     {
         /// <summary>
         /// Singleton instance of the EtwEventSource.

--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwLogProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwLogProcessor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Etw
     /// <summary>
     /// Processes logs by emitting ETW events.
     /// </summary>
-    public class EtwLogProcessor : BaseProcessor<LogRecord>
+    internal class EtwLogProcessor : BaseProcessor<LogRecord>
     {
         private readonly ExportFormatter _formatter;
         private readonly ILogger<EtwLogProcessor>? _logger;

--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwLoggingBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwLoggingBuilder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Etw
     /// <summary>
     /// Builds the ETW + OpenTelemetry logging configuration.
     /// </summary>
-    public sealed class EtwLoggingBuilder
+    internal sealed class EtwLoggingBuilder
     {
         private static readonly Lazy<ILoggerFactory> FallbackConsoleLoggerFactory = new Lazy<ILoggerFactory>(() => LoggerFactory.Create(b => b.AddConsole()));
         private readonly IServiceCollection _services;

--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwScopeEventProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwScopeEventProcessor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Etw
     /// <summary>
     /// Processes spans by emitting ETW events.
     /// </summary>
-    public class EtwScopeEventProcessor: BaseProcessor<Activity>
+    internal class EtwScopeEventProcessor: BaseProcessor<Activity>
     {
         private readonly ExportFormatter _formatter;
         private readonly Resource _resource;

--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwServiceCollectionExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Etw
     /// <summary>
     /// Extension methods for configuring ETW in <see cref="IServiceCollection"/>.
     /// </summary>
-    public static class EtwServiceCollectionExtensions
+    internal static class EtwServiceCollectionExtensions
     {
         /// <summary>
         /// Adds OpenTelemetry tracing with ETW to the service collection.

--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwTracingBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwTracingBuilder.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Etw
     /// <summary>
     /// Builds the ETW + OpenTelemetry tracing configuration.
     /// </summary>
-    public sealed class EtwTracingBuilder
+    internal sealed class EtwTracingBuilder
     {
         private readonly IServiceCollection _services;
         private bool _isBuilt = false;

--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/IA365EtwLogger.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/IA365EtwLogger.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Etw
     /// <summary>
     /// Interface for ETW Logger
     /// </summary>
-    public interface IA365EtwLogger<T>
+    internal interface IA365EtwLogger<T>
     {
         /// <summary>
         /// Logs an invoke_agent event.

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/AgentFramework/BuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/AgentFramework/BuilderExtensions.cs
@@ -12,7 +12,7 @@ using global::OpenTelemetry;
 /// <summary>
 /// Extension methods for configuring Builder with Agent Framework integration.
 /// </summary>
-public static class BuilderExtensions
+internal static class BuilderExtensions
 {
     /// <summary>
     /// The activity source name for Agent Framework tracing.

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/OpenAI/BuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/OpenAI/BuilderExtensions.cs
@@ -10,7 +10,7 @@ using global::OpenTelemetry.Trace;
 /// <summary>
 /// Extension methods for configuring Builder with OpenAI integration.
 /// </summary>
-public static class BuilderExtensions
+internal static class BuilderExtensions
 {
     /// <summary>
     /// Adds OpenAI integration to the builder.

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/OpenAI/ChatToolCallExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/OpenAI/ChatToolCallExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Extensions.OpenAI;
 /// <summary>
 /// Extension methods for ChatToolCall.
 /// </summary>
-public static class ChatToolCallExtensions
+internal static class ChatToolCallExtensions
 {
     /// <summary>
     /// Starts an ExecuteToolScope for the given ChatToolCall for OpenTelemetry tracing.

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/BuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/BuilderExtensions.cs
@@ -11,7 +11,7 @@ using global::OpenTelemetry;
 /// <summary>
 /// Extension methods for configuring Builder with SemanticKernel integration.
 /// </summary>
-public static class BuilderExtensions
+internal static class BuilderExtensions
 {
     /// <summary>
     /// Adds SemanticKernel integration to the builder with function invocation filtering.

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/ChatCompletionAgentExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/ChatCompletionAgentExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.SemanticKernel.Agents;
 /// <summary>
 /// Extension methods for enabling tracing on SemanticKernel agents.
 /// </summary>
-public static class ChatCompletionAgentExtensions
+internal static class ChatCompletionAgentExtensions
 {
     /// <summary>
     /// Wraps a ChatCompletionAgent with tracing capabilities.

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/FunctionInvocationFilter.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/FunctionInvocationFilter.cs
@@ -12,7 +12,7 @@ using System.Text.Json.Serialization;
 /// <summary>
 /// Function invocation filter that adds tracing capabilities to SemanticKernel function calls.
 /// </summary>
-public sealed class FunctionInvocationFilter : IFunctionInvocationFilter
+internal sealed class FunctionInvocationFilter : IFunctionInvocationFilter
 {
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/Models/AiChoice.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/Models/AiChoice.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 /// <summary>
 /// Represents an AI choice containing a message with role and tool calls information.
 /// </summary>
-public sealed class AiChoice
+internal sealed class AiChoice
 {
     /// <summary>
     /// Gets or sets the AI choice message, which includes role and tool calls information.
@@ -20,7 +20,7 @@ public sealed class AiChoice
 /// <summary>
 /// Represents an AI choice message, including the role and associated tool calls.
 /// </summary>
-public sealed class AiChoiceMessage
+internal sealed class AiChoiceMessage
 {
     /// <summary>
     /// Gets or sets the role of the AI message.
@@ -44,7 +44,7 @@ public sealed class AiChoiceMessage
 /// <summary>
 /// Represents a tool call within an AI choice message.
 /// </summary>
-public sealed class AiChoiceToolCall
+internal sealed class AiChoiceToolCall
 {
     /// <summary>
     /// Gets or sets the function associated with the tool call.
@@ -56,7 +56,7 @@ public sealed class AiChoiceToolCall
 /// <summary>
 /// Represents a function within a tool call.
 /// </summary>
-public sealed class AiChoiceFunction
+internal sealed class AiChoiceFunction
 {
     /// <summary>
     /// Gets or sets the arguments for the function.
@@ -68,7 +68,7 @@ public sealed class AiChoiceFunction
 /// <summary>
 /// Represents the arguments for an AI choice function.
 /// </summary>
-public sealed class AiChoiceArguments
+internal sealed class AiChoiceArguments
 {
     /// <summary>
     /// Gets or sets the message body for the function arguments.

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/Models/MessageContent.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/Models/MessageContent.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models;
 /// Represents the structure of a message as found in OpenTelemetry activity events and invocation input tags.
 /// Used in the <c>gen_ai.agent.invocation_input</c> tag and <c>gen_ai.event.content</c> attribute.
 /// </summary>
-public class MessageContent
+internal class MessageContent
 {
     /// <summary>
     /// The role of the message, such as "user" or "assistant".

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/Models/NestedContent.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/Models/NestedContent.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Extensions.SemanticKernel.Models;
 /// Represents a nested content structure that may appear within a MessageContent's Content property.
 /// Used when Content is a JSON object with contentType and content fields.
 /// </summary>
-public class NestedContent
+internal class NestedContent
 {
     /// <summary>
     /// The type of the content (e.g., "Text").

--- a/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/Utils/SemanticKernelSpanProcessorHelper.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Extensions/SemanticKernel/Utils/SemanticKernelSpanProcessorHelper.cs
@@ -13,7 +13,7 @@ using System.Text.RegularExpressions;
 /// <summary>
 /// Provides helper methods for processing and filtering Semantic Kernel span tags and events.
 /// </summary>
-public static class SemanticKernelSpanProcessorHelper
+internal static class SemanticKernelSpanProcessorHelper
 {
     private static readonly Regex UnquotedPropertyValueRegex =
         new Regex(

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Caching/AgenticTokenCache.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Caching/AgenticTokenCache.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Caching
     /// Caches observability tokens per (agentId, tenantId) using the provided UserAuthorization and TurnContext.
     /// Includes automatic periodic cleanup of expired tokens for improved memory management.
     /// </summary>
-    public class AgenticTokenCache : IExporterTokenCache<AgenticTokenStruct>, IDisposable
+    internal class AgenticTokenCache : IExporterTokenCache<AgenticTokenStruct>, IDisposable
     {
         private sealed class Entry
         {

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Caching/AgenticTokenStruct.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Caching/AgenticTokenStruct.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Caching
     /// <summary>
     /// Struct containing UserAuthorization and TurnContext for token generation.
     /// </summary>
-    public class AgenticTokenStruct
+    internal class AgenticTokenStruct
     {
         /// <summary>
         /// UserAuthorization instance used to acquire tokens.

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Caching/IExporterTokenCache.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Caching/IExporterTokenCache.cs
@@ -7,7 +7,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Caching
     /// <summary>
     /// Cache only for observability (exporter) scoped tokens per (agentId, tenantId).
     /// </summary>
-    public interface IExporterTokenCache<T> where T : class
+    internal interface IExporterTokenCache<T> where T : class
     {
         /// <summary>
         /// Registers (idempotent) a credential to be used for observability token acquisition.

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Caching/ServiceTokenCache.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Caching/ServiceTokenCache.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Caching
     /// Caches observability tokens per (agentId, tenantId) with expiration and invalidation support.
     /// Includes automatic periodic cleanup of expired tokens for improved memory management.
     /// </summary>
-    public class ServiceTokenCache : IExporterTokenCache<string>, IDisposable
+    internal class ServiceTokenCache : IExporterTokenCache<string>, IDisposable
     {
         private sealed class Entry
         {

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/BaggageBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/BaggageBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Extensions
     /// <summary>
     /// Utility class for BaggageBuilder extensions.
     /// </summary>
-    public static class BaggageBuilderExtensions
+    internal static class BaggageBuilderExtensions
     {
         /// <summary>
         /// Sets the baggage values from TurnContext.

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/InvokeAgentScopeExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/InvokeAgentScopeExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Extensions
     /// <summary>
     /// Extension methods for InvokeAgentScope.
     /// </summary>
-    public static class InvokeAgentScopeExtensions
+    internal static class InvokeAgentScopeExtensions
     {
         /// <summary>
         /// Sets tag values from TurnContext.

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Extensions
     /// <summary>
     /// Extension methods for extracting values from ITurnContext.
     /// </summary>
-    public static class TurnContextExtensions
+    internal static class TurnContextExtensions
     {
         private const string O11ySpanIdKey = "O11ySpanId";
         private const string O11yTraceIdKey = "O11yTraceId";

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Middleware/BaggageTurnMiddleware.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Middleware/BaggageTurnMiddleware.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Middleware
     /// Async replies (ContinueConversation events) are passed through without
     /// baggage setup because their context is established by the originating turn.
     /// </remarks>
-    public sealed class BaggageTurnMiddleware : IMiddleware
+    internal sealed class BaggageTurnMiddleware : IMiddleware
     {
         /// <inheritdoc/>
         public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Middleware/ObservabilityBaggageMiddleware.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Middleware/ObservabilityBaggageMiddleware.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Middleware
     /// <summary>
     /// ASP.NET Core middleware for setting per-request observability context (baggage).
     /// </summary>
-    public sealed class ObservabilityBaggageMiddleware
+    internal sealed class ObservabilityBaggageMiddleware
     {
         private readonly RequestDelegate _next;
         private readonly Func<HttpContext, (string? tenant, string? agentId)> _resolver;
@@ -56,7 +56,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Middleware
     /// A middleware to set per-request observability context (baggage). 
     /// Middleware to be used in ASP.NET scenarios.
     /// </summary>
-    public static class ObservabilityBaggageMiddlewareExtensions
+    internal static class ObservabilityBaggageMiddlewareExtensions
     {
         /// <summary>
         /// Adds the observability baggage middleware to the application pipeline.

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Middleware/OutputLoggingMiddleware.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Middleware/OutputLoggingMiddleware.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting.Middleware
     /// span attributes and exported to the configured telemetry backend.
     /// </para>
     /// </remarks>
-    public sealed class OutputLoggingMiddleware : IMiddleware
+    internal sealed class OutputLoggingMiddleware : IMiddleware
     {
         /// <summary>
         /// The <see cref="ITurnContext.StackState"/> key used to store the parent

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/ObservabilityBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/ObservabilityBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting
     /// <summary>
     /// Provides extension methods for configuring Microsoft Agent 365 SDK with OpenTelemetry tracing.
     /// </summary>
-    public static class ObservabilityBuilderExtensions
+    internal static class ObservabilityBuilderExtensions
     {
         /// <summary>
         /// Adds the Microsoft Agent 365 SDK with OpenTelemetry tracing for AI agents and tools.

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/ObservabilityServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Hosting
     /// <summary>
     /// Provides extension methods for configuring Microsoft Agent 365 SDK with OpenTelemetry tracing.
     /// </summary>
-    public static class ObservabilityServiceCollectionExtensions
+    internal static class ObservabilityServiceCollectionExtensions
     {
         /// <summary>
         /// Adds agentic token handling to the service collection.

--- a/src/Microsoft.OpenTelemetry/Agent365/ObservabilityBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/ObservabilityBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OpenTelemetry.Agent365
     /// <summary>
     /// Provides extension methods for configuring Microsoft Agent 365 SDK with OpenTelemetry tracing.
     /// </summary>
-    public static class ObservabilityBuilderExtensions
+    internal static class ObservabilityBuilderExtensions
     {
 
         /// <summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/Agent365Exporter.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/Agent365Exporter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Exporters
     /// Sends POST {Endpoint}/v1/traces with application/json.
     /// </summary>
 
-    public sealed class Agent365Exporter : BaseExporter<Activity>
+    internal sealed class Agent365Exporter : BaseExporter<Activity>
     {
         private readonly HttpClient _httpClient;
         private readonly Resource _resource;

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/Agent365ExporterAsync.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/Agent365ExporterAsync.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Exporters
     /// Sends POST {Endpoint}/v1/traces with application/json.
     /// </summary>
 
-    public sealed class Agent365ExporterAsync : BaseExporterAsync<Activity>
+    internal sealed class Agent365ExporterAsync : BaseExporterAsync<Activity>
     {
         private readonly HttpClient _httpClient;
         private readonly Resource _resource;

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/Agent365ExporterCore.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Exporters
     /// Utility methods for Agent365 trace exporters.
     /// Provides helpers for partitioning activities and building endpoint URIs.
     /// </summary>
-    public class Agent365ExporterCore
+    internal class Agent365ExporterCore
     {
         private const string CorrelationIdHeaderKey = "x-ms-correlation-id";
         private readonly ExportFormatter _formatter;

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/Agent365ExporterType.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/Agent365ExporterType.cs
@@ -5,7 +5,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Exporters
     /// <summary>
     /// Represents the supported Agent365 exporter types.
     /// </summary>
-    public enum Agent365ExporterType
+    internal enum Agent365ExporterType
     {
         /// <summary>
         /// Agent365 synchronous exporter type.

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/BaseExporterAsync.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/BaseExporterAsync.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Exporters
     /// Abstract base class for asynchronous exporters of telemetry objects.
     /// </summary>
     /// <typeparam name="T">The type of telemetry object to export.</typeparam>
-    public abstract class BaseExporterAsync<T> : IDisposable
+    internal abstract class BaseExporterAsync<T> : IDisposable
         where T : class
     {
         /// <summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/ObservabilityTracerProviderBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Exporters/ObservabilityTracerProviderBuilderExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Exporters
     /// <summary>
     /// Extension methods to add Agent365 Exporter to OpenTelemetry TracerProviderBuilder.
     /// </summary>
-    public static class ObservabilityTracerProviderBuilderExtensions
+    internal static class ObservabilityTracerProviderBuilderExtensions
     {
         private static readonly Lazy<ILoggerFactory> FallbackConsoleLoggerFactory = new Lazy<ILoggerFactory>(() => LoggerFactory.Create(b => b.AddConsole()));
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Processors/ActivityProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Processors/ActivityProcessor.cs
@@ -10,7 +10,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Processors
     /// <summary>
     /// Processes activity telemetry data by adding contextual baggage information.
     /// </summary>
-    public sealed class ActivityProcessor : BaseProcessor<Activity>
+    internal sealed class ActivityProcessor : BaseProcessor<Activity>
     {
         private static readonly string[] AttributeKeys = new[]
         {

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Processors/BatchActivityExportProcessorAsync.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Processors/BatchActivityExportProcessorAsync.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Processors
     /// <summary>
     /// Implements an async processor that batches <see cref="Activity"/> objects before calling exporter asynchronously.
     /// </summary>
-    public class BatchActivityExportProcessorAsync : BaseProcessor<Activity>
+    internal class BatchActivityExportProcessorAsync : BaseProcessor<Activity>
     {
         internal const int DefaultMaxQueueSize = 2048;
         internal const int DefaultScheduledDelayMilliseconds = 5000;

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Scopes/AutoInstrumentationConstants.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Scopes/AutoInstrumentationConstants.cs
@@ -6,7 +6,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Scopes
     /// <summary>
     /// Constants used for auto-instrumentation.
     /// </summary>
-    public static class AutoInstrumentationConstants
+    internal static class AutoInstrumentationConstants
     {
         /// <summary> The key for the input to a GenAI agent invocation. </summary>
         /// <remarks> Set by the Semantic Kernel OpenTelemetry integration for agent invocations.</remarks>

--- a/src/Microsoft.OpenTelemetry/Agent365/Tracing/Scopes/OpenTelemetryConstants.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Tracing/Scopes/OpenTelemetryConstants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenTelemetry.Agent365.Tracing.Scopes
     /// <summary>
     /// OpenTelemetry constant keys and values used across the Microsoft Agent 365 SDK.
     /// </summary>
-    public static class OpenTelemetryConstants
+    internal static class OpenTelemetryConstants
     {
         public const string EnableOpenTelemetrySwitch = "Azure.Experimental.EnableActivitySource";
         public const string SourceName = "Agent365Sdk";

--- a/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkOpenTelemetryBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenTelemetry;
 /// <summary>
 /// Extension methods for configuring Microsoft Agent Framework observability on <see cref="IOpenTelemetryBuilder"/>.
 /// </summary>
-public static class AgentFrameworkOpenTelemetryBuilderExtensions
+internal static class AgentFrameworkOpenTelemetryBuilderExtensions
 {
     /// <summary>
     /// Configures the distro to capture telemetry from Microsoft Agent Framework.
@@ -32,7 +32,7 @@ public static class AgentFrameworkOpenTelemetryBuilderExtensions
     ///     .UseAgentFramework();
     /// </code>
     /// </remarks>
-    public static IOpenTelemetryBuilder UseAgentFramework(this IOpenTelemetryBuilder builder)
+    internal static IOpenTelemetryBuilder UseAgentFramework(this IOpenTelemetryBuilder builder)
     {
         builder.WithTracing(tracing =>
         {

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/OpenTelemetryBuilderExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenTelemetry
     /// <summary>
     /// Extension methods for setting up Azure Monitor in an <see cref="IOpenTelemetryBuilder" />.
     /// </summary>
-    public static class OpenTelemetryBuilderExtensions
+    internal static class OpenTelemetryBuilderExtensions
     {
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Microsoft.OpenTelemetry
         /// <item>SQL Client.</item>
         /// </list>
         /// </remarks>
-        public static IOpenTelemetryBuilder UseAzureMonitor(this IOpenTelemetryBuilder builder)
+        internal static IOpenTelemetryBuilder UseAzureMonitor(this IOpenTelemetryBuilder builder)
         {
             builder.Services.TryAddSingleton<IConfigureOptions<AzureMonitorOptions>,
                         DefaultAzureMonitorOptions>();
@@ -70,7 +70,7 @@ namespace Microsoft.OpenTelemetry
         /// <item>SQL Client.</item>
         /// </list>
         /// </remarks>
-        public static IOpenTelemetryBuilder UseAzureMonitor(this IOpenTelemetryBuilder builder, Action<AzureMonitorOptions> configureAzureMonitor)
+        internal static IOpenTelemetryBuilder UseAzureMonitor(this IOpenTelemetryBuilder builder, Action<AzureMonitorOptions> configureAzureMonitor)
         {
             if (builder.Services == null)
             {

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -96,8 +96,7 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
                 exporters |= ExportTarget.AzureMonitor;
             if (options.Agent365.Exporter.TokenResolver != null)
                 exporters |= ExportTarget.Agent365;
-            if (options.OtlpEndpoint != null)
-                exporters |= ExportTarget.Otlp;
+            
         }
 
         // --- Azure Monitor (always: instrumentation; exporter gated by Exporters flag) ---
@@ -140,18 +139,12 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
         {
             builder.WithTracing(tracing =>
             {
-                if (options.OtlpEndpoint != null)
-                    tracing.AddOtlpExporter(o => o.Endpoint = options.OtlpEndpoint);
-                else
-                    tracing.AddOtlpExporter();
+                tracing.AddOtlpExporter();
             });
 
             builder.WithMetrics(metrics =>
             {
-                if (options.OtlpEndpoint != null)
-                    metrics.AddOtlpExporter(o => o.Endpoint = options.OtlpEndpoint);
-                else
-                    metrics.AddOtlpExporter();
+                metrics.AddOtlpExporter();
             });
         }
 

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryOptions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryOptions.cs
@@ -49,10 +49,4 @@ public class MicrosoftOpenTelemetryOptions
     /// Listens to <c>Experimental.Microsoft.Agents.AI</c> activity sources automatically.
     /// </summary>
     public bool EnableAgentFramework { get; set; } = true;
-
-    /// <summary>
-    /// Gets or sets the OTLP exporter endpoint.
-    /// Only used when <see cref="Exporters"/> includes <see cref="ExportTarget.Otlp"/>.
-    /// </summary>
-    public Uri? OtlpEndpoint { get; set; }
 }

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
@@ -149,8 +149,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                 .UseMicrosoftOpenTelemetry(o =>
                 {
                     o.Exporters = ExportTarget.Otlp;
-                    o.OtlpEndpoint = new Uri("http://localhost:4317");
-                });
+                    });
 
             Assert.True(services.Any(s =>
                 s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||


### PR DESCRIPTION
## Summary

Reduces the public API surface from 613 to 252 symbols by internalizing implementation details and establishing `UseMicrosoftOpenTelemetry()` as the single public entry point.

## Changes

### Entry points internalized
- `UseAzureMonitor()` → internal (was public)
- `UseAgent365()` → internal (was public)  
- `UseAgentFramework()` → internal (was public)
- Only `UseMicrosoftOpenTelemetry()` remains public (3 overloads)

### Agent365 types internalized (64 types)
- **DTOs**: BaseData, all DataBuilder classes, SpanKindConstants, AiChoice models, MessageContent, NestedContent
- **Exporters**: Agent365Exporter, Agent365ExporterAsync, Agent365ExporterCore, BaseExporterAsync, BatchActivityExportProcessorAsync, Agent365ExporterType, ExportFormatter
- **ETW**: All 9 ETW types (EtwEventSource, EtwLogger, EtwLoggingBuilder, etc.)
- **Common**: ActivityExtensions, EnvironmentUtils, PowerPlatformApiDiscovery, ActivityProcessor
- **Hosting**: All middleware, caching, extension helpers, Builder, legacy ObservabilityBuilderExtensions
- **Extensions**: FunctionInvocationFilter, ChatToolCallExtensions, BuilderExtensions, SemanticKernelSpanProcessorHelper

### Other reductions
- `OpenTelemetryConstants` → internal (tag key strings are OTel GenAI semantic conventions — well-documented)
- `OtlpEndpoint` removed from `MicrosoftOpenTelemetryOptions` (OTLP exporter handles its own endpoint via `OTEL_EXPORTER_OTLP_ENDPOINT` env var / `IConfiguration`)
- `AutoInstrumentationConstants` → internal

### What remains public (252 symbols)
- `UseMicrosoftOpenTelemetry()` + `MicrosoftOpenTelemetryOptions` + `ExportTarget`
- `AzureMonitorOptions`, `Agent365Options`, `Agent365ExporterOptions` + delegates
- Scopes: `InvokeAgentScope`, `InferenceScope