### PR TITLE
Add Console demo + fix Azure Monitor exporter for non-hosted apps

### DIFF
--- a/Microsoft.OpenTelemetry.slnx
+++ b/Microsoft.OpenTelemetry.slnx
@@ -4,5 +4,6 @@
   <Project Path="examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Microsoft.OpenTelemetry.AgentFramework.Demo.csproj" />
   <Project Path="test/Microsoft.OpenTelemetry.Agent365.Tests/Microsoft.OpenTelemetry.Agent365.Tests.csproj" />
   <Project Path="test/Microsoft.OpenTelemetry.AzureMonitor.Tests/Microsoft.OpenTelemetry.AzureMonitor.Tests.csproj" />
+  <Project Path="examples/Microsoft.OpenTelemetry.Console.Demo/Microsoft.OpenTelemetry.Console.Demo.csproj" />
   <Project Path="src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj" />
 </Solution>

--- a/examples/Microsoft.OpenTelemetry.Console.Demo/Microsoft.OpenTelemetry.Console.Demo.csproj
+++ b/examples/Microsoft.OpenTelemetry.Console.Demo/Microsoft.OpenTelemetry.Console.Demo.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <UserSecretsId>console-demo-b842df34-390f-490d-9dc0-73909363ad17</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.OpenTelemetry\Microsoft.OpenTelemetry.csproj" />
+    <!-- Explicit refs needed for ProjectReference builds: Microsoft.Agents.Builder (PrivateAssets=all)
+         pulls in 10.x Microsoft.Extensions.* which conflict with the net8.0 shared framework.
+         Real NuGet consumers don't need these — PrivateAssets suppresses the transitive flow. -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Microsoft.OpenTelemetry.Console.Demo/Program.cs
+++ b/examples/Microsoft.OpenTelemetry.Console.Demo/Program.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// ────────────────────────────────────────────────────────────────────────────
+// Console Demo — OpenTelemetrySdk.Create() API
+//
+// Demonstrates using the Microsoft OpenTelemetry distro with the recommended
+// non-hosted approach: OpenTelemetrySdk.Create(). This provides a unified,
+// multi-signal setup under a single disposable boundary — no DI container
+// or host builder needed.
+//
+// Collects traces, metrics, and logs; exports to Console, OTLP, and
+// Azure Monitor (when APPLICATIONINSIGHTS_CONNECTION_STRING is set).
+// ────────────────────────────────────────────────────────────────────────────
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Logs;
+
+// ── Custom telemetry sources ──
+var activitySource = new ActivitySource("Demo.Console");
+var meter = new Meter("Demo.Console");
+var requestCounter = meter.CreateCounter<long>("demo.requests", description: "Number of demo requests processed");
+var latencyHistogram = meter.CreateHistogram<double>("demo.request.duration", "ms", "Request processing latency");
+
+// ── Create the SDK with the distro ──
+// OpenTelemetrySdk.Create() is the recommended approach for non-hosted apps.
+// It manages TracerProvider, MeterProvider, and LoggerFactory under one disposable.
+var sdk = OpenTelemetrySdk.Create(otel =>
+{
+    otel.UseMicrosoftOpenTelemetry(o =>
+    {
+        // Export to Console, OTLP, and Azure Monitor.
+        // Azure Monitor requires APPLICATIONINSIGHTS_CONNECTION_STRING env var.
+        o.Exporters = ExportTarget.Console | ExportTarget.Otlp | ExportTarget.AzureMonitor;
+        o.AzureMonitor.ConnectionString = "InstrumentationKey=66f50587-a821-4a96-8511-fa96e8f28fd7;IngestionEndpoint=https://westus2-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/;ApplicationId=b9fa6c07-f06f-414c-b222-f3207aab66cd";
+    })
+    .WithTracing(tracing => tracing.AddSource("Demo.Console"))
+    .WithMetrics(metrics => metrics.AddMeter("Demo.Console"));
+});
+
+// Get a logger from the SDK's built-in LoggerFactory
+var logger = sdk.GetLoggerFactory().CreateLogger("Demo.Console");
+
+Console.WriteLine("═══════════════════════════════════════════════════");
+Console.WriteLine("  Microsoft.OpenTelemetry Console Demo");
+Console.WriteLine("  (OpenTelemetrySdk.Create — non-hosted)");
+Console.WriteLine("═══════════════════════════════════════════════════");
+Console.WriteLine();
+
+// ── Generate telemetry ──
+for (int i = 1; i <= 3; i++)
+{
+    Console.WriteLine($"── Request {i} ──");
+
+    // Trace: create a span
+    using (var activity = activitySource.StartActivity($"ProcessRequest-{i}", ActivityKind.Server))
+    {
+        activity?.SetTag("request.id", i);
+        activity?.SetTag("request.type", "demo");
+
+        logger.LogInformation("Processing request {RequestId}", i);
+
+        // Child span: simulate a database call
+        var sw = Stopwatch.StartNew();
+        using (var dbActivity = activitySource.StartActivity("DatabaseQuery", ActivityKind.Client))
+        {
+            dbActivity?.SetTag("db.system", "sqlite");
+            dbActivity?.SetTag("db.statement", $"SELECT * FROM items WHERE id = {i}");
+            await Task.Delay(50 + Random.Shared.Next(100));
+        }
+
+        // Child span: simulate an HTTP call
+        using (var httpActivity = activitySource.StartActivity("ExternalApiCall", ActivityKind.Client))
+        {
+            httpActivity?.SetTag("http.method", "GET");
+            httpActivity?.SetTag("http.url", $"https://api.example.com/items/{i}");
+            httpActivity?.SetTag("http.status_code", 200);
+            await Task.Delay(30 + Random.Shared.Next(70));
+        }
+
+        sw.Stop();
+
+        // Metrics: record counters and histograms
+        requestCounter.Add(1, new KeyValuePair<string, object?>("request.type", "demo"));
+        latencyHistogram.Record(sw.Elapsed.TotalMilliseconds, new KeyValuePair<string, object?>("request.type", "demo"));
+
+        logger.LogInformation("Request {RequestId} completed in {Duration:F1}ms", i, sw.Elapsed.TotalMilliseconds);
+
+        if (i == 2)
+        {
+            // Simulate an error on request 2
+            activity?.SetStatus(ActivityStatusCode.Error, "Simulated error");
+            logger.LogError("Simulated error on request {RequestId}", i);
+        }
+    }
+
+    Console.WriteLine();
+}
+
+// ── Summary ──
+// ForceFlush ensures Azure Monitor's batch exporter sends all pending telemetry
+// before the process exits. Dispose alone may not wait long enough.
+sdk.TracerProvider?.ForceFlush(timeoutMilliseconds: 10000);
+sdk.LoggerProvider?.ForceFlush(timeoutMilliseconds: 10000);
+sdk.MeterProvider?.ForceFlush(timeoutMilliseconds: 10000);
+
+sdk.Dispose();
+Console.WriteLine("═══════════════════════════════════════════════════");
+Console.WriteLine("  Demo complete. Telemetry flushed.");
+Console.WriteLine("═══════════════════════════════════════════════════");
+Console.WriteLine();
+Console.WriteLine("Exporters configured:");
+Console.WriteLine("  • Console  — visible above");
+Console.WriteLine("  • OTLP     — set OTEL_EXPORTER_OTLP_ENDPOINT (default: http://localhost:4317)");
+Console.WriteLine("  • Azure Monitor — set APPLICATIONINSIGHTS_CONNECTION_STRING");
+Console.WriteLine();

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -259,6 +259,53 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             });
         }
 
+        // --- Non-hosted scenario support ---
+        // Azure Monitor's trace and log exporters are registered via IHostedService
+        // (ExporterRegistrationHostedService), which only starts in hosted apps.
+        // For non-hosted apps (e.g., OpenTelemetrySdk.Create()), we initialize them
+        // during MeterProvider build — by then TracerProvider and LoggerProvider are
+        // already built and cached as singletons, so resolving them is safe.
+        //
+        // We remove the IHostedService registration to prevent double-initialization
+        // in hosted apps (ExporterRegistrationHostedService.Initialize() is NOT
+        // idempotent — calling it twice adds duplicate exporters).
+        // Same pattern used by ApplicationInsights 3.x SDK (TelemetryConfiguration.StartHostedServices).
+        if (exporters.HasFlag(ExportTarget.AzureMonitor))
+        {
+            // Find and remove only the Azure Monitor ExporterRegistrationHostedService.
+            // Other IHostedService registrations (e.g., A365OnlyModeStartupLogger) must stay.
+            ServiceDescriptor? exporterServiceDescriptor = null;
+            for (int i = builder.Services.Count - 1; i >= 0; i--)
+            {
+                var descriptor = builder.Services[i];
+                if (descriptor.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService)
+                    && descriptor.ImplementationFactory != null)
+                {
+                    // Verify this is the Azure Monitor exporter registration, not an unrelated hosted service.
+                    var declaringType = descriptor.ImplementationFactory.Method.DeclaringType?.FullName ?? string.Empty;
+                    if (declaringType.Contains("Azure.Monitor") || declaringType.Contains("AzureMonitor"))
+                    {
+                        exporterServiceDescriptor = descriptor;
+                        builder.Services.RemoveAt(i);
+                        break;
+                    }
+                }
+            }
+
+            if (exporterServiceDescriptor != null)
+            {
+                var savedFactory = exporterServiceDescriptor.ImplementationFactory!;
+
+                // MeterProvider builds last (after Tracer and Logger), so both providers
+                // are available for the exporter to attach to.
+                builder.Services.ConfigureOpenTelemetryMeterProvider((sp, _) =>
+                {
+                    var service = (Microsoft.Extensions.Hosting.IHostedService)savedFactory(sp);
+                    service.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+                });
+            }
+        }
+
         return builder;
     }
 

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Microsoft.OpenTelemetry.Agent365.Tests.csproj
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Microsoft.OpenTelemetry.Agent365.Tests.csproj
@@ -7,11 +7,16 @@
     <IsTestProject>true</IsTestProject>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);SA1636;CS1591;CS1574;ASPDEPR004</NoWarn>
+    <NoWarn>$(NoWarn);SA1636;CS1591;CS1574;ASPDEPR004;MSB3277</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <!-- Force CPM pin for transitive vulnerability -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.Memory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/Microsoft.OpenTelemetry.AzureMonitor.Tests.csproj
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/Microsoft.OpenTelemetry.AzureMonitor.Tests.csproj
@@ -6,7 +6,7 @@
     <IsTestProject>true</IsTestProject>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);SA1636;CS1591;xUnit1012</NoWarn>
+    <NoWarn>$(NoWarn);SA1636;CS1591;xUnit1012;MSB3277</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/NonHostedExporterTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/NonHostedExporterTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#if NET
+
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
+using Xunit;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
+{
+    [Collection("EnvironmentVariableTests")]
+    public class NonHostedExporterTests
+    {
+        private const string TestConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+
+        [Fact]
+        public void AzureMonitor_ExporterHostedService_RemovedFromDI()
+        {
+            // When Azure Monitor is enabled, the ExporterRegistrationHostedService
+            // should be removed from IHostedService registrations to prevent
+            // double-initialization in hosted apps.
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.AzureMonitor;
+                    o.AzureMonitor.ConnectionString = TestConnectionString;
+                    o.AzureMonitor.DisableOfflineStorage = true;
+                    o.AzureMonitor.EnableLiveMetrics = false;
+                });
+
+            // The Azure Monitor ExporterRegistrationHostedService should have been
+            // removed from IHostedService registrations
+            var hostedServiceDescriptors = services
+                .Where(s => s.ServiceType == typeof(IHostedService))
+                .ToList();
+
+            // Should NOT contain any Azure Monitor exporter hosted service
+            foreach (var descriptor in hostedServiceDescriptors)
+            {
+                if (descriptor.ImplementationFactory != null)
+                {
+                    var declaringType = descriptor.ImplementationFactory.Method.DeclaringType?.FullName ?? string.Empty;
+                    Assert.DoesNotContain("ExporterRegistration", declaringType);
+                }
+            }
+        }
+
+        [Fact]
+        public void AzureMonitor_OtherHostedServices_NotRemoved()
+        {
+            // Other IHostedService registrations (like A365OnlyModeStartupLogger)
+            // should NOT be removed when Azure Monitor exporter service is removed.
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Console;
+                    o.AzureMonitor.ConnectionString = TestConnectionString;
+                    o.AzureMonitor.DisableOfflineStorage = true;
+                    o.AzureMonitor.EnableLiveMetrics = false;
+                });
+
+            // A365OnlyModeStartupLogger should still be registered
+            // (it's not Azure Monitor related)
+            var hostedServiceDescriptors = services
+                .Where(s => s.ServiceType == typeof(IHostedService))
+                .ToList();
+
+            // Should have at least one hosted service remaining (A365OnlyModeStartupLogger, etc.)
+            Assert.NotEmpty(hostedServiceDescriptors);
+        }
+
+        [Fact]
+        public void NoAzureMonitor_HostedServices_Untouched()
+        {
+            // When Azure Monitor is NOT enabled, no hosted services should be removed.
+            const string envVar = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+            var original = System.Environment.GetEnvironmentVariable(envVar);
+            try
+            {
+                System.Environment.SetEnvironmentVariable(envVar, null);
+
+                var services = new ServiceCollection();
+                services.AddOpenTelemetry()
+                    .UseMicrosoftOpenTelemetry(o =>
+                    {
+                        o.Exporters = ExportTarget.Console;
+                    });
+
+                // No Azure Monitor → no removal → all hosted services intact
+                var hostedServiceDescriptors = services
+                    .Where(s => s.ServiceType == typeof(IHostedService))
+                    .ToList();
+
+                // A365OnlyModeStartupLogger should be registered
+                Assert.NotEmpty(hostedServiceDescriptors);
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable(envVar, original);
+            }
+        }
+
+        [Fact]
+        public void AzureMonitor_MeterProviderCallback_Registered()
+        {
+            // When Azure Monitor is enabled and the hosted service is removed,
+            // a ConfigureOpenTelemetryMeterProvider callback should be registered
+            // to initialize the exporter during MeterProvider build.
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.AzureMonitor;
+                    o.AzureMonitor.ConnectionString = TestConnectionString;
+                    o.AzureMonitor.DisableOfflineStorage = true;
+                    o.AzureMonitor.EnableLiveMetrics = false;
+                });
+
+            // Verify MeterProvider configuration callbacks are registered
+            // (ConfigureOpenTelemetryMeterProvider adds IConfigureMeterProviderBuilder)
+            Assert.Contains(services, s =>
+                s.ServiceType.Name.Contains("IConfigureMeterProviderBuilder") ||
+                s.ServiceType.Name.Contains("MeterProviderBuilder"));
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Changes

### Console Demo (examples/Microsoft.OpenTelemetry.Console.Demo/)
- Non-hosted console app using \OpenTelemetrySdk.Create()\ (recommended non-DI path)
- Exports traces, metrics, and logs to Console, OTLP, and Azure Monitor
- Custom ActivitySource and Meter with demo spans and metrics
- Uses \sdk.GetLoggerFactory()\ for structured logging through OTel pipeline

### Fix: Azure Monitor trace/log exporters for non-hosted apps
- Azure Monitor's trace and log exporters are registered via \ExporterRegistrationHostedService\ (an \IHostedService\), which only starts when a host runs
- In non-hosted apps (\OpenTelemetrySdk.Create()\), the hosted service never starts and traces/logs are never exported to Azure Monitor (metrics work because they use a different registration path)
- Fix: The distro now removes the \IHostedService\ registration and invokes the exporter initialization during \MeterProvider\ build (which runs after TracerProvider and LoggerProvider are built)
- Safe for DI/hosted apps: the hosted service is removed from DI so the host has nothing to start — no duplicate exporters

### Build warning fixes
- Fix NU1903: explicit PackageReference for Microsoft.Bcl.Memory in test project
- Suppress MSB3277 IdentityModel version conflict in test projects
- Added Console.Demo to solution