### PR TITLE
Add missing Agent Framework and OpenAI activity sources

### DIFF
--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
@@ -83,8 +83,11 @@ internal static class Agent365OpenTelemetryBuilderExtensions
                 .AddSource(OpenTelemetryConstants.SourceName)
                 .AddSource(SemanticKernelTelemetryConstants.SemanticKernelSourceWildcard)
                 .AddSource("Azure.AI.OpenAI*")
+                .AddSource("OpenAI.*")
                 .AddSource("Experimental.Microsoft.Extensions.AI")
                 .AddSource("Experimental.Microsoft.Agents.AI")
+                .AddSource("Experimental.Microsoft.Agents.AI.Agent")
+                .AddSource("Experimental.Microsoft.Agents.AI.ChatClient")
                 .AddProcessor<ActivityProcessor>()
                 .AddProcessor(new SemanticKernelSpanProcessor());
 


### PR DESCRIPTION
Add sources from Agent365 SDK that were missing in the distro:
- Experimental.Microsoft.Agents.AI.Agent
- Experimental.Microsoft.Agents.AI.ChatClient
- OpenAI.* (wildcard for OpenAI SDK spans)