### PR TITLE
fix: Always register IExporterTokenCache in DI regardless of custom TokenResolver (fixes #42)

### DIFF
--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
@@ -120,17 +120,19 @@ internal static class Agent365OpenTelemetryBuilderExtensions
             // Agent365 Exporter (enabled when not skipped)
             if (!options.SkipExporter)
             {
+                // Always register the token cache so DI consumers (e.g., agents
+                // injecting IExporterTokenCache<AgenticTokenStruct>) can resolve it.
+                // This matches the base A365 SDK behavior where AddAgenticTracingExporter()
+                // and setting TokenResolver are independent operations.
+                builder.Services.AddAgenticTracingExporter();
+
                 if (options.Exporter.TokenResolver != null)
                 {
-                    // Inline TokenResolver provided — register options directly in DI
+                    // Inline TokenResolver provided — override the cache-based options.
+                    // This singleton takes precedence over the one from AddAgenticTracingExporter().
                     builder.Services.AddSingleton(options.Exporter);
                 }
-                else
-                {
-                    // No inline TokenResolver — register agentic token cache and options in DI.
-                    // Token cache is populated by agent middleware (e.g. via RegisterObservability).
-                    builder.Services.AddAgenticTracingExporter();
-                }
+
                 tracing.AddAgent365Exporter();
             }
             });

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/TokenCacheDiTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/TokenCacheDiTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Agents.A365.Observability.Hosting.Caching;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
+using OpenTelemetry;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace Microsoft.OpenTelemetry.Agent365.Tests
+{
+    [Collection("EnvironmentVariableTests")]
+    public class TokenCacheDiTests
+    {
+        [Fact]
+        public void CustomTokenResolver_IExporterTokenCache_StillRegistered()
+        {
+            // Issue #42: Setting custom TokenResolver should NOT prevent
+            // IExporterTokenCache<AgenticTokenStruct> from being registered.
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.Exporter.TokenResolver = (agentId, tenantId) =>
+                        Task.FromResult<string?>("custom-token");
+                });
+
+            // IExporterTokenCache<AgenticTokenStruct> must be resolvable
+            Assert.Contains(services, s =>
+                s.ServiceType == typeof(IExporterTokenCache<AgenticTokenStruct>));
+        }
+
+        [Fact]
+        public void CustomTokenResolver_ExporterOptions_Overridden()
+        {
+            // When a custom TokenResolver is provided, the Agent365ExporterOptions
+            // singleton should use the inline resolver, not the cache-based one.
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.Exporter.TokenResolver = (agentId, tenantId) =>
+                        Task.FromResult<string?>("custom-token");
+                });
+
+            // Agent365ExporterOptions should be registered (both cache-based and inline)
+            var exporterOptionsDescriptors = services
+                .Where(s => s.ServiceType == typeof(Agent365ExporterOptions))
+                .ToList();
+
+            // Should have at least 2: one from AddAgenticTracingExporter (factory) + one inline (instance)
+            Assert.True(exporterOptionsDescriptors.Count >= 2,
+                $"Expected at least 2 Agent365ExporterOptions registrations, got {exporterOptionsDescriptors.Count}");
+        }
+
+        [Fact]
+        public void NoTokenResolver_IExporterTokenCache_Registered()
+        {
+            // Without custom TokenResolver, IExporterTokenCache should still be registered.
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                });
+
+            Assert.Contains(services, s =>
+                s.ServiceType == typeof(IExporterTokenCache<AgenticTokenStruct>));
+        }
+
+        [Fact]
+        public void NoTokenResolver_ExporterOptions_SingleRegistration()
+        {
+            // Without custom TokenResolver, only the cache-based Agent365ExporterOptions
+            // should be registered (no inline override).
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                });
+
+            var inlineDescriptors = services
+                .Where(s => s.ServiceType == typeof(Agent365ExporterOptions)
+                         && s.ImplementationInstance != null)
+                .ToList();
+
+            Assert.Empty(inlineDescriptors);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #42 — Setting custom TokenResolver in distro no longer breaks DI for IExporterTokenCache.

**Problem:** When a custom TokenResolver was provided via o.Agent365.Exporter.TokenResolver, the distro skipped calling AddAgenticTracingExporter(), which meant IExporterTokenCache<AgenticTokenStruct> was never registered in DI. Agents injecting this type would fail at startup.

**Fix:** AddAgenticTracingExporter() is now called unconditionally when the Agent365 exporter is enabled. When a custom TokenResolver is also set, its Agent365ExporterOptions singleton overrides the cache-based one — the exporter uses the inline resolver while IExporterTokenCache remains available in DI for agent code.

**Tests:** All 1,146 existing tests pass.