### PR TITLE
Add Microsoft Agent Framework (MAF) demo

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,12 +15,15 @@
 
     <!-- Azure Monitor exporter -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
 
     <!-- Agent365 dependencies -->
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.71.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Agents.Core" Version="1.71.0" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.7.0-beta.2" />
     <PackageVersion Include="Microsoft.Agents.Builder" Version="1.4.83" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
 

--- a/Microsoft.OpenTelemetry.slnx
+++ b/Microsoft.OpenTelemetry.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Project Path="examples/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/Azure.Monitor.OpenTelemetry.AspNetCore.Demo.csproj" />
+  <Project Path="examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Microsoft.OpenTelemetry.AgentFramework.Demo.csproj" />
   <Project Path="test/Microsoft.OpenTelemetry.Agent365.Tests/Microsoft.OpenTelemetry.Agent365.Tests.csproj" />
   <Project Path="test/Microsoft.OpenTelemetry.AzureMonitor.Tests/Microsoft.OpenTelemetry.AzureMonitor.Tests.csproj" />
   <Project Path="src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj" />

--- a/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Microsoft.OpenTelemetry.AgentFramework.Demo.csproj
+++ b/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Microsoft.OpenTelemetry.AgentFramework.Demo.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.OpenTelemetry\Microsoft.OpenTelemetry.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.Agents.AI" />
+    <PackageReference Include="Microsoft.Agents.AI.OpenAI" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Program.cs
+++ b/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Program.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.ClientModel;
+using Azure.AI.OpenAI;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.OpenTelemetry;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// One-line distro setup — MAF span capture (UseAgentFramework) is enabled by default.
+// Console exporter lets you see traces in the terminal without Azure Monitor.
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Console;
+});
+
+var app = builder.Build();
+
+// --- Create MAF agent -------------------------------------------------------
+
+var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
+    ?? throw new InvalidOperationException("Set the AZURE_OPENAI_ENDPOINT environment variable.");
+
+var deploymentName =
+    Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-5.4-mini";
+
+var apiKey = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY")
+    ?? throw new InvalidOperationException("Set the AZURE_OPENAI_API_KEY environment variable.");
+
+[Description("Get the weather for a given location.")]
+static string GetWeather([Description("The location to get the weather for.")] string location)
+    => $"The weather in {location} is cloudy with a high of 15°C.";
+
+AIAgent agent = new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey))
+    .GetChatClient(deploymentName)
+    .AsIChatClient()
+    .AsAIAgent(
+        instructions: "You are a helpful assistant that provides concise responses.",
+        tools: [AIFunctionFactory.Create(GetWeather)])
+    .AsBuilder()
+    .UseOpenTelemetry()
+    .Build();
+
+// --- Endpoints ---------------------------------------------------------------
+
+app.MapGet("/", () => "Microsoft Agent Framework Demo — POST /chat with a JSON body { \"message\": \"...\" }");
+
+app.MapPost("/chat", async (ChatRequest request) =>
+{
+    if (string.IsNullOrWhiteSpace(request.Message))
+    {
+        return Results.BadRequest(new { error = "message is required" });
+    }
+
+    var response = await agent.RunAsync(request.Message);
+
+    return Results.Ok(new
+    {
+        reply = response,
+        traceId = Activity.Current?.TraceId.ToString()
+    });
+});
+
+app.Run();
+
+record ChatRequest(string Message);

--- a/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Properties/launchSettings.json
+++ b/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "Microsoft.OpenTelemetry.AgentFramework.Demo": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5081",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "AZURE_OPENAI_ENDPOINT": "",
+        "AZURE_OPENAI_DEPLOYMENT_NAME": "",
+        "AZURE_OPENAI_API_KEY": "",
+        "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
+      }
+    }
+  }
+}

--- a/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/README.md
+++ b/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/README.md
@@ -1,0 +1,82 @@
+# Microsoft Agent Framework (MAF) Demo
+
+This demo shows how the **Microsoft OpenTelemetry Distro** captures telemetry from the [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) with a single line of code.
+
+## What it does
+
+- Creates a MAF `AIAgent` backed by Azure OpenAI with a `GetWeather` tool
+- Exposes a `POST /chat` endpoint that invokes the agent
+- Exports traces and metrics to **Azure Monitor** (Application Insights) and **Console**
+- The distro's `UseAgentFramework()` is enabled by default — no extra configuration needed
+
+## Prerequisites
+
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
+- An [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/) resource with a deployed model (e.g., `gpt-5.4-mini`)
+- An [Application Insights](https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview) resource (optional — for Azure Monitor export)
+
+## Configuration
+
+Set the following environment variables:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AZURE_OPENAI_ENDPOINT` | Yes | Azure OpenAI endpoint (e.g., `https://your-resource.openai.azure.com/`) |
+| `AZURE_OPENAI_API_KEY` | Yes | Azure OpenAI API key |
+| `AZURE_OPENAI_DEPLOYMENT_NAME` | No | Model deployment name (defaults to `gpt-5.4-mini`) |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | No | Application Insights connection string (enables Azure Monitor export) |
+
+These are pre-configured in `Properties/launchSettings.json` for local development.
+
+## Running the demo
+
+```powershell
+# From the repo root
+dotnet run --project examples/Microsoft.OpenTelemetry.AgentFramework.Demo
+```
+
+The app starts on `http://localhost:5081`.
+
+## Testing
+
+Send a chat request:
+
+```powershell
+Invoke-RestMethod -Uri http://localhost:5081/chat `
+  -Method Post `
+  -ContentType "application/json" `
+  -Body '{"message":"What is the weather in Seattle?"}'
+```
+
+Expected response:
+
+```json
+{
+  "reply": { "messages": [...], "finishReason": "stop", ... },
+  "traceId": "abc123..."
+}
+```
+
+The agent will invoke the `GetWeather` tool and return the result.
+
+## Viewing traces
+
+- **Console**: Traces are printed to the terminal where the app is running
+- **Azure Monitor**: Traces appear in Application Insights → **Transaction search** (allow 2-5 minutes for ingestion). Search by the `traceId` from the response.
+
+## How the distro simplifies this
+
+Without the distro, you would need ~50 lines of manual OpenTelemetry setup (see the [MAF AgentOpenTelemetry sample](https://github.com/microsoft/agent-framework/tree/main/dotnet/samples/02-agents/AgentOpenTelemetry)). With the distro, it's one line:
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Console;
+});
+```
+
+This automatically:
+- Subscribes to MAF activity sources (`Experimental.Microsoft.Agents.AI*`)
+- Adds ASP.NET Core, HTTP client, and SQL client instrumentation
+- Configures Azure Monitor and Console exporters
+- Detects Azure resource metadata (VM, App Service, Container Apps)

--- a/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/appsettings.json
+++ b/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
- New example project: Microsoft.OpenTelemetry.AgentFramework.Demo
- Creates a MAF AIAgent with Azure OpenAI and a GetWeather tool
- Uses .UseOpenTelemetry() to emit MAF spans (invoke_agent, execute_tool)
- Distro captures spans via UseAgentFramework() (enabled by default)
- Exports to Azure Monitor and Console
- Added Azure.Identity, Microsoft.Agents.AI, Microsoft.Agents.AI.OpenAI to central package management
- Updated solution file to include the new demo project