### PR TITLE
Add testing docs and set version to 1.0.0-alpha.1

### DIFF
--- a/docs/testing-agent-framework.md
+++ b/docs/testing-agent-framework.md
@@ -1,0 +1,226 @@
+# Testing Microsoft.OpenTelemetry Distro — Agent Framework (MAF) Team
+
+## Package
+
+```
+Microsoft.OpenTelemetry 1.0.0-alpha.1
+```
+
+Available at: `c:\aidistro-repos\local-nuget\` (local feed) or request from distro team.
+
+## What the distro provides
+
+For Agent Framework apps, the distro gives you one-line OpenTelemetry setup with:
+
+- Correct `ActivitySource` registration for `Experimental.Microsoft.Extensions.AI` and `Experimental.Microsoft.Agents.AI`
+- `ParentBasedSampler(AlwaysOnSampler)` — ensures gen_ai spans aren't dropped in async processing
+- Console exporter, Azure Monitor exporter, and/or Agent365 exporter
+- Baggage-to-tags propagation via `ActivityProcessor`
+- Semantic Kernel span processor (if using SK)
+
+## Setup
+
+### 1. Add NuGet source
+
+Create `nuget.config` in your project directory:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local-distro" value="c:\aidistro-repos\local-nuget" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+### 2. Add package to .csproj
+
+```xml
+<PackageReference Include="Microsoft.OpenTelemetry" Version="1.0.0-alpha.1" />
+
+<!-- Keep your existing Agent Framework packages -->
+<PackageReference Include="Microsoft.Agents.AI" Version="1.0.0" />
+<PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0" />
+```
+
+You do **not** need to add individual OpenTelemetry packages — the distro includes them.
+
+### 3. Program.cs — Minimal setup
+
+```csharp
+using Microsoft.OpenTelemetry;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// One-line distro setup — includes all OTel instrumentation + correct samplers
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Console;
+});
+
+var app = builder.Build();
+```
+
+If you need to add custom activity sources, use the longer form:
+
+```csharp
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Console;
+    })
+    .WithTracing(tracing => tracing
+        .AddSource("MyApp.CustomSource"));
+```
+
+> **Note:** `builder.UseMicrosoftOpenTelemetry()` internally calls `builder.Services.AddOpenTelemetry().UseMicrosoftOpenTelemetry()`. Use the short form unless you need `.WithTracing()`.
+
+### 4. Create your agent with UseOpenTelemetry()
+
+```csharp
+using System.ClientModel;
+using Azure.AI.OpenAI;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+AIAgent agent = new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey))
+    .GetChatClient(deploymentName)
+    .AsIChatClient()
+    .AsAIAgent(
+        instructions: "You are a helpful assistant.",
+        tools: [AIFunctionFactory.Create(GetWeather)])
+    .AsBuilder()
+    .UseOpenTelemetry()    // <-- This creates the gen_ai spans
+    .Build();
+```
+
+### 5. UseMicrosoftOpenTelemetry options
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    // Export targets (combine with |)
+    o.Exporters = ExportTarget.Console              // Console output (dev)
+                | ExportTarget.AzureMonitor;        // Application Insights
+
+    // Azure Monitor (requires APPLICATIONINSIGHTS_CONNECTION_STRING env var, or set here)
+    // o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
+
+    // Agent365 exporter (for A365 platform — requires token resolver)
+    // o.Exporters |= ExportTarget.Agent365;
+    // o.Agent365.Exporter.TokenResolver = async (agentId, tenantId) =>
+    //     await MyTokenService.GetTokenAsync(agentId, tenantId);
+});
+```
+
+If `Exporters` is not set explicitly, exporters are **auto-detected** from configuration:
+- `AzureMonitor` — enabled if `APPLICATIONINSIGHTS_CONNECTION_STRING` is found
+- `Agent365` — enabled if `TokenResolver` is set
+
+### 6. Set environment variables
+
+```powershell
+$env:AZURE_OPENAI_ENDPOINT = "https://your-endpoint.openai.azure.com/"
+$env:AZURE_OPENAI_API_KEY = "your-key"
+$env:AZURE_OPENAI_DEPLOYMENT_NAME = "gpt-4o-mini"
+```
+
+### 7. Run
+
+```powershell
+dotnet run --no-launch-profile
+```
+
+> **Important:** Use `--no-launch-profile` if your `launchSettings.json` has empty environment variable overrides — they will blank out your env vars.
+
+## Non-DI setup (Console apps, tests, background jobs)
+
+If you're not using `WebApplicationBuilder` or the Generic Host, use `OpenTelemetrySdk.Create()` directly. This doesn't require the distro package — just the standard OpenTelemetry packages:
+
+```csharp
+using System.ClientModel;
+using Azure.AI.OpenAI;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+// --- OTel setup (non-DI) ---
+using var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.ConfigureResource(r => r.AddService("my-agent-app"));
+
+    otel.WithTracing(tracing => tracing
+        .SetSampler(new ParentBasedSampler(
+            rootSampler: new AlwaysOnSampler(),
+            localParentNotSampled: new AlwaysOnSampler(),
+            remoteParentNotSampled: new AlwaysOnSampler()))
+        .AddSource("Experimental.Microsoft.Extensions.AI")
+        .AddSource("Experimental.Microsoft.Agents.AI")
+        .AddConsoleExporter());
+
+    otel.WithMetrics(metrics => metrics
+        .AddMeter("Experimental.Microsoft.Agents.AI")
+        .AddMeter("Experimental.Microsoft.Extensions.AI")
+        .AddConsoleExporter());
+});
+
+// --- Create and use your agent ---
+AIAgent agent = new AzureOpenAIClient(
+        new Uri(Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")!),
+        new ApiKeyCredential(Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY")!))
+    .GetChatClient(Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "gpt-4o-mini")
+    .AsIChatClient()
+    .AsAIAgent(instructions: "You are a helpful assistant.")
+    .AsBuilder()
+    .UseOpenTelemetry()
+    .Build();
+
+var response = await agent.RunAsync("What is 2+2?");
+Console.WriteLine(response);
+```
+
+**Key points for non-DI:**
+- `OpenTelemetrySdk.Create()` manages lifecycle — `using var` ensures flush on exit
+- The `ParentBasedSampler(AlwaysOnSampler)` is critical — without it, orphan root spans may be dropped
+- ActivitySource names must match exactly: `Experimental.Microsoft.Extensions.AI` and `Experimental.Microsoft.Agents.AI`
+- No distro package needed — use `OpenTelemetry`, `OpenTelemetry.Exporter.Console` (or `.OpenTelemetryProtocol`) directly
+
+## Expected spans
+
+Send a request to your `/chat` endpoint (check console output for the actual port):
+
+```powershell
+Invoke-RestMethod -Uri "http://localhost:<port>/chat" -Method POST `
+    -ContentType "application/json" `
+    -Body '{"message":"What is the weather in Seattle?"}'
+```
+
+Console output should show:
+
+| Span | Source | Description |
+|------|--------|-------------|
+| `invoke_agent *` | `Experimental.Microsoft.Agents.AI` | Agent invocation |
+| `execute_tool *` | `Experimental.Microsoft.Agents.AI` | Tool call (if tools configured) |
+| `chat gpt-*` | `Experimental.Microsoft.Extensions.AI` | LLM call (if `.UseOpenTelemetry()` on IChatClient too) |
+| `POST` | `System.Net.Http` | HTTP call to Azure OpenAI |
+| `POST /chat` | `Microsoft.AspNetCore.Hosting` | Your endpoint |
+
+## Export targets
+
+| Target | When to use | Requires |
+|--------|-------------|----------|
+| `ExportTarget.Console` | Local development / debugging | Nothing |
+| `ExportTarget.AzureMonitor` | Application Insights | `APPLICATIONINSIGHTS_CONNECTION_STRING` env var |
+| `ExportTarget.Agent365` | Agent365 observability platform | Token resolver + agent registration |
+
+## Reference implementation
+
+See: `examples/Microsoft.OpenTelemetry.AgentFramework.Demo/` in the distro repo.
+
+This is a minimal WebAPI app with a `/chat` endpoint, weather tool, and `UseOpenTelemetry()` on the agent — no Bot Framework, no dev tunnel, no Agent365 auth.

--- a/docs/testing-agent365.md
+++ b/docs/testing-agent365.md
@@ -1,0 +1,244 @@
+# Testing Microsoft.OpenTelemetry Distro — Agent365 Team
+
+## Package
+
+```
+Microsoft.OpenTelemetry 1.0.0-alpha.1
+```
+
+Available at: `c:\aidistro-repos\local-nuget\` (local feed) or request from distro team.
+
+## What changes
+
+The distro replaces the Agent365 observability packages **and** the raw OpenTelemetry packages with a single package. Namespaces are identical to the Agent365 SDK — no `using` changes needed in your agent code.
+
+### Packages to REMOVE from .csproj
+
+```xml
+<!-- Remove all of these -->
+<PackageReference Include="Microsoft.Agents.A365.Observability.Extensions.AgentFramework" Version="0.2.151-beta" />
+<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+```
+
+### Package to ADD
+
+```xml
+<PackageReference Include="Microsoft.OpenTelemetry" Version="1.0.0-alpha.1" />
+```
+
+### Packages to KEEP (unchanged)
+
+```xml
+<PackageReference Include="Microsoft.Agents.A365.Notifications" Version="0.2.151-beta" />
+<PackageReference Include="Microsoft.Agents.A365.Tooling.Extensions.AgentFramework" Version="0.2.151-beta" />
+<!-- ... all other non-observability packages stay as-is -->
+```
+
+## Program.cs changes
+
+### BEFORE (Agent365 SDK)
+
+```csharp
+using Microsoft.Agents.A365.Observability;
+using Microsoft.Agents.A365.Observability.Extensions.AgentFramework;
+using Microsoft.Agents.A365.Observability.Runtime;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.ConfigureOpenTelemetry();
+
+builder.Services.AddSingleton(new Agent365ExporterOptions
+{
+    TokenResolver = (agentId, tenantId) => Task.FromResult(TokenStore.GetToken(agentId, tenantId))
+});
+
+builder.AddA365Tracing(config =>
+{
+    config.WithAgentFramework();
+});
+```
+
+### AFTER (Distro)
+
+```csharp
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Console | ExportTarget.Agent365;
+    })
+    .WithTracing(tracing => tracing
+        .AddSource(
+            "A365.AgentFramework",
+            "Microsoft.Agents.Builder",
+            "Microsoft.Agents.Hosting"));
+```
+
+> **Shorter alternative** (if you don't need custom `.AddSource()` calls):
+> ```csharp
+> builder.UseMicrosoftOpenTelemetry(o =>
+> {
+>     o.Exporters = ExportTarget.Console | ExportTarget.Agent365;
+> });
+> ```
+
+### What to REMOVE from Program.cs
+
+- `builder.ConfigureOpenTelemetry();` — replaced by `UseMicrosoftOpenTelemetry()`
+- `builder.Services.AddSingleton(new Agent365ExporterOptions { ... });` — token cache is auto-registered via DI
+- `builder.AddA365Tracing(config => { ... });` — replaced by `UseMicrosoftOpenTelemetry()`
+- `using` statements for `Microsoft.Agents.A365.Observability.*` in Program.cs — replace with `using Microsoft.OpenTelemetry;` and `using OpenTelemetry;`
+- `TokenStore` class file — delete it entirely. Replaced by `IExporterTokenCache<AgenticTokenStruct>` (injected via DI)
+- `ConfigureOpenTelemetry()` extension method file (if you have one) — delete it, the distro handles all OTel setup
+
+### What to REMOVE from A365OtelWrapper.cs
+
+The `TokenStore.SetToken(...)` / `TokenStore.GetToken(...)` calls are replaced. Instead, inject `IExporterTokenCache<AgenticTokenStruct>` via the constructor:
+
+```csharp
+// BEFORE: TokenStore.SetToken(agentId, tenantId, token);
+// AFTER:  (inject via constructor)
+private readonly IExporterTokenCache<AgenticTokenStruct>? _agentTokenCache;
+
+// Then in your method:
+_agentTokenCache?.RegisterObservability(agentId, tenantId, new AgenticTokenStruct(
+    userAuthorization: authSystem,
+    turnContext: turnContext,
+    authHandlerName: authHandlerName
+), EnvironmentUtils.GetObservabilityAuthenticationScope());
+```
+
+### What to ADD
+
+- `using Microsoft.OpenTelemetry;`
+- The `UseMicrosoftOpenTelemetry()` block shown above
+
+## Agent code (MyAgent.cs, A365OtelWrapper.cs)
+
+**No changes needed** to `using` statements in agent code. The distro uses the same `Microsoft.Agents.A365.Observability.*` namespaces as the Agent365 SDK:
+
+```csharp
+// These usings still work — namespaces are identical
+using Microsoft.Agents.A365.Observability.Hosting.Caching;  // IExporterTokenCache, AgenticTokenStruct
+using Microsoft.Agents.A365.Observability.Runtime.Common;    // BaggageBuilder, EnvironmentUtils
+```
+
+### Token registration pattern
+
+The `A365OtelWrapper.RegisterObservability` call stays the same:
+
+```csharp
+agentTokenCache.RegisterObservability(agentId, tenantId, new AgenticTokenStruct(
+    userAuthorization: authSystem,
+    turnContext: turnContext,
+    authHandlerName: authHandlerName
+), EnvironmentUtils.GetObservabilityAuthenticationScope());
+```
+
+The only difference: `IExporterTokenCache<AgenticTokenStruct>` comes from DI automatically (no need to manually create `Agent365ExporterOptions` or `TokenStore`).
+
+## NuGet source setup
+
+Add to your `nuget.config` (or create one in the project directory):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local-distro" value="c:\aidistro-repos\local-nuget" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+## Run and verify
+
+```powershell
+$env:ASPNETCORE_ENVIRONMENT='Development'
+dotnet run
+```
+
+## UseMicrosoftOpenTelemetry options reference
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        // --- Export targets (pick one or combine with |) ---
+        o.Exporters = ExportTarget.Console          // Console output (dev)
+                    | ExportTarget.Agent365          // Agent365 observability platform
+                    | ExportTarget.AzureMonitor;     // Application Insights
+
+        // --- Agent365 exporter settings ---
+
+        // Option A: Let the distro auto-manage tokens via DI (recommended)
+        // IExporterTokenCache<AgenticTokenStruct> is registered automatically.
+        // Your A365OtelWrapper calls RegisterObservability() at runtime.
+        // No TokenResolver needed here — it's wired internally.
+
+        // Option B: Provide your own token resolver (advanced/custom)
+        o.Agent365.Exporter.TokenResolver = async (agentId, tenantId) =>
+        {
+            // Return a valid bearer token for the given agent/tenant
+            return await MyTokenService.GetTokenAsync(agentId, tenantId);
+        };
+
+        // Optional: custom domain resolver (default: agent365.svc.cloud.microsoft)
+        o.Agent365.Exporter.DomainResolver = tenantId => "agent365.svc.cloud.microsoft";
+
+        // Optional: use S2S endpoint path
+        o.Agent365.Exporter.UseS2SEndpoint = false;
+
+        // Optional: batch export tuning
+        o.Agent365.Exporter.MaxQueueSize = 2048;
+        o.Agent365.Exporter.MaxExportBatchSize = 512;
+        o.Agent365.Exporter.ScheduledDelayMilliseconds = 5000;
+        o.Agent365.Exporter.ExporterTimeoutMilliseconds = 30000;
+
+        // --- Azure Monitor settings ---
+        // o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
+        // o.AzureMonitor.SamplingRatio = 1.0f;
+        // o.AzureMonitor.EnableLiveMetrics = true;
+    });
+```
+
+### Token resolver: auto vs custom
+
+| Approach | When to use | How it works |
+|----------|-------------|--------------|
+| **Auto (DI)** — default | Agent Framework apps with `UserAuthorization` | Distro registers `IExporterTokenCache<AgenticTokenStruct>`. Your `A365OtelWrapper` calls `RegisterObservability()`. Token exchange happens via `ExchangeTurnTokenAsync`. |
+| **Custom resolver** | Non-agent apps, service-to-service, or custom auth | Set `o.Agent365.Exporter.TokenResolver` directly. You own token acquisition. |
+
+If you set `TokenResolver` explicitly, the auto DI token cache is **not** registered — your resolver is used instead.
+
+Send a message via Teams. In the console output, look for:
+
+```
+Activity.DisplayName:        chat gpt-*
+Activity.DisplayName:        invoke_agent *
+Activity.DisplayName:        MessageProcessor
+```
+
+And A365 export:
+```
+Received HTTP response headers after *ms - 200
+```
+
+## Known issues
+
+- `launch­Settings.json` may override environment variables with empty strings — use `dotnet run --no-launch-profile` or set values via `dotnet user-secrets` instead
+- If `ExportTarget.Agent365` is set, `IExporterTokenCache<AgenticTokenStruct>` must be populated at runtime via `RegisterObservability()` — otherwise the exporter will skip export silently
+- Azure Monitor requires `APPLICATIONINSIGHTS_CONNECTION_STRING` to be set if `ExportTarget.AzureMonitor` is included
+
+## Reference implementation
+
+See: `examples/Microsoft.OpenTelemetry.Agent365.Demo/` in the distro repo.

--- a/src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj
+++ b/src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet packaging -->
     <PackageId>Microsoft.OpenTelemetry</PackageId>
-    <Version>1.0.0-beta.1</Version>
+    <Version>1.0.0-alpha.1</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See CHANGELOG.md for release notes.</PackageReleaseNotes>


### PR DESCRIPTION
Adds testing instructions for Agent365 and Agent Framework teams to validate the `Microsoft.OpenTelemetry` distro package, and sets the package version to `1.0.0-alpha.1`.

## Changes

- `docs/testing-agent365.md` — Migration guide for Agent365 team: package swap, Program.cs before/after, TokenStore→DI migration, options reference
- `docs/testing-agent-framework.md` — Setup guide for MAF team: DI and non-DI (`OpenTelemetrySdk.Create()`) patterns, options reference
- `src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj` — Version `1.0.0-beta.1` → `1.0.0-alpha.1`

## NuGet package

`Microsoft.OpenTelemetry.1.0.0-alpha.1.nupkg` available at `Microsoft.OpenTelemetry-NuGet/` (shared folder).
