### PR TITLE
Rename EventSources to OpenTelemetry-Microsoft-* convention

### DIFF
--- a/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwEventSource.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Etw/EtwEventSource.cs
@@ -5,9 +5,20 @@ using System.Diagnostics.Tracing;
 namespace Microsoft.OpenTelemetry.Agent365.Etw
 {
     /// <summary>
-    /// ETW Event Source for Observability.
+    /// ETW Event Source for Agent365 Observability.
+    /// EventSource Guid at Runtime: {544e9fe9-9c40-549a-ebb5-6492695772f7}.
     /// </summary>
-    [EventSource(Name = "A365-O11y-EventSource")]
+    /// <remarks>
+    /// PerfView Instructions:
+    /// <list type="bullet">
+    /// <item>To collect all events: <code>PerfView.exe collect -MaxCollectSec:300 -NoGui /onlyProviders=*OpenTelemetry-Microsoft-Agent365-Etw</code></item>
+    /// </list>
+    /// Dotnet-Trace Instructions:
+    /// <list type="bullet">
+    /// <item>To collect all events: <code>dotnet-trace collect --process-id PID --providers OpenTelemetry-Microsoft-Agent365-Etw</code></item>
+    /// </list>
+    /// </remarks>
+    [EventSource(Name = "OpenTelemetry-Microsoft-Agent365-Etw")]
     public class EtwEventSource : EventSource
     {
         /// <summary>

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/AzureMonitorAspNetCoreEventSource.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/AzureMonitorAspNetCoreEventSource.cs
@@ -8,32 +8,25 @@ using Microsoft.OpenTelemetry.AzureMonitor.Internals;
 namespace Microsoft.OpenTelemetry
 {
     /// <summary>
-    /// EventSource for the AzureMonitor AspNetCore Distro.
-    /// EventSource Guid at Runtime: 928cf0a7-3e20-5f5d-a14f-0e62fdc972e6.
-    /// (This guid can be found by debugging this class and inspecting the "Log" singleton and reading the "Guid" property).
+    /// EventSource for the Microsoft OpenTelemetry Distro (Azure Monitor).
+    /// EventSource Guid at Runtime: {04e66d6d-bc95-547b-b03a-9107d1abd44d}.
     /// </summary>
     /// <remarks>
     /// PerfView Instructions:
     /// <list type="bullet">
-    /// <item>To collect all events: <code>PerfView.exe collect -MaxCollectSec:300 -NoGui /onlyProviders=*OpenTelemetry-AzureMonitor-AspNetCore</code></item>
-    /// <item>To collect events based on LogLevel: <code>PerfView.exe collect -MaxCollectSec:300 -NoGui /onlyProviders:OpenTelemetry-AzureMonitor-AspNetCore::Verbose</code></item>
+    /// <item>To collect all events: <code>PerfView.exe collect -MaxCollectSec:300 -NoGui /onlyProviders=*OpenTelemetry-Microsoft-AzureMonitor-AspNetCore</code></item>
+    /// <item>To collect events based on LogLevel: <code>PerfView.exe collect -MaxCollectSec:300 -NoGui /onlyProviders:OpenTelemetry-Microsoft-AzureMonitor-AspNetCore::Verbose</code></item>
     /// </list>
     /// Dotnet-Trace Instructions:
     /// <list type="bullet">
-    /// <item>To collect all events: <code>dotnet-trace collect --process-id PID --providers OpenTelemetry-AzureMonitor-AspNetCore</code></item>
-    /// <item>To collect events based on LogLevel: <code>dotnet-trace collect --process-id PID --providers OpenTelemetry-AzureMonitor-AspNetCore::Verbose</code></item>
-    /// </list>
-    /// Logman Instructions:
-    /// <list type="number">
-    /// <item>Create a text file containing providers: <code>echo "{928cf0a7-3e20-5f5d-a14f-0e62fdc972e6}" > providers.txt</code></item>
-    /// <item>Start collecting: <code>logman -start exporter -pf providers.txt -ets -bs 1024 -nb 100 256</code></item>
-    /// <item>Stop collecting: <code>logman -stop exporter -ets</code></item>
+    /// <item>To collect all events: <code>dotnet-trace collect --process-id PID --providers OpenTelemetry-Microsoft-AzureMonitor-AspNetCore</code></item>
+    /// <item>To collect events based on LogLevel: <code>dotnet-trace collect --process-id PID --providers OpenTelemetry-Microsoft-AzureMonitor-AspNetCore::Verbose</code></item>
     /// </list>
     /// </remarks>
     [EventSource(Name = EventSourceName)]
     internal sealed class AzureMonitorAspNetCoreEventSource : EventSource
     {
-        internal const string EventSourceName = "OpenTelemetry-AzureMonitor-AspNetCore";
+        internal const string EventSourceName = "OpenTelemetry-Microsoft-AzureMonitor-AspNetCore";
 
         internal static readonly AzureMonitorAspNetCoreEventSource Log = new AzureMonitorAspNetCoreEventSource();
 


### PR DESCRIPTION
Renames both EventSources to follow a consistent `OpenTelemetry-Microsoft-*` naming convention, enabling unified ETW/EventPipe capture via a single wildcard (`*OpenTelemetry-Microsoft*`).

### Changes

| EventSource | Before | After | GUID |
|---|---|---|---|
| Azure Monitor | `OpenTelemetry-AzureMonitor-AspNetCore` | `OpenTelemetry-Microsoft-AzureMonitor-AspNetCore` | `{04e66d6d-bc95-547b-b03a-9107d1abd44d}` |
| Agent365 ETW | `A365-O11y-EventSource` | `OpenTelemetry-Microsoft-Agent365-Etw` | `{544e9fe9-9c40-549a-ebb5-6492695772f7}` |

### Why

- Consistent naming makes it easy to capture all distro self-diagnostics and ETW data with one command: