### PR TITLE
Exclude examples and test projects from NuGet packaging

### DIFF
--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Add Directory.Build.props with IsPackable=false to examples/ and test/ directories to prevent dotnet pack from producing .nupkg files for demo and test projects. Only the src/Microsoft.OpenTelemetry package should be published to NuGet.org.