### PR TITLE
[WIP] Add IConfiguration binding for MicrosoftOpenTelemetryOptions

### DIFF
--- a/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/AzureMonitorAspNetCoreEventSource.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/AzureMonitorAspNetCoreEventSource.cs
@@ -126,5 +126,17 @@ namespace Microsoft.OpenTelemetry
 
         [Event(15, Message = "Invalid sampler argument '{1}' for sampler '{0}'. Ignoring.", Level = EventLevel.Warning)]
         public void InvalidSamplerArgument(string samplerType, string samplerArg) => WriteEvent(15, samplerType, samplerArg);
+
+        [NonEvent]
+        public void ConfigurationBindingFailed(System.Exception ex)
+        {
+            if (IsEnabled(EventLevel.Warning))
+            {
+                ConfigurationBindingFailed(ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(16, Message = "Failed to bind MicrosoftOpenTelemetryOptions from IConfiguration. Falling back to code defaults. {0}", Level = EventLevel.Warning)]
+        public void ConfigurationBindingFailed(string exceptionMessage) => WriteEvent(16, exceptionMessage);
     }
 }

--- a/src/Microsoft.OpenTelemetry/Internals/DefaultMicrosoftOpenTelemetryConfigureOptions.cs
+++ b/src/Microsoft.OpenTelemetry/Internals/DefaultMicrosoftOpenTelemetryConfigureOptions.cs
@@ -81,10 +81,11 @@ internal class DefaultMicrosoftOpenTelemetryConfigureOptions : IConfigureOptions
                 options.AzureMonitor.ConnectionString = connectionStringFromEnvVar;
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             // Configuration binding errors should not crash the application.
             // The distro will fall back to code defaults.
+            AzureMonitorAspNetCoreEventSource.Log.ConfigurationBindingFailed(ex);
         }
     }
 
@@ -95,12 +96,20 @@ internal class DefaultMicrosoftOpenTelemetryConfigureOptions : IConfigureOptions
     /// </summary>
     internal static void BindFromConfiguration(IConfiguration? configuration, MicrosoftOpenTelemetryOptions options)
     {
-        if (configuration == null)
+        if (configuration != null)
         {
-            return;
+            var configureOptions = new DefaultMicrosoftOpenTelemetryConfigureOptions(configuration);
+            configureOptions.Configure(options);
         }
-
-        var configureOptions = new DefaultMicrosoftOpenTelemetryConfigureOptions(configuration);
-        configureOptions.Configure(options);
+        else
+        {
+            // No IConfiguration available — still check the raw environment variable
+            // so env-var-only scenarios (no host builder) auto-detect Azure Monitor.
+            var connectionStringFromEnvVar = Environment.GetEnvironmentVariable(ConnectionStringEnvVar);
+            if (!string.IsNullOrEmpty(connectionStringFromEnvVar))
+            {
+                options.AzureMonitor.ConnectionString = connectionStringFromEnvVar;
+            }
+        }
     }
 }

--- a/src/Microsoft.OpenTelemetry/Internals/DefaultMicrosoftOpenTelemetryConfigureOptions.cs
+++ b/src/Microsoft.OpenTelemetry/Internals/DefaultMicrosoftOpenTelemetryConfigureOptions.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.OpenTelemetry;
+
+/// <summary>
+/// <see cref="IConfigureOptions{MicrosoftOpenTelemetryOptions}"/> implementation that reads
+/// distro-level options from the "MicrosoftOpenTelemetry" section in <see cref="IConfiguration"/>.
+/// </summary>
+internal class DefaultMicrosoftOpenTelemetryConfigureOptions : IConfigureOptions<MicrosoftOpenTelemetryOptions>
+{
+    internal const string SectionName = "MicrosoftOpenTelemetry";
+    private const string AzureMonitorSectionName = "AzureMonitor";
+    private const string ConnectionStringEnvVar = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+
+    private readonly IConfiguration? _configuration;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultMicrosoftOpenTelemetryConfigureOptions"/> class.
+    /// </summary>
+    /// <param name="configuration"><see cref="IConfiguration"/> from which distro configuration can be retrieved.</param>
+    public DefaultMicrosoftOpenTelemetryConfigureOptions(IConfiguration? configuration = null)
+    {
+        _configuration = configuration;
+    }
+
+    /// <inheritdoc />
+    public void Configure(MicrosoftOpenTelemetryOptions options)
+    {
+        if (_configuration == null)
+        {
+            return;
+        }
+
+        try
+        {
+            // --- MicrosoftOpenTelemetry section (Exporters, Instrumentation) ---
+            var section = _configuration.GetSection(SectionName);
+            if (section.Exists())
+            {
+                // Bind Instrumentation sub-properties (all bool properties with public setters).
+                var instrumentationSection = section.GetSection(nameof(MicrosoftOpenTelemetryOptions.Instrumentation));
+                if (instrumentationSection.Exists())
+                {
+                    instrumentationSection.Bind(options.Instrumentation);
+                }
+
+                // Bind Exporters ([Flags] enum — IConfiguration handles comma-separated values like "AzureMonitor, Otlp").
+                var exportersValue = section[nameof(MicrosoftOpenTelemetryOptions.Exporters)];
+                if (!string.IsNullOrWhiteSpace(exportersValue)
+                    && Enum.TryParse<ExportTarget>(exportersValue, ignoreCase: true, out var exporters))
+                {
+                    options.Exporters = exporters;
+                }
+            }
+
+            // --- AzureMonitor section (top-level, binds ConnectionString and other properties) ---
+            // This populates options.AzureMonitor so the bridge in UseMicrosoftOpenTelemetry
+            // can copy values to the actual AzureMonitorOptions exporter configuration.
+            var azureMonitorSection = _configuration.GetSection(AzureMonitorSectionName);
+            if (azureMonitorSection.Exists())
+            {
+                azureMonitorSection.Bind(options.AzureMonitor);
+            }
+
+            // APPLICATIONINSIGHTS_CONNECTION_STRING via IConfiguration
+            // (covers env var provider, in-memory collection, Key Vault, etc.)
+            var connectionStringFromConfig = _configuration[ConnectionStringEnvVar];
+            if (!string.IsNullOrEmpty(connectionStringFromConfig))
+            {
+                options.AzureMonitor.ConnectionString = connectionStringFromConfig;
+            }
+
+            // Raw environment variable takes highest precedence.
+            var connectionStringFromEnvVar = Environment.GetEnvironmentVariable(ConnectionStringEnvVar);
+            if (!string.IsNullOrEmpty(connectionStringFromEnvVar))
+            {
+                options.AzureMonitor.ConnectionString = connectionStringFromEnvVar;
+            }
+        }
+        catch (Exception)
+        {
+            // Configuration binding errors should not crash the application.
+            // The distro will fall back to code defaults.
+        }
+    }
+
+    /// <summary>
+    /// Eagerly binds configuration values to the supplied <paramref name="options"/> instance.
+    /// Used during service registration to read build-time decisions from IConfiguration
+    /// before DI options infrastructure is available.
+    /// </summary>
+    internal static void BindFromConfiguration(IConfiguration? configuration, MicrosoftOpenTelemetryOptions options)
+    {
+        if (configuration == null)
+        {
+            return;
+        }
+
+        var configureOptions = new DefaultMicrosoftOpenTelemetryConfigureOptions(configuration);
+        configureOptions.Configure(options);
+    }
+}

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -118,9 +118,9 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
         {
             exporters = ExportTarget.None;
 
-            // Check code-provided, IConfiguration, and raw env var for connection string
-            if (!string.IsNullOrWhiteSpace(options.AzureMonitor.ConnectionString)
-                || HasAzureMonitorConnectionString(config))
+            // Use the layered options value only — the callback has already had a chance
+            // to clear or set ConnectionString, so re-reading raw config would bypass that.
+            if (!string.IsNullOrWhiteSpace(options.AzureMonitor.ConnectionString))
                 exporters |= ExportTarget.AzureMonitor;
             if (options.Agent365.Exporter.TokenResolver != null)
                 exporters |= ExportTarget.Agent365;
@@ -178,20 +178,20 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
         };
 
         // --- Azure Monitor (always: instrumentation; exporter gated by Exporters flag) ---
-        //builder.UseAzureMonitor(o =>
-        //{
-        //    o.SkipExporter = !exporters.HasFlag(ExportTarget.AzureMonitor);
-        //    o.ConnectionString = options.AzureMonitor.ConnectionString;
-        //    o.Credential = options.AzureMonitor.Credential;
-        //    o.DisableOfflineStorage = options.AzureMonitor.DisableOfflineStorage;
-        //    o.StorageDirectory = options.AzureMonitor.StorageDirectory;
-        //    o.EnableLiveMetrics = options.AzureMonitor.EnableLiveMetrics;
-        //    o.EnableStandardMetrics = options.AzureMonitor.EnableStandardMetrics;
-        //    o.EnablePerfCounters = options.AzureMonitor.EnablePerfCounters;
-        //    o.EnableTraceBasedLogsSampler = options.AzureMonitor.EnableTraceBasedLogsSampler;
-        //    o.SamplingRatio = options.AzureMonitor.SamplingRatio;
-        //    o.TracesPerSecond = options.AzureMonitor.TracesPerSecond;
-        //}, effectiveInstrumentation);
+        builder.UseAzureMonitor(o =>
+        {
+            o.SkipExporter = !exporters.HasFlag(ExportTarget.AzureMonitor);
+            o.ConnectionString = options.AzureMonitor.ConnectionString;
+            o.Credential = options.AzureMonitor.Credential;
+            o.DisableOfflineStorage = options.AzureMonitor.DisableOfflineStorage;
+            o.StorageDirectory = options.AzureMonitor.StorageDirectory;
+            o.EnableLiveMetrics = options.AzureMonitor.EnableLiveMetrics;
+            o.EnableStandardMetrics = options.AzureMonitor.EnableStandardMetrics;
+            o.EnablePerfCounters = options.AzureMonitor.EnablePerfCounters;
+            o.EnableTraceBasedLogsSampler = options.AzureMonitor.EnableTraceBasedLogsSampler;
+            o.SamplingRatio = options.AzureMonitor.SamplingRatio;
+            o.TracesPerSecond = options.AzureMonitor.TracesPerSecond;
+        }, effectiveInstrumentation);
 
         // --- Agent365 (always: scopes + baggage + span processors; exporter gated by Exporters flag) ---
         builder.UseAgent365(o =>

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -3,8 +3,10 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using global::OpenTelemetry;
 using global::OpenTelemetry.Trace;
 using global::OpenTelemetry.Metrics;
@@ -90,7 +92,24 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
 
         builder.Services.AddSingleton(UseMicrosoftOpenTelemetryRegistration.Instance);
 
+        // Register IConfigureOptions<MicrosoftOpenTelemetryOptions> so that
+        // runtime IOptions<MicrosoftOpenTelemetryOptions> resolution picks up appsettings.json.
+        // TryAddEnumerable checks the implementation type, not just the service type,
+        // so a prior services.Configure<T>() call won't suppress this registration.
+        builder.Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IConfigureOptions<MicrosoftOpenTelemetryOptions>,
+                DefaultMicrosoftOpenTelemetryConfigureOptions>());
+
+        // Register the caller's Action<> as PostConfigure so it runs after IConfiguration binding
+        // and any services.Configure<MicrosoftOpenTelemetryOptions>() calls at runtime.
+        builder.Services.PostConfigure(configure);
+
+        // Build-time: eagerly resolve options from IConfiguration + Action<> callback.
+        // DI options infrastructure is not available yet, so we manually apply the same
+        // IConfiguration binding followed by the caller's callback.
+        var config = FindConfiguration(builder.Services);
         var options = new MicrosoftOpenTelemetryOptions();
+        DefaultMicrosoftOpenTelemetryConfigureOptions.BindFromConfiguration(config, options);
         configure(options);
 
         // Auto-detect exporters from configuration if not explicitly set
@@ -101,11 +120,10 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
 
             // Check code-provided, IConfiguration, and raw env var for connection string
             if (!string.IsNullOrWhiteSpace(options.AzureMonitor.ConnectionString)
-                || HasAzureMonitorConnectionString(builder.Services))
+                || HasAzureMonitorConnectionString(config))
                 exporters |= ExportTarget.AzureMonitor;
             if (options.Agent365.Exporter.TokenResolver != null)
                 exporters |= ExportTarget.Agent365;
-            
         }
 
         // When A365 is the only real exporter (with or without Console), suppress noisy
@@ -160,20 +178,20 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
         };
 
         // --- Azure Monitor (always: instrumentation; exporter gated by Exporters flag) ---
-        builder.UseAzureMonitor(o =>
-        {
-            o.SkipExporter = !exporters.HasFlag(ExportTarget.AzureMonitor);
-            o.ConnectionString = options.AzureMonitor.ConnectionString;
-            o.Credential = options.AzureMonitor.Credential;
-            o.DisableOfflineStorage = options.AzureMonitor.DisableOfflineStorage;
-            o.StorageDirectory = options.AzureMonitor.StorageDirectory;
-            o.EnableLiveMetrics = options.AzureMonitor.EnableLiveMetrics;
-            o.EnableStandardMetrics = options.AzureMonitor.EnableStandardMetrics;
-            o.EnablePerfCounters = options.AzureMonitor.EnablePerfCounters;
-            o.EnableTraceBasedLogsSampler = options.AzureMonitor.EnableTraceBasedLogsSampler;
-            o.SamplingRatio = options.AzureMonitor.SamplingRatio;
-            o.TracesPerSecond = options.AzureMonitor.TracesPerSecond;
-        }, effectiveInstrumentation);
+        //builder.UseAzureMonitor(o =>
+        //{
+        //    o.SkipExporter = !exporters.HasFlag(ExportTarget.AzureMonitor);
+        //    o.ConnectionString = options.AzureMonitor.ConnectionString;
+        //    o.Credential = options.AzureMonitor.Credential;
+        //    o.DisableOfflineStorage = options.AzureMonitor.DisableOfflineStorage;
+        //    o.StorageDirectory = options.AzureMonitor.StorageDirectory;
+        //    o.EnableLiveMetrics = options.AzureMonitor.EnableLiveMetrics;
+        //    o.EnableStandardMetrics = options.AzureMonitor.EnableStandardMetrics;
+        //    o.EnablePerfCounters = options.AzureMonitor.EnablePerfCounters;
+        //    o.EnableTraceBasedLogsSampler = options.AzureMonitor.EnableTraceBasedLogsSampler;
+        //    o.SamplingRatio = options.AzureMonitor.SamplingRatio;
+        //    o.TracesPerSecond = options.AzureMonitor.TracesPerSecond;
+        //}, effectiveInstrumentation);
 
         // --- Agent365 (always: scopes + baggage + span processors; exporter gated by Exporters flag) ---
         builder.UseAgent365(o =>
@@ -263,25 +281,30 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
     }
 
     /// <summary>
-    /// Checks if an Azure Monitor connection string is available from IConfiguration
-    /// (appsettings.json, env var provider, Key Vault, etc.) or raw environment variable.
-    /// Does NOT call BuildServiceProvider().
+    /// Finds an <see cref="IConfiguration"/> instance from the service descriptors without
+    /// calling <c>BuildServiceProvider()</c>. Returns <c>null</c> when not found.
     /// </summary>
-    private static bool HasAzureMonitorConnectionString(IServiceCollection services)
+    private static IConfiguration? FindConfiguration(IServiceCollection services)
     {
-        // Try to find IConfiguration from service descriptors (registered as singleton instance
-        // by HostApplicationBuilder, WebApplicationBuilder, and Host.CreateDefaultBuilder)
-        IConfiguration? config = null;
         for (int i = services.Count - 1; i >= 0; i--)
         {
             if (services[i].ServiceType == typeof(IConfiguration)
                 && services[i].ImplementationInstance is IConfiguration c)
             {
-                config = c;
-                break;
+                return c;
             }
         }
 
+        return null;
+    }
+
+    /// <summary>
+    /// Checks if an Azure Monitor connection string is available from IConfiguration
+    /// (appsettings.json, env var provider, Key Vault, etc.) or raw environment variable.
+    /// Does NOT call BuildServiceProvider().
+    /// </summary>
+    private static bool HasAzureMonitorConnectionString(IConfiguration? config)
+    {
         if (config != null)
         {
             // Check "AzureMonitor" config section (appsettings.json)

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
@@ -4,10 +4,12 @@
 #if NET
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using OpenTelemetry;
 using Xunit;
 
@@ -165,6 +167,299 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
             Assert.Contains(services, s =>
                 s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
                 s.ServiceType.Name.Contains("TracerProviderBuilder"));
+        }
+
+        [Fact]
+        public void Config_ReadsExportersFromAppSettings()
+        {
+            const string envVar = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+            var original = Environment.GetEnvironmentVariable(envVar);
+            try
+            {
+                Environment.SetEnvironmentVariable(envVar, null);
+
+                var configData = new Dictionary<string, string?>
+                {
+                    ["MicrosoftOpenTelemetry:Exporters"] = "AzureMonitor",
+                    ["AzureMonitor:ConnectionString"] = TestConnectionString,
+                };
+                var configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(configData)
+                    .Build();
+
+                var services = new ServiceCollection();
+                services.AddSingleton<IConfiguration>(configuration);
+                services.AddOpenTelemetry()
+                    .UseMicrosoftOpenTelemetry(o =>
+                    {
+                        o.AzureMonitor.DisableOfflineStorage = true;
+                        o.AzureMonitor.EnableLiveMetrics = false;
+                    });
+
+                // Exporters explicitly set from config — AzureMonitor should be registered
+                Assert.True(HasAzureMonitorExporter(services),
+                    "Azure Monitor exporter should be registered when Exporters includes AzureMonitor from config.");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+            }
+        }
+
+        [Fact]
+        public void Config_ReadsInstrumentationFromAppSettings()
+        {
+            var configData = new Dictionary<string, string?>
+            {
+                ["MicrosoftOpenTelemetry:Instrumentation:EnableSqlClientInstrumentation"] = "false",
+                ["MicrosoftOpenTelemetry:Instrumentation:EnableOpenAIInstrumentation"] = "false",
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+
+            var options = new MicrosoftOpenTelemetryOptions();
+            DefaultMicrosoftOpenTelemetryConfigureOptions.BindFromConfiguration(configuration, options);
+
+            Assert.False(options.Instrumentation.EnableSqlClientInstrumentation,
+                "EnableSqlClientInstrumentation should be false from config.");
+            Assert.False(options.Instrumentation.EnableOpenAIInstrumentation,
+                "EnableOpenAIInstrumentation should be false from config.");
+            // Defaults should remain for unspecified values
+            Assert.True(options.Instrumentation.EnableTracing);
+            Assert.True(options.Instrumentation.EnableMetrics);
+            Assert.True(options.Instrumentation.EnableLogging);
+            Assert.True(options.Instrumentation.EnableAspNetCoreInstrumentation);
+        }
+
+        [Fact]
+        public void Config_ActionCallbackOverridesAppSettings()
+        {
+            var configData = new Dictionary<string, string?>
+            {
+                ["MicrosoftOpenTelemetry:Instrumentation:EnableSqlClientInstrumentation"] = "true",
+                ["MicrosoftOpenTelemetry:Instrumentation:EnableTracing"] = "true",
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    // Action callback overrides config values
+                    o.Instrumentation.EnableSqlClientInstrumentation = false;
+                    o.Exporters = ExportTarget.Console;
+                });
+
+            // Verify the Action<> callback takes effect for build-time by checking
+            // that IConfigureOptions is registered (runtime resolution test below
+            // verifies the PostConfigure ordering)
+            Assert.Contains(services, s =>
+                s.ServiceType.IsGenericType &&
+                s.ServiceType.GetGenericTypeDefinition() == typeof(IConfigureOptions<>) &&
+                s.ServiceType.GetGenericArguments().Any(a => a == typeof(MicrosoftOpenTelemetryOptions)));
+        }
+
+        [Fact]
+        public void Config_RegistersIConfigureOptions()
+        {
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Console;
+                });
+
+            // Verify IConfigureOptions<MicrosoftOpenTelemetryOptions> is registered
+            Assert.Contains(services, s =>
+                s.ServiceType == typeof(IConfigureOptions<MicrosoftOpenTelemetryOptions>));
+        }
+
+        [Fact]
+        public void Config_RuntimeOptionsResolution()
+        {
+            var configData = new Dictionary<string, string?>
+            {
+                ["MicrosoftOpenTelemetry:Instrumentation:EnableSqlClientInstrumentation"] = "false",
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Console;
+                });
+
+            // Resolve IOptions<MicrosoftOpenTelemetryOptions> at runtime
+            var sp = services.BuildServiceProvider();
+            var resolvedOptions = sp.GetRequiredService<IOptions<MicrosoftOpenTelemetryOptions>>().Value;
+
+            // IConfiguration binding should have set this to false
+            Assert.False(resolvedOptions.Instrumentation.EnableSqlClientInstrumentation,
+                "Runtime IOptions should reflect IConfiguration binding.");
+            // PostConfigure (Action<> callback) should set Exporters
+            Assert.Equal(ExportTarget.Console, resolvedOptions.Exporters);
+        }
+
+        [Fact]
+        public void Config_ServicesConfigureAffectsRuntimeOptions()
+        {
+            var services = new ServiceCollection();
+
+            // User calls services.Configure<MicrosoftOpenTelemetryOptions> before UseMicrosoftOpenTelemetry
+            services.Configure<MicrosoftOpenTelemetryOptions>(o =>
+            {
+                o.Instrumentation.EnableHttpClientInstrumentation = false;
+            });
+
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Console;
+                });
+
+            var sp = services.BuildServiceProvider();
+            var resolvedOptions = sp.GetRequiredService<IOptions<MicrosoftOpenTelemetryOptions>>().Value;
+
+            // services.Configure runs between IConfigureOptions and PostConfigure,
+            // so its value should be visible unless the PostConfigure callback overwrites it.
+            // Since the Action<> callback doesn't set EnableHttpClientInstrumentation,
+            // the services.Configure value should survive.
+            Assert.False(resolvedOptions.Instrumentation.EnableHttpClientInstrumentation,
+                "services.Configure<MicrosoftOpenTelemetryOptions> should affect runtime IOptions resolution.");
+        }
+
+        [Fact]
+        public void Config_ExportersFlagsEnum_ParsesCommasSeparated()
+        {
+            var configData = new Dictionary<string, string?>
+            {
+                ["MicrosoftOpenTelemetry:Exporters"] = "AzureMonitor, Otlp",
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+
+            var options = new MicrosoftOpenTelemetryOptions();
+            DefaultMicrosoftOpenTelemetryConfigureOptions.BindFromConfiguration(configuration, options);
+
+            Assert.True(options.ExportersExplicitlySet, "Exporters should be explicitly set from config.");
+            Assert.True(options.Exporters.HasFlag(ExportTarget.AzureMonitor));
+            Assert.True(options.Exporters.HasFlag(ExportTarget.Otlp));
+            Assert.False(options.Exporters.HasFlag(ExportTarget.Agent365));
+            Assert.False(options.Exporters.HasFlag(ExportTarget.Console));
+        }
+
+        [Fact]
+        public void Config_EmptySection_PreservesDefaults()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>())
+                .Build();
+
+            var options = new MicrosoftOpenTelemetryOptions();
+            DefaultMicrosoftOpenTelemetryConfigureOptions.BindFromConfiguration(configuration, options);
+
+            // No MicrosoftOpenTelemetry section → all defaults preserved
+            Assert.False(options.ExportersExplicitlySet);
+            Assert.Equal(ExportTarget.None, options.Exporters);
+            Assert.True(options.Instrumentation.EnableTracing);
+            Assert.True(options.Instrumentation.EnableMetrics);
+            Assert.True(options.Instrumentation.EnableLogging);
+            Assert.True(options.Instrumentation.EnableSqlClientInstrumentation);
+        }
+
+        [Fact]
+        public void Config_BindsAzureMonitorConnectionStringFromSection()
+        {
+            var configData = new Dictionary<string, string?>
+            {
+                ["AzureMonitor:ConnectionString"] = TestConnectionString,
+            };
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configData)
+                .Build();
+
+            var options = new MicrosoftOpenTelemetryOptions();
+            DefaultMicrosoftOpenTelemetryConfigureOptions.BindFromConfiguration(configuration, options);
+
+            Assert.Equal(TestConnectionString, options.AzureMonitor.ConnectionString);
+        }
+
+        [Fact]
+        public void Config_AzureMonitorConnectionStringFlowsToExporter()
+        {
+            const string envVar = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+            var original = Environment.GetEnvironmentVariable(envVar);
+            try
+            {
+                Environment.SetEnvironmentVariable(envVar, null);
+
+                var configData = new Dictionary<string, string?>
+                {
+                    ["MicrosoftOpenTelemetry:Exporters"] = "AzureMonitor",
+                    ["AzureMonitor:ConnectionString"] = TestConnectionString,
+                };
+                var configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(configData)
+                    .Build();
+
+                var services = new ServiceCollection();
+                services.AddSingleton<IConfiguration>(configuration);
+
+                // Parameterless — everything from config
+                services.AddOpenTelemetry()
+                    .UseMicrosoftOpenTelemetry(o =>
+                    {
+                        o.AzureMonitor.DisableOfflineStorage = true;
+                        o.AzureMonitor.EnableLiveMetrics = false;
+                    });
+
+                // Azure Monitor exporter should be registered with a valid connection string
+                Assert.True(HasAzureMonitorExporter(services),
+                    "Azure Monitor exporter should be registered when ConnectionString is in AzureMonitor config section.");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+            }
+        }
+
+        [Fact]
+        public void Config_ConnectionStringEnvVarOverridesSection()
+        {
+            const string envVar = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+            const string envVarConnectionString = "InstrumentationKey=11111111-1111-1111-1111-111111111111";
+            var original = Environment.GetEnvironmentVariable(envVar);
+            try
+            {
+                Environment.SetEnvironmentVariable(envVar, envVarConnectionString);
+
+                var configData = new Dictionary<string, string?>
+                {
+                    ["AzureMonitor:ConnectionString"] = TestConnectionString,
+                };
+                var configuration = new ConfigurationBuilder()
+                    .AddInMemoryCollection(configData)
+                    .Build();
+
+                var options = new MicrosoftOpenTelemetryOptions();
+                DefaultMicrosoftOpenTelemetryConfigureOptions.BindFromConfiguration(configuration, options);
+
+                // Env var should take precedence over config section
+                Assert.Equal(envVarConnectionString, options.AzureMonitor.ConnectionString);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds IConfiguration binding so that MicrosoftOpenTelemetryOptions can be configured via appsettings.json, environment variables, and other configuration providers -- in addition to the existing Action<> callback.

## Changes

### New: DefaultMicrosoftOpenTelemetryConfigureOptions
- Internal IConfigureOptions<MicrosoftOpenTelemetryOptions> that reads from:
  - `MicrosoftOpenTelemetry` config section (Exporters, Instrumentation flags)
  - `AzureMonitor` config section (ConnectionString and other properties)
  - `APPLICATIONINSIGHTS_CONNECTION_STRING` env var (highest precedence)

### Options layering
- TryAddEnumerable registers the IConfiguration binder as IConfigureOptions<T>
- User's Action<> callback registered as PostConfigure (always wins)
- Precedence: IConfiguration -> services.Configure<T>() -> Action<> callback

### Auto-detect fix
- Exporter auto-detection now uses only the layered options value after IConfiguration binding + callback, so the callback can reliably disable Azure Monitor by clearing ConnectionString
- Raw env var fallback preserved for non-host-builder scenarios

### Diagnostics
- Config binding errors now emit ConfigurationBindingFailed event (ID 16) via EventSource instead of being silently swallowed

### Package bumps
- OTel packages updated to 1.15.x (CVE-2026-40891 fix)

## Testing
- 11 new configuration binding tests
- All 382 tests pass (191 x 2 TFMs)
