### PR TITLE
fix: Use conditional AssemblyInfo for InternalsVisibleTo signing key

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,5 +29,6 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(KeysRoot)\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <DefineConstants>$(DefineConstants);PUBLIC_RELEASE</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj
+++ b/src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj
@@ -35,11 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.OpenTelemetry.AzureMonitor.Tests" PublicKey="0024000004800000940000000602000000240000525341310004000001000100319b35b21a993df850846602dae9e86d8fbb0528a0ad488ecd6414db798996534381825f94f90d8b16b72a51c4e7e07cf66ff3293c1046c045fafc354cfcc15fc177c748111e4a8c5a34d3940e7f3789dd58a928add6160d6f9cc219680253dcea88a034e7d472de51d4989c7783e19343839273e0e63a43b99ab338149dd59f" />
-    <InternalsVisibleTo Include="Microsoft.OpenTelemetry.Agent365.Tests" PublicKey="0024000004800000940000000602000000240000525341310004000001000100319b35b21a993df850846602dae9e86d8fbb0528a0ad488ecd6414db798996534381825f94f90d8b16b72a51c4e7e07cf66ff3293c1046c045fafc354cfcc15fc177c748111e4a8c5a34d3940e7f3789dd58a928add6160d6f9cc219680253dcea88a034e7d472de51d4989c7783e19343839273e0e63a43b99ab338149dd59f" />
-  </ItemGroup>
-
-  <ItemGroup>
     <!-- OpenTelemetry core -->
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/src/Microsoft.OpenTelemetry/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.OpenTelemetry/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.OpenTelemetry.AzureMonitor.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.OpenTelemetry.Agent365.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
+
+internal static class AssemblyInfo
+{
+#if PUBLIC_RELEASE
+    // Public key from 35MSSharedLib1024.snk; assemblies are delay signed.
+    public const string PublicKey = "0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9";
+#else
+    // Public key from InternalKey.snk; assemblies are full signed.
+    public const string PublicKey = "0024000004800000940000000602000000240000525341310004000001000100319b35b21a993df850846602dae9e86d8fbb0528a0ad488ecd6414db798996534381825f94f90d8b16b72a51c4e7e07cf66ff3293c1046c045fafc354cfcc15fc177c748111e4a8c5a34d3940e7f3789dd58a928add6160d6f9cc219680253dcea88a034e7d472de51d4989c7783e19343839273e0e63a43b99ab338149dd59f";
+#endif
+}


### PR DESCRIPTION
CI Release builds with -p:PublicRelease=True use 35MSSharedLib1024.snk (delay-signed) while local dev builds use InternalKey.snk (full-signed). The InternalsVisibleTo attributes must reference the matching public key.

Use the same pattern as ApplicationInsights-dotnet: a Properties/AssemblyInfo.cs with #if PUBLIC_RELEASE to switch between keys. The PUBLIC_RELEASE constant is defined in Directory.Build.props when PublicRelease=True.

This fixes CS0281 (friend access denied) errors in CI for both Microsoft.OpenTelemetry.Agent365.Tests and
Microsoft.OpenTelemetry.AzureMonitor.Tests.