### PR TITLE
Add Azure Monitor, Agent Framework, and customization docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,214 +12,148 @@ dotnet add package Microsoft.OpenTelemetry
 
 ## Quick Start
 
-Send Agent Framework traces to Agent365 in one call:
+### ASP.NET Core / Worker Services (hosted)
 
 ```csharp
 using Microsoft.OpenTelemetry;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        // Agent365 auto-enables when the Microsoft.Agents.A365.Observability.Hosting
-        // token cache is registered by your app, OR when you set a TokenResolver:
-        o.Agent365.Exporter.TokenResolver = (agentId, tenantId)
-            => tokenProvider.GetTokenAsync(agentId, tenantId);
-    });
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
 
 var app = builder.Build();
-app.MapPost("/api/messages", () => Results.Ok());
 app.Run();
 ```
 
-> A shorthand `builder.UseMicrosoftOpenTelemetry(...)` extension on `WebApplicationBuilder` is also available and is equivalent to the form above.
+### Console / non-hosted apps
 
-Not using Agent Framework / Agent365? Jump to [Azure Monitor](#3-azure-monitor-aspnet-core--worker--console) or the [Options reference](#options-reference).
+```csharp
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor;
+    });
+});
+
+// Your application logic here.
+// The SDK must stay alive for the lifetime of the app.
+// Disposing the SDK flushes pending telemetry and shuts down all providers.
+
+sdk.Dispose();
+```
+
+> **Important:** Do not dispose the SDK until your application is shutting down. Disposing it early stops all telemetry collection and export — you will lose data.
+
+> `UseMicrosoftOpenTelemetry()` works on any `IOpenTelemetryBuilder` — both the host-integrated and `OpenTelemetrySdk.Create()` paths are supported.
 
 ## Signals & destinations
 
-| Signal | Azure Monitor | Agent365 | OTLP |
-|---|:---:|:---:|:---:|
-| Traces | ✅ | ✅ | ✅ |
-| Metrics | ✅ | — | ✅ |
-| Logs | ✅ | — | ✅ |
+| Signal | Azure Monitor | Agent365 | OTLP | Console |
+|---|:---:|:---:|:---:|:---:|
+| Traces | ✅ | ✅ | ✅ | ✅ |
+| Metrics | ✅ | — | ✅ | ✅ |
+| Logs | ✅ | — | ✅ | ✅ |
 
 Exporters auto-detect when `Exporters` isn't set:
 - **Azure Monitor** — enabled when `ConnectionString` is set (code, env var `APPLICATIONINSIGHTS_CONNECTION_STRING`, or `IConfiguration`).
 - **Agent365** — enabled when `TokenResolver` is set (or when the DI token cache is registered by `Microsoft.Agents.A365.Observability.Hosting`).
-- **OTLP** — enabled when `OtlpEndpoint` is set.
+
+Set explicitly to override auto-detection: `o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Agent365;`
 
 ## Instrumentation (always active)
 
 - ASP.NET Core incoming HTTP requests
 - HTTP client outbound calls (with Azure SDK dedup filter)
 - SQL client queries
+- Azure SDK client calls
 - Resource detection (Azure App Service, VM, Container Apps)
 - Agent365 scopes (`InvokeAgentScope`, `InferenceScope`, `ExecuteToolScope`, `OutputScope`) and baggage propagation
-- Microsoft Agent Framework — `Experimental.Microsoft.Agents.AI` activity source
+- Microsoft Agent Framework — `Experimental.Microsoft.Agents.AI` activity sources
+- Semantic Kernel — `Microsoft.SemanticKernel*` activity sources
+- OpenAI / Azure OpenAI — `Azure.AI.OpenAI*`, `OpenAI.*`, `Experimental.Microsoft.Extensions.AI`
 - Azure SDK EventSource → `ILogger` log forwarding
 - Metrics — `Microsoft.AspNetCore.Hosting`, `System.Net.Http`
 
 ## Onboarding by scenario
 
-Pick the section that matches your workload. All three can be combined in the same app.
+Pick the section that matches your workload. All can be combined in the same app.
 
 ---
 
-### 1. Agent365
+### 1. Azure Monitor
 
-Send agent telemetry (invoke agent, inference, tool execution, output) to the [Agent365](https://learn.microsoft.com/en-us/microsoft-agent-365/) observability backend.
-
-**Prerequisites**
-- An Agent365 tenant and agent identity — see the [Agent365 developer docs](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/).
-- Either:
-  - **Auto-managed tokens (recommended for Agent Framework apps):** the `Microsoft.Agents.A365.Observability.Hosting` package registers a token cache via DI — no code needed on your side.
-  - **Custom token resolver:** an async function that returns a bearer token for `(agentId, tenantId)`.
-- NuGet packages: `Microsoft.OpenTelemetry`, `Microsoft.Agents.Builder`.
-
-**Setup**
+Send traces, metrics, and logs to Application Insights / Azure Monitor.
 
 ```csharp
-using Microsoft.OpenTelemetry;
-
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        // Custom token resolver (skip if using auto-managed tokens)
-        o.Agent365.Exporter.TokenResolver = (agentId, tenantId)
-            => tokenProvider.GetTokenAsync(agentId, tenantId);
-    });
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
+});
 ```
 
-**What you get**
-- **Scopes**: `InvokeAgentScope`, `InferenceScope`, `ExecuteToolScope`, `OutputScope`
-- **Baggage**: per-request tenant / agent / session context propagation
-- **Exporter**: authenticated export to Agent365 endpoint
+**Configuration sources** — the connection string can be set via code, `appsettings.json`, or the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable.
 
-**Composable alternative**
-
-```csharp
-builder.Services.AddOpenTelemetry()
-    .UseAgent365(o =>
-    {
-        o.Exporter.TokenResolver = (agentId, tenantId) => tokenProvider.GetTokenAsync(agentId, tenantId);
-    });
-```
-
-See [examples/Microsoft.OpenTelemetry.Agent365.Demo](examples/Microsoft.OpenTelemetry.Agent365.Demo).
+📖 **Full guide:** [Azure Monitor Getting Started](docs/azure-monitor-getting-started.md)
 
 ---
 
 ### 2. Microsoft Agent Framework
 
-Capture activity from the `Experimental.Microsoft.Agents.AI` activity source and export to your backend of choice.
-
-**Prerequisites**
-- An app that uses `Microsoft.Agents.AI` (Agent Framework).
-- An export destination (Azure Monitor connection string, OTLP collector, or Agent365 identity).
-- NuGet package: `Microsoft.OpenTelemetry`.
-
-**Setup — Agent Framework → Azure Monitor**
+Capture activity from Agent Framework agents and export to Azure Monitor, OTLP, or both.
 
 ```csharp
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
-        // Agent Framework activity source is already captured — no extra flag needed.
-    });
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Otlp;
+});
 ```
 
-**Setup — Agent Framework → OTLP (Aspire Dashboard, Jaeger, Grafana Tempo)**
+Agent Framework activity sources are captured automatically — no extra configuration needed.
 
-```csharp
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        o.OtlpEndpoint = new Uri("http://localhost:4317");
-    });
-```
-
-**Setup — Agent Framework → Agent365**
-
-```csharp
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        o.Agent365.Exporter.TokenResolver = (agentId, tenantId)
-            => tokenProvider.GetTokenAsync(agentId, tenantId);
-    });
-```
-
-**Composable alternative**
-
-```csharp
-builder.Services.AddOpenTelemetry()
-    .UseAgentFramework();
-```
-
-See [examples/Microsoft.OpenTelemetry.AgentFramework.Demo](examples/Microsoft.OpenTelemetry.AgentFramework.Demo).
+📖 **Full guide:** [Agent Framework Getting Started](docs/agent-framework-getting-started.md)
 
 ---
 
-### 3. Azure Monitor (ASP.NET Core / Worker / Console)
+### 3. Agent365
 
-Send traces, metrics, and logs to Application Insights / Azure Monitor.
-
-**Prerequisites**
-- An Application Insights resource — copy its **Connection String** from the Azure portal.
-- NuGet package: `Microsoft.OpenTelemetry`.
-
-**Setup**
+Send agent telemetry (invoke agent, inference, tool execution, output) to the [Agent365](https://learn.microsoft.com/en-us/microsoft-agent-365/) observability backend.
 
 ```csharp
-using Microsoft.OpenTelemetry;
-
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Agent365;
+    o.Agent365.Exporter.TokenResolver = async (agentId, tenantId) =>
     {
-        o.AzureMonitor.ConnectionString =
-            builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
-    });
+        return await MyTokenService.GetTokenAsync(agentId, tenantId);
+    };
+});
 ```
 
-**Configuration sources**
-
-| Source | Key |
-|---|---|
-| Environment variable | `APPLICATIONINSIGHTS_CONNECTION_STRING` |
-| `appsettings.json` | `"APPLICATIONINSIGHTS_CONNECTION_STRING": "..."` |
-| Code | `o.AzureMonitor.ConnectionString = "..."` |
-
-**Composable alternative**
-
-```csharp
-builder.Services.AddOpenTelemetry()
-    .UseAzureMonitor(o => o.ConnectionString = "InstrumentationKey=...");
-```
-
-See [examples/Azure.Monitor.OpenTelemetry.AspNetCore.Demo](examples/Azure.Monitor.OpenTelemetry.AspNetCore.Demo).
+📖 **Full guide:** [Agent365 Getting Started](docs/agent365-getting-started.md)
 
 ---
 
 ### Combining destinations
 
 ```csharp
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Agent365 | ExportTarget.Otlp;
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Agent365 | ExportTarget.Otlp;
 
-        o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
-        o.Agent365.Exporter.TokenResolver = (agentId, tenantId)
-            => tokenProvider.GetTokenAsync(agentId, tenantId);
-        o.OtlpEndpoint = new Uri("http://localhost:4317");
-    });
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
+    o.Agent365.Exporter.TokenResolver = async (agentId, tenantId) =>
+    {
+        return await MyTokenService.GetTokenAsync(agentId, tenantId);
+    };
+});
 ```
 
 ## Options reference
@@ -227,48 +161,63 @@ builder.Services.AddOpenTelemetry()
 Full surface of `MicrosoftOpenTelemetryOptions`. Everything is opt-in; values shown are defaults.
 
 ```csharp
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    // --- Export targets (pick one or combine with |) ---
+    o.Exporters = ExportTarget.Console         // Console output (dev)
+                | ExportTarget.Agent365        // Agent365 observability platform
+                | ExportTarget.AzureMonitor    // Application Insights
+                | ExportTarget.Otlp;           // OTLP (Aspire, Jaeger, Grafana)
+
+    // --- Azure Monitor settings ---
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
+    o.AzureMonitor.Credential = new DefaultAzureCredential(); // Optional AAD auth
+    o.AzureMonitor.SamplingRatio = 1.0f;
+    o.AzureMonitor.TracesPerSecond = 5.0;     // Rate-limited sampling (default)
+    o.AzureMonitor.EnableLiveMetrics = true;
+    o.AzureMonitor.EnableStandardMetrics = true;
+    o.AzureMonitor.EnablePerfCounters = true;
+    o.AzureMonitor.EnableTraceBasedLogsSampler = true;
+    o.AzureMonitor.DisableOfflineStorage = false;
+    o.AzureMonitor.StorageDirectory = null;
+
+    // --- Agent365 exporter settings ---
+
+    // Option A: Auto-managed tokens via DI (recommended for Agent Framework apps).
+    // The Microsoft.Agents.A365.Observability.Hosting package registers
+    // IExporterTokenCache<AgenticTokenStruct>. No TokenResolver needed.
+
+    // Option B: Custom token resolver (non-agent apps, S2S, custom auth)
+    o.Agent365.Exporter.TokenResolver = async (agentId, tenantId) =>
     {
-        // --- Export targets (pick one or combine with |) ---
-        o.Exporters = ExportTarget.Console         // Console output (dev)
-                    | ExportTarget.Agent365        // Agent365 observability platform
-                    | ExportTarget.AzureMonitor    // Application Insights
-                    | ExportTarget.Otlp;           // OTLP (Aspire, Jaeger, Grafana)
+        return await MyTokenService.GetTokenAsync(agentId, tenantId);
+    };
 
-        // --- Agent365 exporter settings ---
+    // Optional: custom domain resolver (default: agent365.svc.cloud.microsoft)
+    o.Agent365.Exporter.DomainResolver = tenantId => "agent365.svc.cloud.microsoft";
 
-        // Option A: Auto-managed tokens via DI (recommended for Agent Framework apps).
-        // The Microsoft.Agents.A365.Observability.Hosting package registers
-        // IExporterTokenCache<AgenticTokenStruct>. Tokens are exchanged
-        // per request via ExchangeTurnTokenAsync — no TokenResolver needed.
+    // Optional: use S2S endpoint path
+    o.Agent365.Exporter.UseS2SEndpoint = false;
 
-        // Option B: Custom token resolver (non-agent apps, S2S, custom auth)
-        o.Agent365.Exporter.TokenResolver = async (agentId, tenantId) =>
-        {
-            return await MyTokenService.GetTokenAsync(agentId, tenantId);
-        };
+    // Optional: batch export tuning
+    o.Agent365.Exporter.MaxQueueSize = 2048;
+    o.Agent365.Exporter.MaxExportBatchSize = 512;
+    o.Agent365.Exporter.ScheduledDelayMilliseconds = 5000;
+    o.Agent365.Exporter.ExporterTimeoutMilliseconds = 30000;
 
-        // Optional: custom domain resolver (default: agent365.svc.cloud.microsoft)
-        o.Agent365.Exporter.DomainResolver = tenantId => "agent365.svc.cloud.microsoft";
-
-        // Optional: use S2S endpoint path
-        o.Agent365.Exporter.UseS2SEndpoint = false;
-
-        // Optional: batch export tuning
-        o.Agent365.Exporter.MaxQueueSize = 2048;
-        o.Agent365.Exporter.MaxExportBatchSize = 512;
-        o.Agent365.Exporter.ScheduledDelayMilliseconds = 5000;
-        o.Agent365.Exporter.ExporterTimeoutMilliseconds = 30000;
-
-        // --- Azure Monitor settings ---
-        o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
-        o.AzureMonitor.SamplingRatio = 1.0f;
-        o.AzureMonitor.EnableLiveMetrics = true;
-
-        // --- OTLP settings ---
-        o.OtlpEndpoint = new Uri("http://localhost:4317");
-    });
+    // --- Instrumentation options (all default to true) ---
+    o.Instrumentation.EnableTracing = true;
+    o.Instrumentation.EnableMetrics = true;
+    o.Instrumentation.EnableLogging = true;
+    o.Instrumentation.EnableAspNetCoreInstrumentation = true;
+    o.Instrumentation.EnableHttpClientInstrumentation = true;
+    o.Instrumentation.EnableSqlClientInstrumentation = true;
+    o.Instrumentation.EnableAzureSdkInstrumentation = true;
+    o.Instrumentation.EnableOpenAIInstrumentation = true;
+    o.Instrumentation.EnableSemanticKernelInstrumentation = true;
+    o.Instrumentation.EnableAgentFrameworkInstrumentation = true;
+    o.Instrumentation.EnableAgent365Instrumentation = true;
+});
 ```
 
 ### Token resolver: auto vs custom
@@ -313,8 +262,11 @@ builder.Services.AddLogging(logging => logging.AddConsole());
 
 ## Documentation
 
-- [Agent 365 Getting Started](docs/agent365-getting-started.md) — Comprehensive guide for adding Agent365 observability using the distro
-- [Agent 365 Migration Guide](docs/agent365-migration.md) — Migrating from the standalone Agent365 SDK to the distro
+- [Azure Monitor Getting Started](docs/azure-monitor-getting-started.md) — Send traces, metrics, and logs to Application Insights
+- [Agent Framework Getting Started](docs/agent-framework-getting-started.md) — Instrument Agent Framework agents with Azure Monitor and OTLP
+- [Customization Guide](docs/customization.md) — Resource configuration, enrichment, filtering, and OTLP exporter tuning
+- [Agent 365 Getting Started](docs/agent365-getting-started.md) — Add Agent365 observability using the distro
+- [Agent 365 Migration Guide](docs/agent365-migration.md) — Migrate from the standalone Agent365 SDK to the distro
 - [Agent 365 Migration Testing](docs/testing-agent365.md) — Detailed migration checklist with auto-instrumentation, env vars, and span comparison
 
 ## Examples

--- a/docs/agent-framework-getting-started.md
+++ b/docs/agent-framework-getting-started.md
@@ -1,0 +1,385 @@
+# Agent Framework Observability (.NET)
+
+> **Standalone guide** — covers everything you need to add observability to [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) agents using the `Microsoft.OpenTelemetry` distro, with telemetry sent to Azure Monitor and/or OTLP-compatible backends.
+
+The Microsoft OpenTelemetry distro provides built-in support for capturing telemetry from the Microsoft Agent Framework (MAF). With a single line of configuration, the distro automatically subscribes to MAF's activity sources, captures traces and metrics from agent invocations, tool executions, and LLM inference calls, and exports them to Azure Monitor (Application Insights), OTLP endpoints, or the console.
+
+## Key benefits
+
+- **Zero manual wiring**: The distro auto-registers MAF activity source listeners — no need to manually call `AddSource()` for each MAF source.
+- **End-to-end agent tracing**: Capture `invoke_agent`, `chat`, and `execute_tool` spans with full parent-child relationships.
+- **Multi-destination export**: Send telemetry to Azure Monitor, OTLP (Aspire Dashboard, Jaeger, Grafana), or console — simultaneously.
+- **GenAI semantic conventions**: Spans follow the [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) for consistent observability across agent platforms.
+
+## Auto-captured spans and metrics
+
+Once observability is enabled, the distro automatically captures:
+
+### Spans
+
+| Span | Description |
+|---|---|
+| `invoke_agent <agent_name>` | Top-level span for each agent invocation. Contains all other spans as children. |
+| `chat <model_name>` | Span for LLM calls. Includes prompt and response as attributes when sensitive data is enabled. |
+| `execute_tool <function_name>` | Span for tool/function executions. Includes arguments and results when sensitive data is enabled. |
+
+### Metrics
+
+| Metric | Type | Description |
+|---|---|---|
+| `gen_ai.client.operation.duration` | Histogram | Duration of each LLM operation (seconds). |
+| `gen_ai.client.token.usage` | Histogram | Token usage per LLM call. |
+| `agent_framework.function.invocation.duration` | Histogram | Duration of tool/function invocations (seconds). |
+
+### Activity sources
+
+The distro listens to these MAF activity sources:
+
+| ActivitySource | Description |
+|---|---|
+| `Experimental.Microsoft.Agents.AI` | Default source — used when no custom `sourceName` is specified in `.UseOpenTelemetry()`. |
+| `Experimental.Microsoft.Agents.AI.Agent` | Agent-level operations. |
+| `Experimental.Microsoft.Agents.AI.ChatClient` | Chat client operations. |
+
+## Prerequisites
+
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
+- A [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) agent
+- An [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/) or OpenAI resource for the backing LLM
+- An [Application Insights](https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview) resource (for Azure Monitor export) and/or an OTLP-compatible backend
+
+## Installation
+
+Install the Microsoft OpenTelemetry Distro NuGet package:
+
+```xml
+<PackageReference Include="Microsoft.OpenTelemetry" Version="<latest>" />
+```
+
+> **Note:** Add a `nuget.config` in your project root if the package is not available on the public NuGet feed. Check the [README](../README.md) for feed configuration.
+
+## Configuration (hosted apps)
+
+### Send to Azure Monitor
+
+In `Program.cs`, call `UseMicrosoftOpenTelemetry()` to enable observability. The distro automatically captures MAF telemetry — no extra configuration needed:
+
+```csharp
+using Microsoft.OpenTelemetry;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+
+var app = builder.Build();
+```
+
+Set the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable, or configure it explicitly:
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+});
+```
+
+### Send to OTLP (Aspire Dashboard, Jaeger, Grafana)
+
+To export telemetry to an OTLP-compatible backend such as the [Aspire Dashboard](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/overview):
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Otlp;
+});
+```
+
+Set the OTLP endpoint via environment variable:
+
+```powershell
+$env:OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
+```
+
+### Send to Azure Monitor + OTLP + Console
+
+Combine multiple export targets:
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Otlp | ExportTarget.Console;
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+});
+```
+
+> ⚠️ **Production warning:** `ExportTarget.Console` is intended for local development only. Do not include it in production deployments — it adds overhead and may log sensitive telemetry to stdout.
+
+## Configuration (non-hosted apps)
+
+For console applications or non-hosted scenarios, use `OpenTelemetrySdk.Create()` with the distro's `UseMicrosoftOpenTelemetry()` extension. The distro automatically registers all MAF activity sources — no manual `AddSource()` calls needed:
+
+> **Important:** Do not dispose the SDK until your application is shutting down. Disposing it early stops all telemetry collection and export — you will lose data.
+
+### Non-hosted with Azure Monitor
+
+```csharp
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor;
+        o.AzureMonitor.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+    });
+});
+
+// Build and run your agent — all MAF spans and metrics are captured automatically.
+// Dispose the SDK only at application shutdown.
+```
+
+### Non-hosted with OTLP (Aspire Dashboard)
+
+To send telemetry to the Aspire Dashboard or any OTLP-compatible backend:
+
+```csharp
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Otlp;
+    });
+});
+
+// Build and run your agent.
+// Dispose the SDK only at application shutdown.
+```
+
+Set the OTLP endpoint via environment variable:
+
+```powershell
+$env:OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
+```
+
+Combine Azure Monitor and OTLP:
+
+```csharp
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Otlp | ExportTarget.Console;
+    });
+});
+```
+
+## Instrumenting the agent
+
+Regardless of which builder pattern you use, instrument your MAF agent by calling `.UseOpenTelemetry()` on the chat client and `.WithOpenTelemetry()` on the agent:
+
+```csharp
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+const string SourceName = "MyAgentApp";
+
+var instrumentedChatClient = new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey))
+    .GetChatClient(deploymentName)
+    .AsIChatClient()
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: cfg => cfg.EnableSensitiveData = true)
+    .Build();
+
+var agent = new ChatClientAgent(
+    instrumentedChatClient,
+    name: "MyAgent",
+    instructions: "You are a helpful assistant.",
+    tools: [AIFunctionFactory.Create(GetWeather)])
+    .WithOpenTelemetry(sourceName: SourceName, configure: cfg => cfg.EnableSensitiveData = true);
+```
+
+> **Important:** When you enable observability on both the chat client and the agent, you may see duplicated information — prompts and responses are captured in both spans. Depending on your needs, consider enabling observability on only one or the other to avoid duplication.
+
+> ⚠️ **Warning:** Only enable `EnableSensitiveData` in development or testing environments. Sensitive data includes prompts, responses, function call arguments, and results.
+
+> **Tip:** If you don't specify a `sourceName`, the default `Experimental.Microsoft.Agents.AI` is used. Make sure the source name matches what your tracer provider listens to.
+
+## Aspire Dashboard (local development)
+
+The [Aspire Dashboard](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/overview) is a quick way to visualize traces and metrics during development without needing Azure Monitor.
+
+### Setting up Aspire Dashboard with Docker
+
+```powershell
+docker run --rm -it -d `
+    -p 18888:18888 `
+    -p 4317:18889 `
+    --name aspire-dashboard `
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+This starts the dashboard with:
+- **Web UI**: [http://localhost:18888](http://localhost:18888)
+- **OTLP endpoint**: `http://localhost:4317` for receiving telemetry
+
+### Configuring your application
+
+**With the distro (hosted apps):**
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Otlp | ExportTarget.Console;
+});
+```
+
+```powershell
+$env:OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
+dotnet run
+```
+
+**With `OpenTelemetrySdk.Create()` (non-hosted apps):**
+
+```csharp
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Otlp | ExportTarget.Console;
+    });
+});
+```
+
+Set the endpoint:
+
+```powershell
+$env:OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
+```
+
+Navigate to [http://localhost:18888](http://localhost:18888) to explore traces, logs, and metrics. Follow the [Aspire Dashboard exploration guide](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/explore) for details.
+
+## Distro vs. manual setup
+
+The distro simplifies Agent Framework observability significantly. Here is a comparison:
+
+**Without the distro** (manual setup with `OpenTelemetrySdk.Create()`):
+
+```csharp
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.ConfigureResource(r => r.AddService("my-agent"));
+
+    otel.WithTracing(tracing => tracing
+        .AddSource("MyAgentApp")
+        .AddSource("Experimental.Microsoft.Agents.AI")
+        .AddSource("Experimental.Microsoft.Agents.AI.Agent")
+        .AddSource("Experimental.Microsoft.Agents.AI.ChatClient")
+        .AddHttpClientInstrumentation()
+        .AddAzureMonitorTraceExporter(o => o.ConnectionString = connectionString));
+
+    otel.WithMetrics(metrics => metrics
+        .AddMeter("MyAgentApp")
+        .AddMeter("Experimental.Microsoft.Agents.AI")
+        .AddMeter("Experimental.Microsoft.Agents.AI.Agent")
+        .AddMeter("Experimental.Microsoft.Agents.AI.ChatClient")
+        .AddHttpClientInstrumentation()
+        .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString));
+
+    otel.WithLogging(logging => logging
+        .AddAzureMonitorLogExporter(o => o.ConnectionString = connectionString));
+});
+```
+
+**With the distro** (one line):
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+```
+
+The distro automatically:
+- Subscribes to MAF activity sources (`Experimental.Microsoft.Agents.AI*`)
+- Adds ASP.NET Core, HTTP client, SQL client, and Azure SDK instrumentation
+- Configures Azure Monitor exporters for traces, metrics, and logs
+- Detects Azure resource metadata (VM, App Service, Container Apps)
+- Adds a span processor that enriches MAF spans with additional metadata
+
+## Controlling MAF instrumentation
+
+To disable Agent Framework instrumentation while keeping other instrumentation active:
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.Instrumentation.EnableAgentFrameworkInstrumentation = false;
+});
+```
+
+Other related instrumentation options:
+
+| Property | Description | Default |
+|---|---|---|
+| `EnableAgentFrameworkInstrumentation` | Agent Framework operation traces and metrics. | `true` |
+| `EnableOpenAIInstrumentation` | OpenAI / Azure OpenAI call traces. | `true` |
+| `EnableSemanticKernelInstrumentation` | Semantic Kernel operation traces. | `true` |
+
+## Troubleshooting
+
+### No MAF spans appearing
+
+**Symptoms:** Agent runs successfully, but no `invoke_agent`, `chat`, or `execute_tool` spans appear.
+
+**Solutions:**
+
+- Verify that `.UseOpenTelemetry()` is called on the chat client builder and/or `.WithOpenTelemetry()` is called on the agent.
+- If using the distro (`UseMicrosoftOpenTelemetry()`), MAF sources are registered automatically — no manual `AddSource()` needed. Check that `EnableAgentFrameworkInstrumentation` is not set to `false`.
+- If using `OpenTelemetrySdk.Create()` **without** the distro, ensure you call `.AddSource("Experimental.Microsoft.Agents.AI")` in the tracer provider configuration.
+- If using a custom `sourceName`, ensure the same name is used in both the agent instrumentation and the `AddSource()` call.
+
+### Duplicate spans for prompts and responses
+
+**Symptoms:** The same prompt and response appear in both `chat` and `invoke_agent` spans.
+
+**Resolution:** Enable observability on either the chat client or the agent, not both:
+
+```csharp
+// Option A: Instrument only the agent
+var agent = new ChatClientAgent(chatClient, ...)
+    .WithOpenTelemetry(sourceName: SourceName);
+
+// Option B: Instrument only the chat client
+var instrumentedClient = chatClient
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName)
+    .Build();
+var agent = new ChatClientAgent(instrumentedClient, ...);
+```
+
+### Missing telemetry in Azure Monitor
+
+**Solutions:**
+
+- Verify `APPLICATIONINSIGHTS_CONNECTION_STRING` is set correctly.
+- Allow 2–5 minutes for telemetry ingestion.
+- Search by `traceId` in Application Insights → **Transaction search**.
+- Add `ExportTarget.Console` temporarily to verify telemetry is being produced locally.
+
+## Reference implementation
+
+See: `examples/Microsoft.OpenTelemetry.AgentFramework.Demo/` in the distro repo.
+
+For the full manual setup approach (without the distro), see the [Agent Framework AgentOpenTelemetry sample](https://github.com/microsoft/agent-framework/tree/main/dotnet/samples/02-agents/AgentOpenTelemetry).

--- a/docs/azure-monitor-getting-started.md
+++ b/docs/azure-monitor-getting-started.md
@@ -1,0 +1,532 @@
+# Azure Monitor Observability (.NET)
+
+> **Standalone guide** — covers everything you need to add Azure Monitor observability using the `Microsoft.OpenTelemetry` distro.
+
+The Microsoft OpenTelemetry distro provides a unified framework for sending telemetry data to Azure Monitor (Application Insights) following the OpenTelemetry specification. This library instruments your ASP.NET Core applications to collect and send traces, metrics, and logs to Azure Monitor for analysis and monitoring.
+
+## Key benefits
+
+- **One-line onboarding**: A single `UseMicrosoftOpenTelemetry()` call configures traces, metrics, and logs with Azure Monitor exporters, resource detectors, and instrumentation libraries.
+- **Built-in instrumentation**: ASP.NET Core, HttpClient, SQL Client, and Azure SDK instrumentation are included and enabled by default.
+- **Live Metrics**: Integrated support for [Live Metrics](https://learn.microsoft.com/azure/azure-monitor/app/live-stream) enabling real-time monitoring of application performance.
+- **Resource detection**: Automatic resource attributes for Azure App Service, Azure VMs, and Azure Container Apps.
+- **Unified distro**: Combine Azure Monitor with other export targets (Agent365, OTLP, Console) in a single configuration.
+
+## What is included in the distro
+
+The Microsoft OpenTelemetry distro includes:
+
+* **Traces**
+  * **ASP.NET Core Instrumentation**: Automatic tracing for incoming HTTP requests.
+  * **HTTP Client Instrumentation**: Automatic tracing for outgoing HTTP requests made using [System.Net.Http.HttpClient](https://learn.microsoft.com/dotnet/api/system.net.http.httpclient).
+  * **SQL Client Instrumentation**: Automatic tracing for SQL queries executed using [Microsoft.Data.SqlClient](https://www.nuget.org/packages/Microsoft.Data.SqlClient) and [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient).
+  * **Azure SDK Instrumentation**: Automatic tracing for Azure SDK client calls.
+
+* **Metrics**
+  * **Application Insights Standard Metrics**: Automatic collection of Application Insights standard metrics.
+  * **ASP.NET Core and HTTP Client Metrics**: Built-in metrics from `Microsoft.AspNetCore.Hosting` and `System.Net.Http` on .NET 8.0+.
+
+* **Logs**
+  * Logs created with `Microsoft.Extensions.Logging`. See [Logging in .NET Core and ASP.NET Core](https://learn.microsoft.com/aspnet/core/fundamentals/logging) for details.
+
+* **Resource Detectors**
+  * **AppServiceResourceDetector**: Resource attributes for Azure App Service.
+  * **AzureVMResourceDetector**: Resource attributes for Azure Virtual Machines.
+  * **AzureContainerAppsResourceDetector**: Resource attributes for Azure Container Apps.
+
+* **[Live Metrics](https://learn.microsoft.com/azure/azure-monitor/app/live-stream)**: Real-time monitoring of application performance.
+
+* **GenAI / Agent Auto-Instrumentation**
+  * **Microsoft Agent Framework**: Automatic tracing for Agent Framework operations (`Experimental.Microsoft.Agents.AI`, `Experimental.Microsoft.Agents.AI.Agent`, `Experimental.Microsoft.Agents.AI.ChatClient`).
+  * **Semantic Kernel**: Automatic tracing for Semantic Kernel operations (`Microsoft.SemanticKernel*`).
+  * **OpenAI / Azure OpenAI**: Automatic tracing for OpenAI calls (`Azure.AI.OpenAI*`, `OpenAI.*`, `Experimental.Microsoft.Extensions.AI`).
+  * **Agent365 Scopes**: Manual observability scopes (`Agent365Sdk`) for `InvokeAgent`, `ExecuteTool`, `Inference`, and `Output` operations.
+
+> **Note:** GenAI and Agent instrumentation activity sources are always registered by the distro regardless of which export targets are enabled. This means traces from Semantic Kernel, OpenAI, and Agent Framework are captured and sent to Azure Monitor when `ExportTarget.AzureMonitor` is active.
+
+## Prerequisites
+
+- **Azure Subscription:** To use Azure services, including Azure Monitor, you'll need a subscription. If you do not have an existing Azure account, you may sign up for a [free trial](https://azure.microsoft.com/free/dotnet/) or use your [Visual Studio Subscription](https://visualstudio.microsoft.com/subscriptions/) benefits when you [create an account](https://azure.microsoft.com/account).
+- **Azure Application Insights Connection String:** To send telemetry data to the monitoring service you'll need a connection string from Azure Application Insights. If you are not familiar with creating Azure resources, you may wish to follow the step-by-step guide for [Create an Application Insights resource](https://learn.microsoft.com/azure/azure-monitor/app/create-new-resource) and [copy the connection string](https://learn.microsoft.com/azure/azure-monitor/app/sdk-connection-string?tabs=net#find-your-connection-string).
+- **ASP.NET Core App:** An ASP.NET Core application is required. You can either bring your own app or follow [Get started with ASP.NET Core MVC](https://learn.microsoft.com/aspnet/core/tutorials/first-mvc-app/start-mvc) to create a new one.
+
+## Installation
+
+Install the Microsoft OpenTelemetry Distro NuGet package. This single package includes the Azure Monitor exporter, auto-instrumentation for supported frameworks, resource detectors, and standard OpenTelemetry libraries.
+
+```xml
+<PackageReference Include="Microsoft.OpenTelemetry" Version="<latest>" />
+```
+
+> **Note:** Add a `nuget.config` in your project root if the package is not available on the public NuGet feed. Check the [README](../README.md) for feed configuration.
+
+## Choosing the right OpenTelemetry builder
+
+.NET offers two ways to initialize OpenTelemetry. Choose the one that fits your application:
+
+| Approach | DI/Host Integration | Multi-signal | Lifecycle | Best For |
+|---|---|---|---|---|
+| `builder.UseMicrosoftOpenTelemetry()` | ✅ Yes | ✅ Yes | Auto-managed | ASP.NET Core, Worker Services |
+| `OpenTelemetrySdk.Create()` | ❌ No | ✅ Yes | Manual (`using`) | Console apps, background tools, non-hosted apps |
+
+> **Recommendation from OpenTelemetry:** `OpenTelemetrySdk.Create()` is the recommended approach for non-hosted applications. It provides a unified, multi-signal setup under a single disposable boundary.
+
+## Configuration
+
+### Host-integrated (ASP.NET Core / Worker Services) — recommended
+
+In `Program.cs`, call `UseMicrosoftOpenTelemetry()` to enable observability with Azure Monitor:
+
+```csharp
+using Microsoft.OpenTelemetry;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+
+var app = builder.Build();
+app.Run();
+```
+
+The connection string is auto-detected from the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable. To set it explicitly:
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+});
+```
+
+If you need to add your own application-specific activity sources, use the longer form:
+
+```csharp
+using Microsoft.OpenTelemetry;
+
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor;
+    })
+    .WithTracing(tracing => tracing
+        .AddSource("MyCompany.MyProduct.MyLibrary"));
+```
+
+> ⚠️ **Note:** When `Exporters` is not explicitly set, Azure Monitor is auto-detected if a connection string is available (via code, environment variable, or `IConfiguration`). Setting `Exporters` explicitly overrides auto-detection.
+
+### Non-hosted (Console apps, background tools) — `OpenTelemetrySdk.Create()`
+
+For console applications and non-hosted scenarios that don't use the .NET Generic Host, use `OpenTelemetrySdk.Create()` with the distro's `UseMicrosoftOpenTelemetry()` extension:
+
+```csharp
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor;
+        o.AzureMonitor.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+    });
+});
+
+// Your application logic here — all telemetry is captured automatically.
+
+// Keep the SDK alive for the lifetime of your application.
+// Dispose only at shutdown — this flushes pending telemetry and shuts down all providers.
+sdk.Dispose();
+```
+
+> **Important:** Do not dispose the SDK until your application is shutting down. Disposing it early (e.g., via a `using` block that exits too soon) stops all telemetry collection and export — you will lose data.
+
+> **Note:** `UseMicrosoftOpenTelemetry()` works on any `IOpenTelemetryBuilder` — including the one provided by `OpenTelemetrySdk.Create()`. This gives you the same auto-instrumentation, resource detectors, and exporter configuration as the hosted approach.
+
+You can also chain additional custom sources after the distro call:
+
+```csharp
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor;
+    })
+    .WithTracing(tracing => tracing
+        .AddSource("MyCompany.MyApp.CustomSource"));
+});
+```
+
+> **Note:** `OpenTelemetrySdk.Create()` manages the lifecycle of all providers. Dispose the returned object at application shutdown to flush pending telemetry.
+
+### Export targets
+
+The `ExportTarget` flags enum controls where telemetry is sent:
+
+| Value | Description |
+|---|---|
+| `ExportTarget.None` | No exporters enabled. Distro-managed telemetry pipelines are disabled unless you configure your own providers separately. |
+| `ExportTarget.Console` | Console output (development only). |
+| `ExportTarget.Agent365` | Agent365 observability platform. |
+| `ExportTarget.AzureMonitor` | Application Insights (auto-detected via `APPLICATIONINSIGHTS_CONNECTION_STRING`). |
+| `ExportTarget.Otlp` | OpenTelemetry Protocol export. |
+
+Combine targets with `|`: `ExportTarget.AzureMonitor | ExportTarget.Console`.
+
+### Azure Monitor options
+
+Configure Azure Monitor behavior via `o.AzureMonitor`:
+
+| Property | Type | Description | Default |
+|---|---|---|---|
+| `ConnectionString` | `string?` | Azure Application Insights connection string. Auto-detected from `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable. | `null` |
+| `Credential` | `TokenCredential?` | AAD token credential for authentication. When not set, uses instrumentation key from connection string. | `null` |
+| `SamplingRatio` | `float` | Ratio of telemetry to sample (0.0–1.0). | `1.0` |
+| `TracesPerSecond` | `double?` | Rate limit for traces per second. Takes precedence over `SamplingRatio` when set. | `5.0` |
+| `EnableLiveMetrics` | `bool` | Enable [Live Metrics](https://learn.microsoft.com/azure/azure-monitor/app/live-stream) for real-time monitoring. | `true` |
+| `EnableStandardMetrics` | `bool` | Enable Application Insights standard metrics collection. | `true` |
+| `EnablePerfCounters` | `bool` | Enable performance counter collection. | `true` |
+| `EnableTraceBasedLogsSampler` | `bool` | When enabled, only logs associated with sampled traces are exported. Logs without trace context are always exported. | `true` |
+| `DisableOfflineStorage` | `bool` | Disable offline storage for telemetry. | `false` |
+| `StorageDirectory` | `string?` | Override the default directory for offline storage. | `null` |
+
+### Instrumentation options
+
+Control which auto-instrumentation libraries are enabled via `o.Instrumentation`. All default to `true`:
+
+| Property | Description |
+|---|---|
+| `EnableTracing` | Enable trace signal pipeline. |
+| `EnableMetrics` | Enable metrics signal pipeline. |
+| `EnableLogging` | Enable logging signal pipeline. |
+| `EnableAspNetCoreInstrumentation` | ASP.NET Core request/response traces. |
+| `EnableHttpClientInstrumentation` | HttpClient outgoing request traces. |
+| `EnableSqlClientInstrumentation` | SQL client query traces. |
+| `EnableAzureSdkInstrumentation` | Azure SDK client traces. |
+| `EnableOpenAIInstrumentation` | OpenAI / Azure OpenAI call traces. |
+| `EnableSemanticKernelInstrumentation` | Semantic Kernel operation traces. |
+| `EnableAgentFrameworkInstrumentation` | Agent Framework operation traces. |
+| `EnableAgent365Instrumentation` | Agent365 manual scopes (InvokeAgent, ExecuteTool, etc.). |
+
+Example — disable SQL instrumentation:
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.Instrumentation.EnableSqlClientInstrumentation = false;
+});
+```
+
+## Authenticate the client
+
+Azure Active Directory (AAD) authentication is an optional feature. To enable AAD authentication, set the `Credential` property in `AzureMonitorOptions`. This is made easy with the [Azure Identity library](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/identity/Azure.Identity/README.md):
+
+```csharp
+using Azure.Identity;
+
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+    o.AzureMonitor.Credential = new DefaultAzureCredential();
+});
+```
+
+With this configuration, the distro uses the credentials of the currently logged-in user or of the service principal to authenticate and send telemetry data to Azure Monitor.
+
+If `Credential` is not set, the instrumentation key from the connection string is used instead.
+
+## Advanced configuration
+
+### Customizing sampling behavior
+
+The distro uses **rate-limited sampling** by default, collecting up to **5.0 traces per second**.
+
+**Option 1: Set the rate-limited sampler to a configured traces per second**
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.AzureMonitor.TracesPerSecond = 10.0; // Collect up to 10 traces per second
+});
+```
+
+**Option 2: Switch to percentage-based sampling**
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.AzureMonitor.SamplingRatio = 0.5F; // Sample 50% of traces
+    o.AzureMonitor.TracesPerSecond = null; // Disable rate-limited sampling
+});
+```
+
+**Option 3: Use environment variables**
+
+For rate-limited sampling:
+
+```
+OTEL_TRACES_SAMPLER=microsoft.rate_limited
+OTEL_TRACES_SAMPLER_ARG=10
+```
+
+For percentage-based sampling:
+
+```
+OTEL_TRACES_SAMPLER=microsoft.fixed_percentage
+OTEL_TRACES_SAMPLER_ARG=0.5
+```
+
+> **Note:** When both `TracesPerSecond` and `SamplingRatio` are configured, `TracesPerSecond` takes precedence.
+
+### Adding custom ActivitySource to traces
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+builder.Services.ConfigureOpenTelemetryTracerProvider((sp, builder) =>
+    builder.AddSource("MyCompany.MyProduct.MyLibrary"));
+```
+
+### Adding custom Meter to metrics
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+builder.Services.ConfigureOpenTelemetryMeterProvider((sp, builder) =>
+    builder.AddMeter("MyCompany.MyProduct.MyLibrary"));
+```
+
+### Adding additional instrumentation
+
+If you need to instrument a library or framework that isn't included in the distro, add additional instrumentation using OpenTelemetry instrumentation packages. For example, to add instrumentation for gRPC clients, install [OpenTelemetry.Instrumentation.GrpcNetClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.GrpcNetClient/):
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+builder.Services.ConfigureOpenTelemetryTracerProvider((sp, builder) =>
+    builder.AddGrpcClientInstrumentation());
+```
+
+### Disable Live Metrics
+
+To disable the Live Metrics feature:
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.AzureMonitor.EnableLiveMetrics = false;
+});
+```
+
+### Drop a metrics instrument
+
+To exclude specific instruments from being collected:
+
+```csharp
+builder.Services.ConfigureOpenTelemetryMeterProvider(metrics =>
+    metrics.AddView(instrumentName: "http.server.active_requests", MetricStreamConfiguration.Drop));
+```
+
+Refer to [Drop an instrument](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#drop-an-instrument) for more examples.
+
+### Customizing instrumentation libraries
+
+The distro includes .NET OpenTelemetry instrumentation for [ASP.NET Core](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore/), [HttpClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http/), and [SQLClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.SqlClient). You can customize these or manually add additional instrumentation using the OpenTelemetry API.
+
+#### Customizing AspNetCoreTraceInstrumentationOptions
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+builder.Services.Configure<AspNetCoreTraceInstrumentationOptions>(options =>
+{
+    options.RecordException = true;
+    options.Filter = (httpContext) =>
+    {
+        // only collect telemetry about HTTP GET requests
+        return HttpMethods.IsGet(httpContext.Request.Method);
+    };
+});
+```
+
+#### Customizing HttpClientTraceInstrumentationOptions
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+builder.Services.Configure<HttpClientTraceInstrumentationOptions>(options =>
+{
+    options.RecordException = true;
+    options.FilterHttpRequestMessage = (httpRequestMessage) =>
+    {
+        // only collect telemetry about HTTP GET requests
+        return HttpMethods.IsGet(httpRequestMessage.Method.Method);
+    };
+});
+```
+
+#### Customizing SqlClientInstrumentationOptions
+
+While the [SQLClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.SqlClient) instrumentation is still in beta, it is vendored within the package. Once it reaches a stable release, it will be included as a standard package reference. Until then, for customization, manually add the package reference:
+
+```
+dotnet add package --prerelease OpenTelemetry.Instrumentation.SqlClient
+```
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor;
+    })
+    .WithTracing(tracing =>
+    {
+        tracing.AddSqlClientInstrumentation(options =>
+        {
+            options.SetDbStatementForStoredProcedure = false;
+        });
+    });
+```
+
+## Environment variables
+
+The distro recognizes these environment variables for Azure Monitor:
+
+| Variable | Description |
+|---|---|
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Azure Monitor connection string. Auto-detected for `ExportTarget.AzureMonitor`. |
+| `OTEL_TRACES_SAMPLER` | OpenTelemetry trace sampler configuration (`microsoft.rate_limited` or `microsoft.fixed_percentage`). |
+| `OTEL_TRACES_SAMPLER_ARG` | OpenTelemetry trace sampler argument (rate or ratio value). |
+
+## Examples
+
+### Log scopes
+
+Log [scopes](https://learn.microsoft.com/dotnet/core/extensions/logging#log-scopes) allow you to add additional properties to the logs generated by your application. Although the distro does support scopes, this feature is off by default in OpenTelemetry. To leverage log scopes, you must explicitly enable them:
+
+```csharp
+builder.Services.Configure<OpenTelemetryLoggerOptions>((loggingOptions) =>
+{
+    loggingOptions.IncludeScopes = true;
+});
+```
+
+When using `ILogger` scopes, use a `List<KeyValuePair<string, object?>>` for best performance. All logs written within the context of the scope will include the specified information. Azure Monitor adds these scope values to the Log's CustomProperties:
+
+```csharp
+List<KeyValuePair<string, object?>> scope =
+[
+    new("scopeKey", "scopeValue")
+];
+
+using (logger.BeginScope(scope))
+{
+    logger.LogInformation("Example message.");
+}
+```
+
+In scenarios involving multiple scopes or a single scope with multiple key-value pairs, if duplicate keys are present, only the first occurrence from the outermost scope will be recorded. When the same key is used both within a logging scope and directly in the log statement, the value in the log message template takes precedence.
+
+### Custom events
+
+Azure Monitor relies on OpenTelemetry's Log Signal to create CustomEvents. To send a CustomEvent via ILogger, include the `"microsoft.custom_event.name"` attribute in the message template:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+
+var app = builder.Build();
+
+app.Logger.LogInformation("{microsoft.custom_event.name} {key1} {key2}", "MyCustomEventName", "value1", "value2");
+```
+
+This generates a CustomEvent structured like this:
+
+```json
+{
+    "name": "Event",
+    "data": {
+        "baseType": "EventData",
+        "baseData": {
+            "name": "MyCustomEventName",
+            "properties": {
+                "key1": "value1",
+                "key2": "value2"
+            }
+        }
+    }
+}
+```
+
+> **Note:** Severity and CategoryName are not recorded in the CustomEvent. Any `ILogger.Log` method can be used. Users should take care to select a severity that is not filtered out by their configuration.
+
+## Validate locally
+
+### Console + Azure Monitor (validate locally and remotely)
+
+To validate telemetry locally while also sending to Azure Monitor:
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Console | ExportTarget.AzureMonitor;
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+});
+```
+
+```powershell
+$env:ASPNETCORE_ENVIRONMENT='Development'
+dotnet run
+```
+
+In the console output, look for spans related to your application:
+
+```
+Activity.DisplayName:        GET /api/...
+Activity.Source:              Microsoft.AspNetCore
+```
+
+> **Note:** The console exporter shows **all** spans — including HTTP, ASP.NET Core, and Azure SDK activity. You can filter console output by `Activity.Source` to focus on specific sources.
+
+## Troubleshooting
+
+The distro uses EventSource for its own internal logging. The logs are available to any EventListener by opting into the source named `OpenTelemetry-AzureMonitor-Exporter`.
+
+OpenTelemetry also provides its own [self-diagnostics feature](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/README.md#troubleshooting) to collect internal logs.
+
+### Missing request telemetry
+
+If an app has a reference to the [OpenTelemetry.Instrumentation.AspNetCore](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore) package, it could be missing request telemetry. To resolve:
+
+- Remove the reference to the `OpenTelemetry.Instrumentation.AspNetCore` package, **or**
+- Add `AddAspNetCoreInstrumentation` to the TracerProvider configuration as per the [OpenTelemetry documentation](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore).
+
+### Missing dependency telemetry
+
+If an app references the [OpenTelemetry.Instrumentation.Http](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http) or [OpenTelemetry.Instrumentation.SqlClient](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.SqlClient) packages, it might be missing dependency telemetry. To resolve:
+
+- Remove the respective package references, **or**
+- Add `AddHttpClientInstrumentation` or `AddSqlClientInstrumentation` to the TracerProvider configuration. See the OpenTelemetry documentation for [HTTP](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Http) and [SQL Client](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.SqlClient).
+
+> **Note:** If all telemetries are missing or if the above troubleshooting steps do not help, please collect [self-diagnostics logs](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/README.md#troubleshooting).

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,0 +1,468 @@
+# Customizing the Microsoft OpenTelemetry Distro (.NET)
+
+> **Advanced guide** — covers resource configuration, additional instrumentation, trace enrichment & filtering, and OTLP exporter tuning beyond the defaults provided by `UseMicrosoftOpenTelemetry()`.
+
+The `Microsoft.OpenTelemetry` distro auto-configures traces, metrics, and logs with sensible defaults. This guide shows how to extend and customize that configuration without losing the built-in behavior.
+
+## Table of contents
+
+- [Configuring the resource](#configuring-the-resource)
+- [Adding custom ActivitySources and Meters](#adding-custom-activitysources-and-meters)
+- [Adding additional instrumentation](#adding-additional-instrumentation)
+- [Enrichment and filtering](#enrichment-and-filtering)
+- [OTLP exporter configuration](#otlp-exporter-configuration)
+- [Environment variables reference](#environment-variables-reference)
+
+---
+
+## Configuring the resource
+
+The distro auto-detects Azure resource attributes (App Service, VM, Container Apps) and sets the distro name. You can add your own resource attributes — for example, a service name — using the standard OpenTelemetry API.
+
+### Hosted (ASP.NET Core / Worker Services)
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+
+builder.Services.ConfigureOpenTelemetryTracerProvider((sp, tracerBuilder) =>
+    tracerBuilder.ConfigureResource(r => r.AddService("my-service", serviceVersion: "1.0.0")));
+```
+
+Or using `AddOpenTelemetry()` chaining:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor;
+    })
+    .ConfigureResource(r => r
+        .AddService("my-service", serviceVersion: "1.0.0")
+        .AddAttributes(new Dictionary<string, object>
+        {
+            ["deployment.environment"] = "production",
+            ["team.name"] = "platform"
+        }));
+```
+
+### Non-hosted (Console apps)
+
+```csharp
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.ConfigureResource(r => r
+        .AddService("my-console-tool", serviceVersion: "1.0.0")
+        .AddAttributes(new Dictionary<string, object>
+        {
+            ["deployment.environment"] = "staging"
+        }));
+
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor;
+    });
+});
+
+// Your application logic here.
+// Dispose the SDK only at application shutdown.
+```
+
+> **Note:** `ConfigureResource()` is additive — your attributes are merged with the distro's auto-detected resource attributes.
+
+### Resource via environment variables
+
+You can also set resource attributes without code changes:
+
+```powershell
+$env:OTEL_SERVICE_NAME = "my-service"
+$env:OTEL_RESOURCE_ATTRIBUTES = "deployment.environment=production,team.name=platform"
+```
+
+---
+
+## Adding custom ActivitySources and Meters
+
+The distro auto-registers activity sources for Agent Framework, Semantic Kernel, OpenAI, and Azure SDK. To capture telemetry from your own custom sources, register them alongside the distro.
+
+### Custom ActivitySource
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+
+builder.Services.ConfigureOpenTelemetryTracerProvider((sp, tracerBuilder) =>
+    tracerBuilder.AddSource("MyCompany.MyProduct.MyLibrary"));
+```
+
+Then emit traces from your code:
+
+```csharp
+using System.Diagnostics;
+
+private static readonly ActivitySource MySource = new("MyCompany.MyProduct.MyLibrary");
+
+public void DoWork()
+{
+    using var activity = MySource.StartActivity("DoWork");
+    activity?.SetTag("work.item.id", itemId);
+    // ... your logic
+}
+```
+
+### Custom Meter
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+
+builder.Services.ConfigureOpenTelemetryMeterProvider((sp, meterBuilder) =>
+    meterBuilder.AddMeter("MyCompany.MyProduct.MyLibrary"));
+```
+
+---
+
+## Adding additional instrumentation
+
+The distro includes instrumentation for ASP.NET Core, HttpClient, SQL Client, and Azure SDK. If you need instrumentation for additional libraries, install the corresponding OpenTelemetry package and register it.
+
+### gRPC client instrumentation
+
+```bash
+dotnet add package OpenTelemetry.Instrumentation.GrpcNetClient
+```
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+
+builder.Services.ConfigureOpenTelemetryTracerProvider((sp, tracerBuilder) =>
+    tracerBuilder.AddGrpcClientInstrumentation());
+```
+
+### Entity Framework Core instrumentation
+
+```bash
+dotnet add package OpenTelemetry.Instrumentation.EntityFrameworkCore
+```
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+
+builder.Services.ConfigureOpenTelemetryTracerProvider((sp, tracerBuilder) =>
+    tracerBuilder.AddEntityFrameworkCoreInstrumentation());
+```
+
+### Disabling built-in instrumentation
+
+To turn off instrumentation the distro registers by default, use `InstrumentationOptions`:
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+    o.Instrumentation.EnableSqlClientInstrumentation = false;
+    o.Instrumentation.EnableHttpClientInstrumentation = false;
+});
+```
+
+See the [Azure Monitor Getting Started](azure-monitor-getting-started.md#instrumentation-options) guide for the full list of toggles.
+
+---
+
+## Enrichment and filtering
+
+The distro's built-in instrumentation libraries support enrichment (adding custom tags to spans) and filtering (suppressing unwanted telemetry). Use `builder.Services.Configure<T>()` to customize after calling `UseMicrosoftOpenTelemetry()`.
+
+### ASP.NET Core trace enrichment and filtering
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor;
+});
+
+builder.Services.Configure<AspNetCoreTraceInstrumentationOptions>(options =>
+{
+    options.RecordException = true;
+
+    // Filter: exclude health check endpoints from tracing
+    options.Filter = context =>
+        !context.Request.Path.StartsWithSegments("/health")
+        && !context.Request.Path.StartsWithSegments("/alive");
+
+    // Enrich: add custom tags from the incoming request
+    options.EnrichWithHttpRequest = (activity, request) =>
+    {
+        activity.SetTag("http.request.body.size", request.ContentLength);
+        activity.SetTag("user_agent", request.Headers.UserAgent.ToString());
+    };
+
+    // Enrich: add custom tags from the response
+    options.EnrichWithHttpResponse = (activity, response) =>
+    {
+        activity.SetTag("http.response.body.size", response.ContentLength);
+    };
+});
+```
+
+### HttpClient trace enrichment and filtering
+
+```csharp
+builder.Services.Configure<HttpClientTraceInstrumentationOptions>(options =>
+{
+    options.RecordException = true;
+
+    // Enrich: add custom tags from outgoing requests
+    options.EnrichWithHttpRequestMessage = (activity, request) =>
+    {
+        activity.SetTag("http.request.method", request.Method.ToString());
+        activity.SetTag("http.request.host", request.RequestUri?.Host);
+    };
+
+    // Enrich: add custom tags from responses
+    options.EnrichWithHttpResponseMessage = (activity, response) =>
+    {
+        activity.SetTag("http.response.status_code", (int)response.StatusCode);
+
+        var headerList = response.Content?.Headers?
+            .Select(h => $"{h.Key}={string.Join(",", h.Value)}")
+            .ToArray();
+
+        if (headerList is { Length: > 0 })
+        {
+            activity.SetTag("http.response.headers", headerList);
+        }
+    };
+
+    // Filter: suppress telemetry for health check requests
+    options.FilterHttpRequestMessage = request =>
+        !request.RequestUri?.AbsolutePath.Contains("health", StringComparison.OrdinalIgnoreCase) ?? true;
+});
+```
+
+### SQL Client customization
+
+While the SQL Client instrumentation is still in beta, it is vendored within the distro. For customization, manually add the package reference:
+
+```bash
+dotnet add package --prerelease OpenTelemetry.Instrumentation.SqlClient
+```
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor;
+    })
+    .WithTracing(tracing =>
+    {
+        tracing.AddSqlClientInstrumentation(options =>
+        {
+            options.SetDbStatementForStoredProcedure = false;
+        });
+    });
+```
+
+### Dropping specific metrics instruments
+
+To exclude specific instruments from being collected:
+
+```csharp
+builder.Services.ConfigureOpenTelemetryMeterProvider(metrics =>
+    metrics.AddView(instrumentName: "http.server.active_requests", MetricStreamConfiguration.Drop));
+```
+
+Refer to [Drop an instrument](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#drop-an-instrument) for more examples.
+
+---
+
+## OTLP exporter configuration
+
+When using `ExportTarget.Otlp`, the distro registers the OTLP exporter with default settings. You can customize the exporter's endpoint, protocol, headers, and other options using `builder.Services.Configure<OtlpExporterOptions>()` or environment variables.
+
+### Configure via code
+
+```csharp
+using OpenTelemetry.Exporter;
+
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Otlp;
+});
+
+builder.Services.Configure<OtlpExporterOptions>(otlp =>
+{
+    otlp.Endpoint = new Uri("http://localhost:4317");
+    otlp.Protocol = OtlpExportProtocol.Grpc;
+    otlp.Headers = "x-api-key=my-secret-key";
+    otlp.TimeoutMilliseconds = 10000;
+});
+```
+
+### Configure via `appsettings.json`
+
+```csharp
+builder.Services.Configure<OtlpExporterOptions>(
+    builder.Configuration.GetSection("OpenTelemetry:Otlp"));
+```
+
+```json
+{
+  "OpenTelemetry": {
+    "Otlp": {
+      "Endpoint": "http://localhost:4317",
+      "Protocol": "grpc",
+      "Headers": "x-api-key=my-secret-key",
+      "TimeoutMilliseconds": 10000
+    }
+  }
+}
+```
+
+### OtlpExporterOptions reference
+
+| Property | Type | Description | Default |
+|---|---|---|---|
+| `Endpoint` | `Uri` | Target endpoint for the exporter. | `localhost:4317` (gRPC) or `localhost:4318` (HTTP) |
+| `Protocol` | `OtlpExportProtocol` | Transport protocol: `Grpc` or `HttpProtobuf`. | `Grpc` |
+| `Headers` | `string?` | Optional headers sent with each request (comma-separated `key=value` pairs). | `null` |
+| `TimeoutMilliseconds` | `int` | Maximum time to wait for the backend to process a batch. | `10000` |
+| `HttpClientFactory` | `Func<HttpClient>?` | Factory for the `HttpClient` used with `HttpProtobuf` protocol. | `null` |
+
+> **Note:** When using `OtlpExportProtocol.HttpProtobuf`, the full URL must include the signal-specific path (e.g., `http://localhost:4318/v1/traces`).
+
+### Per-signal OTLP configuration
+
+The `OtlpExporterOptions` class is shared across all signals. To configure different settings per signal, use named options:
+
+```csharp
+builder.Services.Configure<OtlpExporterOptions>("tracing",
+    builder.Configuration.GetSection("OpenTelemetry:Tracing:Otlp"));
+builder.Services.Configure<OtlpExporterOptions>("metrics",
+    builder.Configuration.GetSection("OpenTelemetry:Metrics:Otlp"));
+builder.Services.Configure<OtlpExporterOptions>("logging",
+    builder.Configuration.GetSection("OpenTelemetry:Logging:Otlp"));
+```
+
+### Configuring metric reader options
+
+Control the metrics export interval and temporality preference:
+
+```csharp
+builder.Services.Configure<MetricReaderOptions>(o =>
+{
+    o.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+    o.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 10_000;
+});
+```
+
+### Non-hosted (Console apps)
+
+For console apps, configure OTLP using environment variables (see below) or pass options inline:
+
+```csharp
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Otlp;
+    });
+});
+
+// Environment variable OTEL_EXPORTER_OTLP_ENDPOINT controls the endpoint.
+// Dispose the SDK only at application shutdown.
+```
+
+---
+
+## Environment variables reference
+
+The OTLP exporter supports the standard [OpenTelemetry environment variables](https://opentelemetry.io/docs/specs/otel/protocol/exporter/). These are read through `IConfiguration`, so they can also be set in `appsettings.json` or on the command line.
+
+> **Note:** Code-based configuration (`OtlpExporterOptions` setters) takes precedence over environment variables.
+
+### All signals
+
+| Environment variable | `OtlpExporterOptions` property | Description |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `Endpoint` | Target endpoint URL |
+| `OTEL_EXPORTER_OTLP_HEADERS` | `Headers` | Request headers (`key=value` pairs) |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | `TimeoutMilliseconds` | Export timeout in milliseconds |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `Protocol` | `grpc` or `http/protobuf` |
+
+### Signal-specific endpoint overrides
+
+| Environment variable | Signal |
+|---|---|
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Traces |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Metrics |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Logs |
+
+Signal-specific headers, timeout, and protocol overrides follow the same pattern (e.g., `OTEL_EXPORTER_OTLP_TRACES_HEADERS`).
+
+### Batch processor (traces)
+
+| Environment variable | Description |
+|---|---|
+| `OTEL_BSP_SCHEDULE_DELAY` | Delay between batch exports (ms) |
+| `OTEL_BSP_EXPORT_TIMEOUT` | Export timeout (ms) |
+| `OTEL_BSP_MAX_QUEUE_SIZE` | Maximum queue size |
+| `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | Maximum batch size |
+
+### Batch processor (logs)
+
+| Environment variable | Description |
+|---|---|
+| `OTEL_BLRP_SCHEDULE_DELAY` | Delay between batch exports (ms) |
+| `OTEL_BLRP_EXPORT_TIMEOUT` | Export timeout (ms) |
+| `OTEL_BLRP_MAX_QUEUE_SIZE` | Maximum queue size |
+| `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` | Maximum batch size |
+
+### Periodic metric reader
+
+| Environment variable | Description |
+|---|---|
+| `OTEL_METRIC_EXPORT_INTERVAL` | Export interval (ms) |
+| `OTEL_METRIC_EXPORT_TIMEOUT` | Export timeout (ms) |
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | Temporality: `cumulative` (default) or `delta` |
+| `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION` | `explicit_bucket_histogram` (default) or `base2_exponential_bucket_histogram` |
+
+### mTLS authentication (.NET 8.0+)
+
+| Environment variable | Description |
+|---|---|
+| `OTEL_EXPORTER_OTLP_CERTIFICATE` | Path to CA certificate file (PEM) |
+| `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` | Path to client certificate file (PEM) |
+| `OTEL_EXPORTER_OTLP_CLIENT_KEY` | Path to client private key file (PEM) |
+
+### Resource and sampler
+
+| Environment variable | Description |
+|---|---|
+| `OTEL_SERVICE_NAME` | Sets the `service.name` resource attribute |
+| `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated `key=value` resource attributes |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Azure Monitor connection string (auto-detected) |
+| `OTEL_TRACES_SAMPLER` | Trace sampler (`microsoft.rate_limited` or `microsoft.fixed_percentage`) |
+| `OTEL_TRACES_SAMPLER_ARG` | Sampler argument (rate or ratio value) |
+
+### Example: sending OTLP to Aspire Dashboard
+
+```powershell
+$env:OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
+$env:OTEL_EXPORTER_OTLP_PROTOCOL = "grpc"
+dotnet run
+```
+
+Navigate to [http://localhost:18888](http://localhost:18888) to explore traces, logs, and metrics in the Aspire Dashboard.

--- a/docs/testing-agent-framework.md
+++ b/docs/testing-agent-framework.md
@@ -151,7 +151,7 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 // --- OTel setup (non-DI) ---
-using var sdk = OpenTelemetrySdk.Create(otel =>
+var sdk = OpenTelemetrySdk.Create(otel =>
 {
     otel.ConfigureResource(r => r.AddService("my-agent-app"));
 


### PR DESCRIPTION
## Summary

Adds three new documentation articles and updates the README:

### New docs
- **docs/azure-monitor-getting-started.md** - Standalone guide for Azure Monitor observability (hosted + non-hosted patterns, options reference, sampling, auth, custom events, log scopes)
- **docs/agent-framework-getting-started.md** - Guide for instrumenting Microsoft Agent Framework agents with Azure Monitor, OTLP, and Aspire Dashboard
- **docs/customization.md** - Advanced guide covering resource configuration, trace enrichment and filtering, additional instrumentation, and OTLP exporter tuning with full environment variables reference

### README updates
- Cleaned up incorrect info (removed references to internal-only APIs and non-existent OtlpEndpoint property)
- Added scenario-based quick starts (Azure Monitor, Agent Framework, Agent365)
- Added links to all new documentation articles

### SDK disposal fix
- Removed using var from all OpenTelemetrySdk.Create() examples across docs to prevent premature SDK disposal causing data loss
- Added explicit lifecycle guidance and warnings