### PR TITLE
chore: Add CODEOWNERS for area-specific review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# CODEOWNERS for opentelemetry-distro-dotnet
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# ─── Default (repo-level) ──────────────────────────────────────────────
+*                                                    @harsimar @rajkumar-rangaraj @xiang17
+
+# ─── Agent365 (src only) ───────────────────────────────────────────────
+src/Microsoft.OpenTelemetry/Agent365/                @harsimar @rajkumar-rangaraj @xiang17 @fpfp100 @nikhilNava @juliomenendez @alexlu4250
+
+# ─── Agent Framework (src only) ────────────────────────────────────────
+src/Microsoft.OpenTelemetry/AgentFramework/          @harsimar @rajkumar-rangaraj @xiang17 @TaoChenOSU
+
+# ─── Shared areas (all contributors) ──────────────────────────────────
+docs/                                                @harsimar @rajkumar-rangaraj @xiang17 @fpfp100 @nikhilNava @juliomenendez @alexlu4250 @TaoChenOSU
+test/                                                @harsimar @rajkumar-rangaraj @xiang17 @fpfp100 @nikhilNava @juliomenendez @alexlu4250 @TaoChenOSU
+examples/                                            @harsimar @rajkumar-rangaraj @xiang17 @fpfp100 @nikhilNava @juliomenendez @alexlu4250 @TaoChenOSU


### PR DESCRIPTION
- Repo-level: @harsimar @rajkumar-rangaraj @xiang17
- Agent365: repo-level + @fpfp100 @nikhilNava @juliomenendez @alexlu4250
- Agent Framework: repo-level + @TaoChenOSU
- Azure Monitor: repo-level (same owners)