### PR TITLE
build: Enable Source Link, deterministic builds, and symbol packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,17 @@
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)target\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
+  <!-- Source Link & deterministic builds -->
+  <PropertyGroup>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true' or '$(GITHUB_ACTIONS)' == 'true' or '$(CI)' == 'true' or '$(PublicRelease)' == 'True'">true</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>portable</DebugType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
   <!-- Strong-name signing -->
   <PropertyGroup>
     <KeysRoot>$(MSBuildThisFileDirectory).keys</KeysRoot>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Source Link -->
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+
     <!-- OpenTelemetry packages -->
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />

--- a/src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj
+++ b/src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj
@@ -30,6 +30,7 @@
   <!-- Public API tracking -->
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <AdditionalFiles Include=".publicApi\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include=".publicApi\PublicAPI.Unshipped.txt" />
   </ItemGroup>


### PR DESCRIPTION
- Add Deterministic, ContinuousIntegrationBuild, EmbedUntrackedSources, PublishRepositoryUrl, DebugType=portable, IncludeSymbols, SymbolPackageFormat=snupkg to Directory.Build.props
- Add Microsoft.SourceLink.GitHub package reference to main csproj
- Add Microsoft.SourceLink.GitHub 8.0.0 to Directory.Packages.props

Fixes NuGet Package Explorer health warnings:
  - Source Link: Missing Symbols
  - Deterministic: Non deterministic
  - Compiler Flags: Missing

**Before**
<img width="703" height="487" alt="image" src="https://github.com/user-attachments/assets/dddd0289-c329-4cd2-a7cf-411b8a090018" />

**After** - validated locally hence no certificate seen.
<img width="420" height="377" alt="image" src="https://github.com/user-attachments/assets/8677f1a3-ec29-443f-8578-647d743e9504" />
