### PR TITLE
Add InstrumentationOptions for per-library and per-signal control

### DIFF
--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -1,4 +1,29 @@
 #nullable enable
+Microsoft.OpenTelemetry.InstrumentationOptions
+Microsoft.OpenTelemetry.InstrumentationOptions.InstrumentationOptions() -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableTracing.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableTracing.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableMetrics.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableMetrics.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableLogging.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableLogging.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableAspNetCoreInstrumentation.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableAspNetCoreInstrumentation.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableHttpClientInstrumentation.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableHttpClientInstrumentation.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableSqlClientInstrumentation.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableSqlClientInstrumentation.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableAzureSdkInstrumentation.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableAzureSdkInstrumentation.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableOpenAIInstrumentation.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableOpenAIInstrumentation.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableSemanticKernelInstrumentation.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableSemanticKernelInstrumentation.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableAgentFrameworkInstrumentation.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableAgentFrameworkInstrumentation.set -> void
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableAgent365Instrumentation.get -> bool
+Microsoft.OpenTelemetry.InstrumentationOptions.EnableAgent365Instrumentation.set -> void
+Microsoft.OpenTelemetry.MicrosoftOpenTelemetryOptions.Instrumentation.get -> Microsoft.OpenTelemetry.InstrumentationOptions!
 abstract Microsoft.Agents.A365.Observability.Runtime.DTOs.BaseData.Name.get -> string!
 abstract Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.BaseExporterAsync<T>.ExportAsync(System.Collections.Generic.IReadOnlyCollection<T!>! batch, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.Agents.A365.Observability.Hosting.Caching.AgenticTokenCache

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
@@ -29,7 +29,7 @@ internal static class Agent365OpenTelemetryBuilderExtensions
     /// <returns>The supplied <see cref="IOpenTelemetryBuilder"/> for chaining calls.</returns>
     internal static IOpenTelemetryBuilder UseAgent365(this IOpenTelemetryBuilder builder)
     {
-        return builder.UseAgent365(o => { });
+        return builder.UseAgent365(o => { }, new InstrumentationOptions());
     }
 
     /// <summary>
@@ -57,16 +57,30 @@ internal static class Agent365OpenTelemetryBuilderExtensions
     /// </remarks>
     internal static IOpenTelemetryBuilder UseAgent365(this IOpenTelemetryBuilder builder, Action<Agent365Options> configure)
     {
+        return builder.UseAgent365(configure, new InstrumentationOptions());
+    }
+
+    /// <summary>
+    /// Configures Agent365 observability with instrumentation options.
+    /// </summary>
+    internal static IOpenTelemetryBuilder UseAgent365(this IOpenTelemetryBuilder builder, Action<Agent365Options> configure, InstrumentationOptions instrumentationOptions)
+    {
         var options = new Agent365Options();
         configure?.Invoke(options);
 
         // Enable Azure SDK activity sources
         AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
-        AppContext.SetSwitch("Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnosticsSensitive", true);
+
+        if (instrumentationOptions.EnableSemanticKernelInstrumentation)
+        {
+            AppContext.SetSwitch("Microsoft.SemanticKernel.Experimental.GenAI.EnableOTelDiagnosticsSensitive", true);
+        }
 
         // --- Core tracing: Agent365 scopes + baggage processor + framework span processors ---
-        builder.WithTracing(tracing =>
+        if (instrumentationOptions.EnableTracing)
         {
+            builder.WithTracing(tracing =>
+            {
             // Match the Agent365 SDK sampler: ParentBasedSampler with AlwaysOnSampler
             // for all cases. The Bot Framework returns HTTP 202 immediately and processes
             // LLM calls on async continuations with no parent Activity. Without this,
@@ -76,17 +90,32 @@ internal static class Agent365OpenTelemetryBuilderExtensions
                 .SetSampler(new global::OpenTelemetry.Trace.ParentBasedSampler(
                     rootSampler: new global::OpenTelemetry.Trace.AlwaysOnSampler(),
                     localParentNotSampled: new global::OpenTelemetry.Trace.AlwaysOnSampler(),
-                    remoteParentNotSampled: new global::OpenTelemetry.Trace.AlwaysOnSampler()))
-                .AddSource(OpenTelemetryConstants.SourceName)
-                .AddSource(SemanticKernelTelemetryConstants.SemanticKernelSourceWildcard)
-                .AddSource("Azure.AI.OpenAI*")
-                .AddSource("OpenAI.*")
-                .AddSource("Experimental.Microsoft.Extensions.AI")
-                .AddSource("Experimental.Microsoft.Agents.AI")
-                .AddSource("Experimental.Microsoft.Agents.AI.Agent")
-                .AddSource("Experimental.Microsoft.Agents.AI.ChatClient")
-                .AddProcessor<ActivityProcessor>()
-                .AddProcessor(new SemanticKernelSpanProcessor());
+                    remoteParentNotSampled: new global::OpenTelemetry.Trace.AlwaysOnSampler()));
+
+            // Agent365 scopes + baggage processor
+            if (instrumentationOptions.EnableAgent365Instrumentation)
+            {
+                tracing
+                    .AddSource(OpenTelemetryConstants.SourceName)
+                    .AddProcessor<ActivityProcessor>();
+            }
+
+            // Semantic Kernel
+            if (instrumentationOptions.EnableSemanticKernelInstrumentation)
+            {
+                tracing
+                    .AddSource(SemanticKernelTelemetryConstants.SemanticKernelSourceWildcard)
+                    .AddProcessor(new SemanticKernelSpanProcessor());
+            }
+
+            // OpenAI / Azure OpenAI
+            if (instrumentationOptions.EnableOpenAIInstrumentation)
+            {
+                tracing
+                    .AddSource("Azure.AI.OpenAI*")
+                    .AddSource("OpenAI.*")
+                    .AddSource("Experimental.Microsoft.Extensions.AI");
+            }
 
             // Agent365 Exporter (enabled when not skipped)
             if (!options.SkipExporter)
@@ -104,7 +133,8 @@ internal static class Agent365OpenTelemetryBuilderExtensions
                 }
                 tracing.AddAgent365Exporter();
             }
-        });
+            });
+        }
 
         return builder;
     }

--- a/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkOpenTelemetryBuilderExtensions.cs
@@ -34,24 +34,44 @@ internal static class AgentFrameworkOpenTelemetryBuilderExtensions
     /// </remarks>
     internal static IOpenTelemetryBuilder UseAgentFramework(this IOpenTelemetryBuilder builder)
     {
-        builder.WithTracing(tracing =>
-        {
-            // Default Microsoft Agent Framework activity sources
-            tracing
-                .AddSource(AgentFrameworkConstants.DefaultSource)
-                .AddSource(AgentFrameworkConstants.AgentSource)
-                .AddSource(AgentFrameworkConstants.ChatClientSource)
-                .AddProcessor(new AgentFrameworkSpanProcessor());
-        });
+        return builder.UseAgentFramework(new InstrumentationOptions());
+    }
 
-        // Also capture metrics from the same sources
-        builder.WithMetrics(metrics =>
+    /// <summary>
+    /// Configures the distro to capture telemetry from Microsoft Agent Framework
+    /// with instrumentation options controlling which signals are active.
+    /// </summary>
+    internal static IOpenTelemetryBuilder UseAgentFramework(this IOpenTelemetryBuilder builder, InstrumentationOptions instrumentationOptions)
+    {
+        if (!instrumentationOptions.EnableAgentFrameworkInstrumentation)
         {
-            metrics
-                .AddMeter(AgentFrameworkConstants.DefaultSource)
-                .AddMeter(AgentFrameworkConstants.AgentSource)
-                .AddMeter(AgentFrameworkConstants.ChatClientSource);
-        });
+            return builder;
+        }
+
+        if (instrumentationOptions.EnableTracing)
+        {
+            builder.WithTracing(tracing =>
+            {
+                // Default Microsoft Agent Framework activity sources
+                tracing
+                    .AddSource(AgentFrameworkConstants.DefaultSource)
+                    .AddSource(AgentFrameworkConstants.AgentSource)
+                    .AddSource(AgentFrameworkConstants.ChatClientSource)
+                    .AddProcessor(new AgentFrameworkSpanProcessor());
+            });
+        }
+
+        if (instrumentationOptions.EnableMetrics)
+        {
+            // Also capture metrics from the same sources
+            builder.WithMetrics(metrics =>
+            {
+                metrics
+                    .AddMeter(AgentFrameworkConstants.DefaultSource)
+                    .AddMeter(AgentFrameworkConstants.AgentSource)
+                    .AddMeter(AgentFrameworkConstants.ChatClientSource);
+            });
+        }
 
         return builder;
     }

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/OpenTelemetryBuilderExtensions.cs
@@ -72,6 +72,15 @@ namespace Microsoft.OpenTelemetry
         /// </remarks>
         internal static IOpenTelemetryBuilder UseAzureMonitor(this IOpenTelemetryBuilder builder, Action<AzureMonitorOptions> configureAzureMonitor)
         {
+            return builder.UseAzureMonitor(configureAzureMonitor, new InstrumentationOptions());
+        }
+
+        /// <summary>
+        /// Configures Azure Monitor with instrumentation options that control which
+        /// auto-instrumentations and signals are active.
+        /// </summary>
+        internal static IOpenTelemetryBuilder UseAzureMonitor(this IOpenTelemetryBuilder builder, Action<AzureMonitorOptions> configureAzureMonitor, InstrumentationOptions instrumentationOptions)
+        {
             if (builder.Services == null)
             {
                 throw new ArgumentNullException(nameof(builder.Services));
@@ -90,26 +99,60 @@ namespace Microsoft.OpenTelemetry
 
             builder.ConfigureResource(configureResource);
 
-            builder.WithTracing(b => b
-                            .AddSource("Azure.*")
-                            .AddAspNetCoreInstrumentation()
-                            .AddHttpClientInstrumentation(o => o.FilterHttpRequestMessage = (_) =>
-                            {
-                                // Azure SDKs create their own client span before calling the service using HttpClient
-                                // In this case, we would see two spans corresponding to the same operation
-                                // 1) created by Azure SDK 2) created by HttpClient
-                                // To prevent this duplication we are filtering the span from HttpClient
-                                // as span from Azure SDK contains all relevant information needed.
-                                var parentActivity = Activity.Current?.Parent;
-                                if (parentActivity != null && parentActivity.Source.Name.Equals("Azure.Core.Http"))
-                                {
-                                    return false;
-                                }
-                                return true;
-                            })
-                            .AddSqlClientInstrumentation());
+            if (instrumentationOptions.EnableTracing)
+            {
+                builder.WithTracing(b =>
+                {
+                    if (instrumentationOptions.EnableAzureSdkInstrumentation)
+                    {
+                        b.AddSource("Azure.*");
+                    }
 
-            builder.WithMetrics(b => b.AddHttpClientAndServerMetrics());
+                    if (instrumentationOptions.EnableAspNetCoreInstrumentation)
+                    {
+                        b.AddAspNetCoreInstrumentation();
+                    }
+
+                    if (instrumentationOptions.EnableHttpClientInstrumentation)
+                    {
+                        b.AddHttpClientInstrumentation(o => o.FilterHttpRequestMessage = (_) =>
+                        {
+                            // Azure SDKs create their own client span before calling the service using HttpClient
+                            // In this case, we would see two spans corresponding to the same operation
+                            // 1) created by Azure SDK 2) created by HttpClient
+                            // To prevent this duplication we are filtering the span from HttpClient
+                            // as span from Azure SDK contains all relevant information needed.
+                            var parentActivity = Activity.Current?.Parent;
+                            if (parentActivity != null && parentActivity.Source.Name.Equals("Azure.Core.Http"))
+                            {
+                                return false;
+                            }
+                            return true;
+                        });
+                    }
+
+                    if (instrumentationOptions.EnableSqlClientInstrumentation)
+                    {
+                        b.AddSqlClientInstrumentation();
+                    }
+                });
+            }
+
+            if (instrumentationOptions.EnableMetrics)
+            {
+                builder.WithMetrics(b =>
+                {
+                    if (instrumentationOptions.EnableAspNetCoreInstrumentation)
+                    {
+                        b.AddMeter("Microsoft.AspNetCore.Hosting");
+                    }
+
+                    if (instrumentationOptions.EnableHttpClientInstrumentation)
+                    {
+                        b.AddMeter("System.Net.Http");
+                    }
+                });
+            }
 
             // Register a configuration action so that when
             // AzureMonitorExporterOptions is requested it is populated from
@@ -172,11 +215,6 @@ namespace Microsoft.OpenTelemetry
             }
 
             return builder;
-        }
-
-        private static MeterProviderBuilder AddHttpClientAndServerMetrics(this MeterProviderBuilder meterProviderBuilder)
-        {
-            return meterProviderBuilder.AddMeter("Microsoft.AspNetCore.Hosting").AddMeter("System.Net.Http");
         }
     }
 }

--- a/src/Microsoft.OpenTelemetry/InstrumentationOptions.cs
+++ b/src/Microsoft.OpenTelemetry/InstrumentationOptions.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.OpenTelemetry;
+
+/// <summary>
+/// Controls which telemetry signals and auto-instrumentations are active.
+/// All options default to <c>true</c> (opt-out model).
+/// </summary>
+public class InstrumentationOptions
+{
+    // ── Signal pipelines ──
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the distributed tracing pipeline is enabled.
+    /// When <c>false</c>, no <c>TracerProvider</c> is configured and all library-level
+    /// tracing options are ignored. Default: <c>true</c>.
+    /// </summary>
+    public bool EnableTracing { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the metrics pipeline is enabled.
+    /// When <c>false</c>, no <c>MeterProvider</c> is configured. Default: <c>true</c>.
+    /// </summary>
+    public bool EnableMetrics { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the logging pipeline is enabled
+    /// for OTLP and Console exporters. When <c>false</c>, log exporters are not
+    /// registered for these targets. Does not affect Azure Monitor logging, which
+    /// is controlled by the Azure Monitor Exporter package. Default: <c>true</c>.
+    /// </summary>
+    public bool EnableLogging { get; set; } = true;
+
+    // ── Auto-instrumentation libraries ──
+
+    /// <summary>
+    /// Gets or sets a value indicating whether ASP.NET Core incoming request
+    /// instrumentation is enabled. Default: <c>true</c>.
+    /// </summary>
+    public bool EnableAspNetCoreInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether <see cref="System.Net.Http.HttpClient"/>
+    /// outgoing request instrumentation is enabled. Default: <c>true</c>.
+    /// </summary>
+    public bool EnableHttpClientInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether SQL Client database call
+    /// instrumentation is enabled. Default: <c>true</c>.
+    /// </summary>
+    public bool EnableSqlClientInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Azure SDK client library
+    /// instrumentation is enabled. Default: <c>true</c>.
+    /// </summary>
+    public bool EnableAzureSdkInstrumentation { get; set; } = true;
+
+    // ── GenAI / Agent instrumentation libraries ──
+
+    /// <summary>
+    /// Gets or sets a value indicating whether OpenAI and Azure OpenAI SDK
+    /// instrumentation is enabled (<c>Azure.AI.OpenAI*</c>, <c>OpenAI.*</c>,
+    /// <c>Experimental.Microsoft.Extensions.AI</c>). Default: <c>true</c>.
+    /// </summary>
+    public bool EnableOpenAIInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Semantic Kernel orchestrator
+    /// instrumentation is enabled (<c>Microsoft.SemanticKernel*</c>). Default: <c>true</c>.
+    /// </summary>
+    public bool EnableSemanticKernelInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Microsoft Agent Framework
+    /// instrumentation is enabled (<c>Experimental.Microsoft.Agents.AI*</c>). Default: <c>true</c>.
+    /// </summary>
+    public bool EnableAgentFrameworkInstrumentation { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Agent365 SDK scope and baggage
+    /// instrumentation is enabled (<c>Agent365Sdk</c> source). Default: <c>true</c>.
+    /// </summary>
+    public bool EnableAgent365Instrumentation { get; set; } = true;
+}

--- a/src/Microsoft.OpenTelemetry/InstrumentationOptions.cs
+++ b/src/Microsoft.OpenTelemetry/InstrumentationOptions.cs
@@ -25,10 +25,12 @@ public class InstrumentationOptions
     public bool EnableMetrics { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the logging pipeline is enabled
-    /// for OTLP and Console exporters. When <c>false</c>, log exporters are not
-    /// registered for these targets. Does not affect Azure Monitor logging, which
-    /// is controlled by the Azure Monitor Exporter package. Default: <c>true</c>.
+    /// Gets or sets a value indicating whether OpenTelemetry log export is enabled.
+    /// When <c>false</c>, a provider-scoped <see cref="Microsoft.Extensions.Logging.LogLevel.None"/>
+    /// filter is added to <c>OpenTelemetryLoggerProvider</c>, suppressing all log records
+    /// from reaching any OpenTelemetry exporter (Azure Monitor, OTLP, Console).
+    /// Other logging providers (console logger, file logger, etc.) are not affected.
+    /// Default: <c>true</c>.
     /// </summary>
     public bool EnableLogging { get; set; } = true;
 

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using global::OpenTelemetry;
 using global::OpenTelemetry.Trace;
 using global::OpenTelemetry.Metrics;
@@ -175,6 +176,18 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             {
                 builder.WithLogging(logging => logging.AddConsoleExporter());
             }
+        }
+
+        // --- Logging kill switch ---
+        // When EnableLogging is false, suppress all log records from reaching
+        // OpenTelemetryLoggerProvider (affects Azure Monitor, OTLP, Console, etc.).
+        // This is a provider-scoped ILogger filter — other loggers are not affected.
+        if (!options.Instrumentation.EnableLogging)
+        {
+            builder.Services.AddLogging(logging =>
+            {
+                logging.AddFilter<OpenTelemetryLoggerProvider>(null, LogLevel.None);
+            });
         }
 
         return builder;

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -99,6 +99,35 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             
         }
 
+        // Determine which signals have at least one exporter destination.
+        // Agent365 only exports traces — metrics and logs sent to it would go nowhere.
+        var hasTracingExporter = exporters != ExportTarget.None; // all exporters support traces
+        var hasMetricsExporter = exporters.HasFlag(ExportTarget.AzureMonitor)
+                              || exporters.HasFlag(ExportTarget.Otlp)
+                              || exporters.HasFlag(ExportTarget.Console);
+        var hasLoggingExporter = hasMetricsExporter; // same set supports logs
+
+        // Effective signal flags: user intent AND exporter availability
+        var effectiveTracing = options.Instrumentation.EnableTracing && hasTracingExporter;
+        var effectiveMetrics = options.Instrumentation.EnableMetrics && hasMetricsExporter;
+        var effectiveLogging = options.Instrumentation.EnableLogging && hasLoggingExporter;
+
+        // Build an effective InstrumentationOptions that subsystems will use
+        var effectiveInstrumentation = new InstrumentationOptions
+        {
+            EnableTracing = effectiveTracing,
+            EnableMetrics = effectiveMetrics,
+            EnableLogging = effectiveLogging,
+            EnableAspNetCoreInstrumentation = options.Instrumentation.EnableAspNetCoreInstrumentation,
+            EnableHttpClientInstrumentation = options.Instrumentation.EnableHttpClientInstrumentation,
+            EnableSqlClientInstrumentation = options.Instrumentation.EnableSqlClientInstrumentation,
+            EnableAzureSdkInstrumentation = options.Instrumentation.EnableAzureSdkInstrumentation,
+            EnableOpenAIInstrumentation = options.Instrumentation.EnableOpenAIInstrumentation,
+            EnableSemanticKernelInstrumentation = options.Instrumentation.EnableSemanticKernelInstrumentation,
+            EnableAgentFrameworkInstrumentation = options.Instrumentation.EnableAgentFrameworkInstrumentation,
+            EnableAgent365Instrumentation = options.Instrumentation.EnableAgent365Instrumentation,
+        };
+
         // --- Azure Monitor (always: instrumentation; exporter gated by Exporters flag) ---
         builder.UseAzureMonitor(o =>
         {
@@ -113,7 +142,7 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             o.EnableTraceBasedLogsSampler = options.AzureMonitor.EnableTraceBasedLogsSampler;
             o.SamplingRatio = options.AzureMonitor.SamplingRatio;
             o.TracesPerSecond = options.AzureMonitor.TracesPerSecond;
-        }, options.Instrumentation);
+        }, effectiveInstrumentation);
 
         // --- Agent365 (always: scopes + baggage + span processors; exporter gated by Exporters flag) ---
         builder.UseAgent365(o =>
@@ -126,15 +155,15 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             o.Exporter.ScheduledDelayMilliseconds = options.Agent365.Exporter.ScheduledDelayMilliseconds;
             o.Exporter.ExporterTimeoutMilliseconds = options.Agent365.Exporter.ExporterTimeoutMilliseconds;
             o.Exporter.MaxExportBatchSize = options.Agent365.Exporter.MaxExportBatchSize;
-        }, options.Instrumentation);
+        }, effectiveInstrumentation);
 
         // --- Microsoft Agent Framework (always: captures MAF spans + processor) ---
-        builder.UseAgentFramework(options.Instrumentation);
+        builder.UseAgentFramework(effectiveInstrumentation);
 
         // --- OTLP exporter ---
         if (exporters.HasFlag(ExportTarget.Otlp))
         {
-            if (options.Instrumentation.EnableTracing)
+            if (effectiveInstrumentation.EnableTracing)
             {
                 builder.WithTracing(tracing =>
                 {
@@ -142,7 +171,7 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
                 });
             }
 
-            if (options.Instrumentation.EnableMetrics)
+            if (effectiveInstrumentation.EnableMetrics)
             {
                 builder.WithMetrics(metrics =>
                 {
@@ -150,7 +179,7 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
                 });
             }
 
-            if (options.Instrumentation.EnableLogging)
+            if (effectiveInstrumentation.EnableLogging)
             {
                 builder.WithLogging(logging =>
                 {
@@ -162,27 +191,27 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
         // --- Console exporter ---
         if (exporters.HasFlag(ExportTarget.Console))
         {
-            if (options.Instrumentation.EnableTracing)
+            if (effectiveInstrumentation.EnableTracing)
             {
                 builder.WithTracing(tracing => tracing.AddConsoleExporter());
             }
 
-            if (options.Instrumentation.EnableMetrics)
+            if (effectiveInstrumentation.EnableMetrics)
             {
                 builder.WithMetrics(metrics => metrics.AddConsoleExporter());
             }
 
-            if (options.Instrumentation.EnableLogging)
+            if (effectiveInstrumentation.EnableLogging)
             {
                 builder.WithLogging(logging => logging.AddConsoleExporter());
             }
         }
 
         // --- Logging kill switch ---
-        // When EnableLogging is false, suppress all log records from reaching
+        // When effective logging is disabled, suppress all log records from reaching
         // OpenTelemetryLoggerProvider (affects Azure Monitor, OTLP, Console, etc.).
         // This is a provider-scoped ILogger filter — other loggers are not affected.
-        if (!options.Instrumentation.EnableLogging)
+        if (!effectiveInstrumentation.EnableLogging)
         {
             builder.Services.AddLogging(logging =>
             {

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -81,6 +81,15 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
         this IOpenTelemetryBuilder builder,
         Action<MicrosoftOpenTelemetryOptions> configure)
     {
+        // Guard against duplicate calls
+        if (builder.Services.Any(s => s.ImplementationInstance is UseMicrosoftOpenTelemetryRegistration))
+        {
+            throw new NotSupportedException(
+                "Multiple calls to UseMicrosoftOpenTelemetry on the same IServiceCollection are not supported.");
+        }
+
+        builder.Services.AddSingleton(UseMicrosoftOpenTelemetryRegistration.Instance);
+
         var options = new MicrosoftOpenTelemetryOptions();
         configure(options);
 

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using global::OpenTelemetry;
 using global::OpenTelemetry.Trace;
 using global::OpenTelemetry.Metrics;
+using global::OpenTelemetry.Logs;
 
 namespace Microsoft.OpenTelemetry;
 
@@ -111,7 +112,7 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             o.EnableTraceBasedLogsSampler = options.AzureMonitor.EnableTraceBasedLogsSampler;
             o.SamplingRatio = options.AzureMonitor.SamplingRatio;
             o.TracesPerSecond = options.AzureMonitor.TracesPerSecond;
-        });
+        }, options.Instrumentation);
 
         // --- Agent365 (always: scopes + baggage + span processors; exporter gated by Exporters flag) ---
         builder.UseAgent365(o =>
@@ -124,30 +125,56 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             o.Exporter.ScheduledDelayMilliseconds = options.Agent365.Exporter.ScheduledDelayMilliseconds;
             o.Exporter.ExporterTimeoutMilliseconds = options.Agent365.Exporter.ExporterTimeoutMilliseconds;
             o.Exporter.MaxExportBatchSize = options.Agent365.Exporter.MaxExportBatchSize;
-        });
+        }, options.Instrumentation);
 
         // --- Microsoft Agent Framework (always: captures MAF spans + processor) ---
-        builder.UseAgentFramework();
+        builder.UseAgentFramework(options.Instrumentation);
 
         // --- OTLP exporter ---
         if (exporters.HasFlag(ExportTarget.Otlp))
         {
-            builder.WithTracing(tracing =>
+            if (options.Instrumentation.EnableTracing)
             {
-                tracing.AddOtlpExporter();
-            });
+                builder.WithTracing(tracing =>
+                {
+                    tracing.AddOtlpExporter();
+                });
+            }
 
-            builder.WithMetrics(metrics =>
+            if (options.Instrumentation.EnableMetrics)
             {
-                metrics.AddOtlpExporter();
-            });
+                builder.WithMetrics(metrics =>
+                {
+                    metrics.AddOtlpExporter();
+                });
+            }
+
+            if (options.Instrumentation.EnableLogging)
+            {
+                builder.WithLogging(logging =>
+                {
+                    logging.AddOtlpExporter();
+                });
+            }
         }
 
         // --- Console exporter ---
         if (exporters.HasFlag(ExportTarget.Console))
         {
-            builder.WithTracing(tracing => tracing.AddConsoleExporter());
-            builder.WithMetrics(metrics => metrics.AddConsoleExporter());
+            if (options.Instrumentation.EnableTracing)
+            {
+                builder.WithTracing(tracing => tracing.AddConsoleExporter());
+            }
+
+            if (options.Instrumentation.EnableMetrics)
+            {
+                builder.WithMetrics(metrics => metrics.AddConsoleExporter());
+            }
+
+            if (options.Instrumentation.EnableLogging)
+            {
+                builder.WithLogging(logging => logging.AddConsoleExporter());
+            }
         }
 
         return builder;

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryOptions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryOptions.cs
@@ -43,4 +43,10 @@ public class MicrosoftOpenTelemetryOptions
     /// Only exporter is gated by <see cref="Exporters"/>; instrumentation (scopes, baggage) is always active.
     /// </summary>
     public Agent365Options Agent365 { get; } = new();
+
+    /// <summary>
+    /// Gets the instrumentation configuration that controls which telemetry signals
+    /// and auto-instrumentation libraries are active.
+    /// </summary>
+    public InstrumentationOptions Instrumentation { get; } = new();
 }

--- a/src/Microsoft.OpenTelemetry/UseMicrosoftOpenTelemetryRegistration.cs
+++ b/src/Microsoft.OpenTelemetry/UseMicrosoftOpenTelemetryRegistration.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.OpenTelemetry;
+
+/// <summary>
+/// Marker class registered as a singleton to detect duplicate calls to
+/// <see cref="MicrosoftOpenTelemetryBuilderExtensions.UseMicrosoftOpenTelemetry"/>.
+/// </summary>
+internal sealed class UseMicrosoftOpenTelemetryRegistration
+{
+    public static readonly UseMicrosoftOpenTelemetryRegistration Instance = new();
+
+    private UseMicrosoftOpenTelemetryRegistration()
+    {
+    }
+}

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
@@ -295,7 +295,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
             services.AddOpenTelemetry()
                 .UseMicrosoftOpenTelemetry(o =>
                 {
-                    // Defaults — tracing enabled, Agent Framework enabled
+                    o.Exporters = ExportTarget.Console;
                 })
                 .WithTracing(t => t.AddInMemoryExporter(exportedActivities));
 
@@ -355,6 +355,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                             services.AddOpenTelemetry()
                                 .UseMicrosoftOpenTelemetry(o =>
                                 {
+                                    o.Exporters = ExportTarget.Console;
                                     o.Instrumentation.EnableAspNetCoreInstrumentation = false;
                                 })
                                 .WithTracing(t => t.AddInMemoryExporter(exportedActivities));
@@ -431,7 +432,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
             services.AddOpenTelemetry()
                 .UseMicrosoftOpenTelemetry(o =>
                 {
-                    // defaults — metrics enabled
+                    o.Exporters = ExportTarget.Console;
                 });
 
             // Verify AspNetCore and Http meters are configured via service registrations
@@ -480,6 +481,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
             services.AddOpenTelemetry()
                 .UseMicrosoftOpenTelemetry(o =>
                 {
+                    o.Exporters = ExportTarget.Console;
                     // defaults — MAF enabled
                 })
                 .WithTracing(t => t.AddInMemoryExporter(exportedActivities));

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
@@ -15,9 +15,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Logs;
 using Xunit;
 
 namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
@@ -688,6 +690,125 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
             Assert.True(servicesEnabled.Count > servicesDisabled.Count,
                 $"Expected more services when logging enabled ({servicesEnabled.Count}) " +
                 $"than disabled ({servicesDisabled.Count})");
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  11. E2E: EnableLogging kill switch suppresses log records
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void EnableLoggingFalse_NoLogRecordsExported()
+        {
+            var exportedLogs = new List<LogRecord>();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Instrumentation.EnableLogging = false;
+                    o.Exporters = ExportTarget.Console;
+                })
+                .WithLogging(logging => logging.AddInMemoryExporter(exportedLogs));
+
+            using var sp = services.BuildServiceProvider();
+
+            // Emit a log via ILogger
+            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("TestCategory");
+            logger.LogInformation("This log should be suppressed");
+            logger.LogError("This error should also be suppressed");
+            logger.LogWarning("This warning too");
+
+            // Force flush the log provider
+            var loggerProvider = sp.GetRequiredService<LoggerProvider>();
+            loggerProvider.ForceFlush();
+
+            Assert.Empty(exportedLogs);
+        }
+
+        [Fact]
+        public void EnableLoggingTrue_LogRecordsExported()
+        {
+            var exportedLogs = new List<LogRecord>();
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Instrumentation.EnableLogging = true;
+                    o.Exporters = ExportTarget.Console;
+                })
+                .WithLogging(logging => logging.AddInMemoryExporter(exportedLogs));
+
+            using var sp = services.BuildServiceProvider();
+
+            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("TestCategory");
+            logger.LogInformation("This log should be captured");
+
+            var loggerProvider = sp.GetRequiredService<LoggerProvider>();
+            loggerProvider.ForceFlush();
+
+            Assert.NotEmpty(exportedLogs);
+            Assert.Contains(exportedLogs, r => r.Body?.ToString()?.Contains("captured") == true);
+        }
+
+        [Fact]
+        public void EnableLoggingFalse_OtherLoggersNotAffected()
+        {
+            var otlpLogs = new List<LogRecord>();
+            var capturedByCustomLogger = new List<string>();
+
+            var services = new ServiceCollection();
+            services.AddLogging(logging =>
+            {
+                // Add a custom logging provider to verify it still works
+                logging.AddProvider(new TestLoggerProvider(capturedByCustomLogger));
+            });
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Instrumentation.EnableLogging = false;
+                    o.Exporters = ExportTarget.Console;
+                })
+                .WithLogging(logging => logging.AddInMemoryExporter(otlpLogs));
+
+            using var sp = services.BuildServiceProvider();
+
+            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("TestCategory");
+            logger.LogInformation("Should reach custom logger but not OTel");
+
+            var loggerProvider = sp.GetRequiredService<LoggerProvider>();
+            loggerProvider.ForceFlush();
+
+            // OTel logs suppressed
+            Assert.Empty(otlpLogs);
+            // Custom logger still received the log
+            Assert.NotEmpty(capturedByCustomLogger);
+            Assert.Contains(capturedByCustomLogger, m => m.Contains("custom logger"));
+        }
+
+        /// <summary>
+        /// Minimal ILoggerProvider for testing that non-OTel loggers are not affected.
+        /// </summary>
+        private sealed class TestLoggerProvider : ILoggerProvider
+        {
+            private readonly List<string> _messages;
+            public TestLoggerProvider(List<string> messages) => _messages = messages;
+            public ILogger CreateLogger(string categoryName) => new TestLogger(_messages);
+            public void Dispose() { }
+
+            private sealed class TestLogger : ILogger
+            {
+                private readonly List<string> _messages;
+                public TestLogger(List<string> messages) => _messages = messages;
+                public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+                public bool IsEnabled(LogLevel logLevel) => true;
+                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+                {
+                    _messages.Add(formatter(state, exception));
+                }
+            }
         }
     }
 }

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
@@ -1,0 +1,695 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if NET
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
+using Xunit;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
+{
+    public class InstrumentationOptionsTests : IDisposable
+    {
+        private IHost? _host;
+
+        public void Dispose()
+        {
+            _host?.Dispose();
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  1. POCO defaults & round-trips
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void Defaults_AllSignalsEnabled()
+        {
+            var options = new InstrumentationOptions();
+
+            Assert.True(options.EnableTracing);
+            Assert.True(options.EnableMetrics);
+            Assert.True(options.EnableLogging);
+        }
+
+        [Fact]
+        public void Defaults_AllInstrumentationsEnabled()
+        {
+            var options = new InstrumentationOptions();
+
+            Assert.True(options.EnableAspNetCoreInstrumentation);
+            Assert.True(options.EnableHttpClientInstrumentation);
+            Assert.True(options.EnableSqlClientInstrumentation);
+            Assert.True(options.EnableAzureSdkInstrumentation);
+            Assert.True(options.EnableOpenAIInstrumentation);
+            Assert.True(options.EnableSemanticKernelInstrumentation);
+            Assert.True(options.EnableAgentFrameworkInstrumentation);
+            Assert.True(options.EnableAgent365Instrumentation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableTracing_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableTracing = value };
+            Assert.Equal(value, options.EnableTracing);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableMetrics_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableMetrics = value };
+            Assert.Equal(value, options.EnableMetrics);
+        }
+
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableAspNetCoreInstrumentation_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableAspNetCoreInstrumentation = value };
+            Assert.Equal(value, options.EnableAspNetCoreInstrumentation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableHttpClientInstrumentation_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableHttpClientInstrumentation = value };
+            Assert.Equal(value, options.EnableHttpClientInstrumentation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableSqlClientInstrumentation_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableSqlClientInstrumentation = value };
+            Assert.Equal(value, options.EnableSqlClientInstrumentation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableAzureSdkInstrumentation_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableAzureSdkInstrumentation = value };
+            Assert.Equal(value, options.EnableAzureSdkInstrumentation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableOpenAIInstrumentation_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableOpenAIInstrumentation = value };
+            Assert.Equal(value, options.EnableOpenAIInstrumentation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableSemanticKernelInstrumentation_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableSemanticKernelInstrumentation = value };
+            Assert.Equal(value, options.EnableSemanticKernelInstrumentation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableAgentFrameworkInstrumentation_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableAgentFrameworkInstrumentation = value };
+            Assert.Equal(value, options.EnableAgentFrameworkInstrumentation);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableAgent365Instrumentation_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableAgent365Instrumentation = value };
+            Assert.Equal(value, options.EnableAgent365Instrumentation);
+        }
+
+        [Fact]
+        public void MultipleProperties_SetIndependently()
+        {
+            var options = new InstrumentationOptions
+            {
+                EnableTracing = false,
+                EnableMetrics = true,
+                EnableLogging = false,
+                EnableAspNetCoreInstrumentation = false,
+                EnableHttpClientInstrumentation = true,
+                EnableSqlClientInstrumentation = false,
+                EnableAzureSdkInstrumentation = true,
+                EnableOpenAIInstrumentation = false,
+                EnableSemanticKernelInstrumentation = true,
+                EnableAgentFrameworkInstrumentation = false,
+                EnableAgent365Instrumentation = true,
+            };
+
+            Assert.False(options.EnableTracing);
+            Assert.True(options.EnableMetrics);
+            Assert.False(options.EnableLogging);
+            Assert.False(options.EnableAspNetCoreInstrumentation);
+            Assert.True(options.EnableHttpClientInstrumentation);
+            Assert.False(options.EnableSqlClientInstrumentation);
+            Assert.True(options.EnableAzureSdkInstrumentation);
+            Assert.False(options.EnableOpenAIInstrumentation);
+            Assert.True(options.EnableSemanticKernelInstrumentation);
+            Assert.False(options.EnableAgentFrameworkInstrumentation);
+            Assert.True(options.EnableAgent365Instrumentation);
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  2. Integration with MicrosoftOpenTelemetryOptions
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void MicrosoftOpenTelemetryOptions_ExposesInstrumentationOptions()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+
+            Assert.NotNull(options.Instrumentation);
+            Assert.IsType<InstrumentationOptions>(options.Instrumentation);
+        }
+
+        [Fact]
+        public void MicrosoftOpenTelemetryOptions_InstrumentationDefaults_AllEnabled()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+
+            Assert.True(options.Instrumentation.EnableTracing);
+            Assert.True(options.Instrumentation.EnableMetrics);
+            Assert.True(options.Instrumentation.EnableLogging);
+            Assert.True(options.Instrumentation.EnableAspNetCoreInstrumentation);
+            Assert.True(options.Instrumentation.EnableHttpClientInstrumentation);
+            Assert.True(options.Instrumentation.EnableSqlClientInstrumentation);
+            Assert.True(options.Instrumentation.EnableAzureSdkInstrumentation);
+            Assert.True(options.Instrumentation.EnableOpenAIInstrumentation);
+            Assert.True(options.Instrumentation.EnableSemanticKernelInstrumentation);
+            Assert.True(options.Instrumentation.EnableAgentFrameworkInstrumentation);
+            Assert.True(options.Instrumentation.EnableAgent365Instrumentation);
+        }
+
+        [Fact]
+        public void MicrosoftOpenTelemetryOptions_InstrumentationIsReadOnly()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+            var first = options.Instrumentation;
+            var second = options.Instrumentation;
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void MicrosoftOpenTelemetryOptions_InstrumentationMutationsStick()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.Instrumentation.EnableSqlClientInstrumentation = false;
+            options.Instrumentation.EnableTracing = false;
+
+            Assert.False(options.Instrumentation.EnableSqlClientInstrumentation);
+            Assert.False(options.Instrumentation.EnableTracing);
+            Assert.True(options.Instrumentation.EnableMetrics);
+            Assert.True(options.Instrumentation.EnableAspNetCoreInstrumentation);
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  3. Behavioral: EnableTracing gates the tracing pipeline
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public async Task EnableTracingFalse_NoAspNetCoreSpansCaptured()
+        {
+            var exportedActivities = new List<Activity>();
+
+            _host = new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder.UseTestServer();
+                    webBuilder.ConfigureServices(services =>
+                    {
+                        services.AddRouting();
+                        services.AddOpenTelemetry()
+                            .UseMicrosoftOpenTelemetry(o =>
+                            {
+                                o.Instrumentation.EnableTracing = false;
+                            })
+                            .WithTracing(t => t.AddInMemoryExporter(exportedActivities));
+                    });
+                    webBuilder.Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.MapGet("/test", async context =>
+                            {
+                                await context.Response.WriteAsync("ok");
+                            });
+                        });
+                    });
+                })
+                .Build();
+
+            await _host.StartAsync();
+
+            var client = _host.GetTestClient();
+            await client.GetAsync("/test");
+
+            // Force flush would normally export, but tracing pipeline was disabled
+            // so nothing from our instrumentation was registered
+            var aspnetSpans = exportedActivities.Where(a =>
+                a.Source.Name == "OpenTelemetry.Instrumentation.AspNetCore").ToList();
+            Assert.Empty(aspnetSpans);
+        }
+
+        [Fact]
+        public void EnableTracingTrue_SpansCaptured()
+        {
+            var exportedActivities = new List<Activity>();
+
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    // Defaults — tracing enabled, Agent Framework enabled
+                })
+                .WithTracing(t => t.AddInMemoryExporter(exportedActivities));
+
+            using var sp = services.BuildServiceProvider();
+            var tracerProvider = sp.GetRequiredService<TracerProvider>();
+
+            // Emit a span from Agent Framework source (registered by our code)
+            using var source = new ActivitySource("Experimental.Microsoft.Agents.AI");
+            using var activity = source.StartActivity("test-op");
+            activity?.Stop();
+
+            tracerProvider.ForceFlush();
+
+            Assert.Contains(exportedActivities, a =>
+                a.Source.Name == "Experimental.Microsoft.Agents.AI");
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  4. Behavioral: DisableAspNetCore but keep HttpClient
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public async Task DisableAspNetCore_HttpClientStillWorks()
+        {
+            var exportedActivities = new List<Activity>();
+
+            // Start a dummy HTTP server
+            var tcpListener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            tcpListener.Start();
+            var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+            tcpListener.Stop();
+
+            var httpListener = new HttpListener();
+            httpListener.Prefixes.Add($"http://localhost:{port}/");
+            httpListener.Start();
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    var ctx = await httpListener.GetContextAsync();
+                    ctx.Response.StatusCode = 200;
+                    ctx.Response.Close();
+                }
+                catch { }
+            });
+
+            try
+            {
+                _host = new HostBuilder()
+                    .ConfigureWebHost(webBuilder =>
+                    {
+                        webBuilder.UseTestServer();
+                        webBuilder.ConfigureServices(services =>
+                        {
+                            services.AddRouting();
+                            services.AddOpenTelemetry()
+                                .UseMicrosoftOpenTelemetry(o =>
+                                {
+                                    o.Instrumentation.EnableAspNetCoreInstrumentation = false;
+                                })
+                                .WithTracing(t => t.AddInMemoryExporter(exportedActivities));
+                        });
+                        webBuilder.Configure(app =>
+                        {
+                            app.UseRouting();
+                            app.UseEndpoints(endpoints =>
+                            {
+                                endpoints.MapGet("/test", async context =>
+                                {
+                                    // This outgoing HttpClient call should be instrumented
+                                    using var httpClient = new HttpClient();
+                                    await httpClient.GetAsync($"http://localhost:{port}/");
+                                    await context.Response.WriteAsync("ok");
+                                });
+                            });
+                        });
+                    })
+                    .Build();
+
+                await _host.StartAsync();
+
+                var testClient = _host.GetTestClient();
+                await testClient.GetAsync("/test");
+                await Task.Delay(500);
+
+                // Should have HttpClient spans but NOT ASP.NET Core spans
+                var aspnetSpans = exportedActivities.Where(a =>
+                    a.Source.Name == "OpenTelemetry.Instrumentation.AspNetCore").ToList();
+                var httpSpans = exportedActivities.Where(a =>
+                    a.Source.Name == "System.Net.Http").ToList();
+
+                Assert.Empty(aspnetSpans);
+                Assert.NotEmpty(httpSpans);
+            }
+            finally
+            {
+                httpListener.Stop();
+            }
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  5. Behavioral: EnableMetrics=false suppresses metrics
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void EnableMetricsFalse_NoAspNetCoreMeters()
+        {
+            var exportedMetrics = new List<Metric>();
+
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Instrumentation.EnableMetrics = false;
+                })
+                .WithMetrics(m => m.AddInMemoryExporter(exportedMetrics));
+
+            using var sp = services.BuildServiceProvider();
+            var meterProvider = sp.GetRequiredService<MeterProvider>();
+            meterProvider.ForceFlush();
+
+            // No ASP.NET Core hosting or System.Net.Http meters registered by our code
+            Assert.DoesNotContain(exportedMetrics, m =>
+                m.MeterName == "Microsoft.AspNetCore.Hosting" ||
+                m.MeterName == "System.Net.Http");
+        }
+
+        [Fact]
+        public void EnableMetricsTrue_AspNetCoreMetersRegistered()
+        {
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    // defaults — metrics enabled
+                });
+
+            // Verify AspNetCore and Http meters are configured via service registrations
+            // (actual metric data requires a running server, so we verify registration)
+            using var sp = services.BuildServiceProvider();
+            // MeterProvider should resolve without error
+            var meterProvider = sp.GetRequiredService<MeterProvider>();
+            Assert.NotNull(meterProvider);
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  6. Behavioral: DisableAgentFramework — no MAF sources
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void DisableAgentFramework_NoMafSourcesRegistered()
+        {
+            var exportedActivities = new List<Activity>();
+
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Instrumentation.EnableAgentFrameworkInstrumentation = false;
+                })
+                .WithTracing(t => t.AddInMemoryExporter(exportedActivities));
+
+            using var sp = services.BuildServiceProvider();
+            var tracerProvider = sp.GetRequiredService<TracerProvider>();
+
+            // Emit a span from Agent Framework source — should NOT be captured
+            using var source = new ActivitySource("Experimental.Microsoft.Agents.AI");
+            using var activity = source.StartActivity("test-agent-op");
+            activity?.Stop();
+
+            Assert.DoesNotContain(exportedActivities, a =>
+                a.Source.Name == "Experimental.Microsoft.Agents.AI");
+        }
+
+        [Fact]
+        public void EnableAgentFramework_MafSourcesCaptured()
+        {
+            var exportedActivities = new List<Activity>();
+
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    // defaults — MAF enabled
+                })
+                .WithTracing(t => t.AddInMemoryExporter(exportedActivities));
+
+            using var sp = services.BuildServiceProvider();
+            var tracerProvider = sp.GetRequiredService<TracerProvider>();
+
+            using var source = new ActivitySource("Experimental.Microsoft.Agents.AI");
+            using var activity = source.StartActivity("test-agent-op");
+            activity?.Stop();
+
+            tracerProvider.ForceFlush();
+
+            Assert.Contains(exportedActivities, a =>
+                a.Source.Name == "Experimental.Microsoft.Agents.AI");
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  7. Behavioral: Console exporter respects signal flags
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void ConsoleExporter_TracingDisabled_NoSpansCaptured()
+        {
+            var exportedActivities = new List<Activity>();
+
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Console;
+                    o.Instrumentation.EnableTracing = false;
+                })
+                .WithTracing(t => t.AddInMemoryExporter(exportedActivities));
+
+            using var sp = services.BuildServiceProvider();
+            var tracerProvider = sp.GetRequiredService<TracerProvider>();
+
+            // Emit a span from a source that would normally be captured
+            using var source = new ActivitySource("Experimental.Microsoft.Agents.AI");
+            using var activity = source.StartActivity("test-op");
+            activity?.Stop();
+
+            tracerProvider.ForceFlush();
+
+            // No Agent Framework spans because tracing was disabled by our code
+            Assert.DoesNotContain(exportedActivities, a =>
+                a.Source.Name == "Experimental.Microsoft.Agents.AI");
+        }
+
+        [Fact]
+        public void ConsoleExporter_TracingEnabled_SpansCaptured()
+        {
+            var exportedActivities = new List<Activity>();
+
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Console;
+                    o.Instrumentation.EnableTracing = true;
+                })
+                .WithTracing(t => t.AddInMemoryExporter(exportedActivities));
+
+            using var sp = services.BuildServiceProvider();
+            var tracerProvider = sp.GetRequiredService<TracerProvider>();
+
+            using var source = new ActivitySource("Experimental.Microsoft.Agents.AI");
+            using var activity = source.StartActivity("test-op");
+            activity?.Stop();
+
+            tracerProvider.ForceFlush();
+
+            Assert.Contains(exportedActivities, a =>
+                a.Source.Name == "Experimental.Microsoft.Agents.AI");
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  8. Behavioral: OTLP exporter respects signal flags
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void OtlpExporter_MetricsDisabled_NoCustomMeters()
+        {
+            var exportedMetrics = new List<Metric>();
+
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Otlp;
+                    o.Instrumentation.EnableMetrics = false;
+                })
+                .WithMetrics(m => m.AddInMemoryExporter(exportedMetrics));
+
+            using var sp = services.BuildServiceProvider();
+            var meterProvider = sp.GetRequiredService<MeterProvider>();
+            meterProvider.ForceFlush();
+
+            // No ASP.NET Core or Agent Framework meters from our code
+            Assert.DoesNotContain(exportedMetrics, m =>
+                m.MeterName == "Microsoft.AspNetCore.Hosting" ||
+                m.MeterName == "Experimental.Microsoft.Agents.AI");
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  9. Behavioral: OTLP logging exporter respects EnableLogging
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void OtlpExporter_LoggingEnabled_LogProviderRegistered()
+        {
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Otlp;
+                    o.Instrumentation.EnableLogging = true;
+                });
+
+            // WithLogging() + AddOtlpExporter() registers log processing configuration
+            var hasOtlpLogConfig = services.Any(s =>
+                s.ServiceType.FullName != null &&
+                s.ServiceType.FullName.Contains("IConfigureOptions") &&
+                s.ImplementationType?.FullName?.Contains("Otlp") == true);
+
+            // Alternative: verify LoggerProviderBuilder configuration was added
+            var hasLogBuilderConfig = services.Any(s =>
+                s.ServiceType.FullName != null &&
+                s.ServiceType.FullName.Contains("LoggerProviderBuilder"));
+
+            Assert.True(hasOtlpLogConfig || hasLogBuilderConfig,
+                "OTLP logging exporter should be registered when EnableLogging=true");
+        }
+
+        [Fact]
+        public void OtlpExporter_LoggingDisabled_FewerServicesThanEnabled()
+        {
+            var servicesEnabled = new ServiceCollection();
+            servicesEnabled.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Otlp;
+                    o.Instrumentation.EnableLogging = true;
+                });
+
+            var servicesDisabled = new ServiceCollection();
+            servicesDisabled.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Otlp;
+                    o.Instrumentation.EnableLogging = false;
+                });
+
+            // When logging is enabled, WithLogging() + AddOtlpExporter() adds
+            // more service registrations than when logging is disabled
+            Assert.True(servicesEnabled.Count > servicesDisabled.Count,
+                $"Expected more services when logging enabled ({servicesEnabled.Count}) " +
+                $"than disabled ({servicesDisabled.Count})");
+        }
+
+        // ══════════════════════════════════════════════════════════════
+        //  10. Behavioral: Console logging exporter respects EnableLogging
+        // ══════════════════════════════════════════════════════════════
+
+        [Fact]
+        public void ConsoleExporter_LoggingEnabled_LogProviderRegistered()
+        {
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Console;
+                    o.Instrumentation.EnableLogging = true;
+                });
+
+            var hasConsoleLogConfig = services.Any(s =>
+                s.ImplementationType?.FullName?.Contains("Console") == true &&
+                s.ImplementationType?.FullName?.Contains("Log") == true);
+
+            var hasLogBuilderConfig = services.Any(s =>
+                s.ServiceType.FullName != null &&
+                s.ServiceType.FullName.Contains("LoggerProviderBuilder"));
+
+            Assert.True(hasConsoleLogConfig || hasLogBuilderConfig,
+                "Console logging exporter should be registered when EnableLogging=true");
+        }
+
+        [Fact]
+        public void ConsoleExporter_LoggingDisabled_FewerServicesThanEnabled()
+        {
+            var servicesEnabled = new ServiceCollection();
+            servicesEnabled.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Console;
+                    o.Instrumentation.EnableLogging = true;
+                });
+
+            var servicesDisabled = new ServiceCollection();
+            servicesDisabled.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Console;
+                    o.Instrumentation.EnableLogging = false;
+                });
+
+            Assert.True(servicesEnabled.Count > servicesDisabled.Count,
+                $"Expected more services when logging enabled ({servicesEnabled.Count}) " +
+                $"than disabled ({servicesDisabled.Count})");
+        }
+    }
+}
+
+#endif

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
@@ -80,6 +80,16 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
             Assert.Equal(value, options.EnableMetrics);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void EnableLogging_RoundTrips(bool value)
+        {
+            var options = new InstrumentationOptions { EnableLogging = value };
+            Assert.Equal(value, options.EnableLogging);
+        }
+
+        // ── Library toggles ──
 
         [Theory]
         [InlineData(true)]


### PR DESCRIPTION
## Summary

Adds `InstrumentationOptions` to `MicrosoftOpenTelemetryOptions`, enabling users to selectively enable/disable telemetry signals and auto-instrumentations. All options default to `true` (opt-out model), consistent with Application Insights `ApplicationInsightsServiceOptions` patterns.

## Usage

```csharp
builder.UseMicrosoftOpenTelemetry(o =>
{
    o.Instrumentation.EnableSqlClientInstrumentation = false;
    o.Instrumentation.EnableMetrics = false;
});
```

## Properties

### Signal-level controls
| Property | What it gates | Default |
|----------|--------------|---------|
| `EnableTracing` | Entire `TracerProvider` pipeline | `true` |
| `EnableMetrics` | Entire `MeterProvider` pipeline | `true` |
| `EnableLogging` | OTel log export — skips `WithLogging()` for OTLP/Console, and adds `LogLevel.None` ILogger filter to suppress Azure Monitor logs | `true` |

### Library-level controls
| Property | What it gates | Default |
|----------|--------------|---------|
| `EnableAspNetCoreInstrumentation` | ASP.NET Core request tracing + `Microsoft.AspNetCore.Hosting` meter | `true` |
| `EnableHttpClientInstrumentation` | HttpClient outgoing request tracing + `System.Net.Http` meter | `true` |
| `EnableSqlClientInstrumentation` | SQL Client database call tracing | `true` |
| `EnableAzureSdkInstrumentation` | Azure SDK `Azure.*` activity sources | `true` |
| `EnableOpenAIInstrumentation` | `Azure.AI.OpenAI*`, `OpenAI.*`, `Experimental.Microsoft.Extensions.AI` | `true` |
| `EnableSemanticKernelInstrumentation` | `Microsoft.SemanticKernel*` + `SemanticKernelSpanProcessor` | `true` |
| `EnableAgentFrameworkInstrumentation` | `Experimental.Microsoft.Agents.AI*` + `AgentFrameworkSpanProcessor` + meters | `true` |
| `EnableAgent365Instrumentation` | `Agent365Sdk` source + `ActivityProcessor` (baggage) | `true` |

## Key behaviors

### Smart signal auto-suppression
User intent (`InstrumentationOptions`) is intersected with exporter capability to compute `effectiveInstrumentation`. Agent365 only exports traces, so when it is the sole exporter, metrics and logging are automatically suppressed — no wasted meters or orphan log pipelines.

| Exporter | Traces | Metrics | Logs |
|----------|--------|---------|------|
| Azure Monitor | Yes | Yes | Yes |
| OTLP | Yes | Yes | Yes |
| Console | Yes | Yes | Yes |
| Agent365 | Yes | No | No |

### Logging kill switch
When `EnableLogging = false` (or auto-suppressed):
1. OTLP and Console: `WithLogging()` + exporter registration skipped entirely
2. Azure Monitor: a provider-scoped `LogLevel.None` filter is added to `OpenTelemetryLoggerProvider`, suppressing all log records before they reach the OTel pipeline. Other logging providers (console, file, etc.) are not affected.

### Independent metrics gating
ASP.NET Core and HttpClient metrics are gated independently by `EnableAspNetCoreInstrumentation` and `EnableHttpClientInstrumentation` respectively. Previously bundled in `AddHttpClientAndServerMetrics()` — now removed.

### Duplicate call guard
`UseMicrosoftOpenTelemetry` registers a singleton marker (`UseMicrosoftOpenTelemetryRegistration`) and throws `NotSupportedException` on duplicate calls, matching the Azure Monitor Exporter pattern. Fails at configuration time, not runtime.

## Additional fixes
- **Remove duplicate Agent Framework source registration** — was registered in both `UseAgent365` and `UseAgentFramework`; now only in `UseAgentFramework`
- **Add logging export for OTLP and Console** — `WithLogging()` + exporter registration now included for OTLP and Console paths, gated by `EnableLogging`
- **Split bundled metrics** — ASP.NET Core and HttpClient meters gated independently (removed `AddHttpClientAndServerMetrics()` helper)

## Test coverage
- 46 new tests across POCO, integration, and behavioral E2E categories
- Behavioral tests verify actual telemetry pipeline gating via `InMemoryExporter`:
  - `EnableTracing=false` → no ASP.NET Core spans captured
  - `EnableAspNetCoreInstrumentation=false` + `EnableHttpClientInstrumentation=true` → only HttpClient spans
  - `EnableAgentFrameworkInstrumentation=false` → Agent Framework `ActivitySource` spans not exported
  - `EnableMetrics=false` → no custom meters registered
  - `EnableLogging=false` → zero `LogRecord`s exported, non-OTel loggers unaffected
  - `EnableLogging=true` → `LogRecord`s captured with correct body
- All 519 tests pass on both net8.0 and net10.0
