### PR TITLE
Fix xUnit2012 warnings: replace Assert.True(collection.Any()) with Assert.Contains

### DIFF
--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/ExportTargetAutoDetectionTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/ExportTargetAutoDetectionTests.cs
@@ -199,10 +199,9 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
             Assert.True(hasAzureMonitorOptions, "Azure Monitor instrumentation should be configured even when exporter is skipped.");
 
             // TracerProvider config IS registered
-            Assert.True(services.Any(s =>
+            Assert.Contains(services, s =>
                 s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
-                s.ServiceType.Name.Contains("TracerProviderBuilder")),
-                "Tracing configuration should be registered.");
+                s.ServiceType.Name.Contains("TracerProviderBuilder"));
         }
 
         [Fact]
@@ -232,9 +231,8 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                 // Agent365 baggage processor source should be registered
                 // (UseAgent365 always adds the Agent365Sdk ActivitySource)
                 // We can verify by checking the services for ActivityProcessor registration
-                Assert.True(services.Any(s => s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
-                    s.ServiceType.Name.Contains("TracerProviderBuilder")),
-                    "Tracing configuration should be registered.");
+                Assert.Contains(services, s => s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
+                    s.ServiceType.Name.Contains("TracerProviderBuilder"));
             }
             finally
             {

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
@@ -44,9 +44,9 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                 Assert.False(HasAgent365Exporter(services));
 
                 // But tracing config IS registered (instrumentation active)
-                Assert.True(services.Any(s =>
+                Assert.Contains(services, s =>
                     s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
-                    s.ServiceType.Name.Contains("TracerProviderBuilder")));
+                    s.ServiceType.Name.Contains("TracerProviderBuilder"));
             }
             finally
             {
@@ -70,10 +70,9 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                 "Azure Monitor exporter should be skipped when not in ExportTarget.");
 
             // But AzureMonitor options ARE configured (instrumentation active)
-            Assert.True(services.Any(s =>
+            Assert.Contains(services, s =>
                 s.ServiceType.IsGenericType &&
-                s.ServiceType.GetGenericArguments().Any(a => a.Name == "AzureMonitorOptions")),
-                "AzureMonitor options should be configured (instrumentation runs).");
+                s.ServiceType.GetGenericArguments().Any(a => a.Name == "AzureMonitorOptions"));
         }
 
         [Fact]
@@ -131,10 +130,9 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
 
             // Console exporter registers via OpenTelemetry internals —
             // verify tracing config exists (console exporter is configured inside WithTracing)
-            Assert.True(services.Any(s =>
+            Assert.Contains(services, s =>
                 s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
-                s.ServiceType.Name.Contains("TracerProviderBuilder")),
-                "Tracing should be configured with console exporter.");
+                s.ServiceType.Name.Contains("TracerProviderBuilder"));
 
             // No Azure Monitor or Agent365
             Assert.False(HasAzureMonitorExporter(services));
@@ -151,10 +149,9 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                     o.Exporters = ExportTarget.Otlp;
                     });
 
-            Assert.True(services.Any(s =>
+            Assert.Contains(services, s =>
                 s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
-                s.ServiceType.Name.Contains("TracerProviderBuilder")),
-                "Tracing should be configured with OTLP exporter.");
+                s.ServiceType.Name.Contains("TracerProviderBuilder"));
         }
 
         [Fact]
@@ -165,10 +162,9 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                 .UseMicrosoftOpenTelemetry(o => { });
 
             // AgentFramework is always enabled — sources and processor are registered
-            Assert.True(services.Any(s =>
+            Assert.Contains(services, s =>
                 s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
-                s.ServiceType.Name.Contains("TracerProviderBuilder")),
-                "Agent Framework sources should be registered.");
+                s.ServiceType.Name.Contains("TracerProviderBuilder"));
         }
     }
 }


### PR DESCRIPTION
Replaces all 7 instances of `Assert.True(collection.Any(predicate))` with 
`Assert.Contains(collection, predicate)` per xUnit analyzer rule xUnit2012.

### Files changed
- `UseMicrosoftOpenTelemetryTests.cs` — 5 instances
- `ExportTargetAutoDetectionTests.cs` — 2 instances

These were flagged by both CodeQL and the xUnit analyzer on every CI run.