### PR TITLE
Respect explicit EnableMetrics/EnableLogging in A365-only Console mode

### DIFF
--- a/src/Microsoft.OpenTelemetry/InstrumentationOptions.cs
+++ b/src/Microsoft.OpenTelemetry/InstrumentationOptions.cs
@@ -10,6 +10,8 @@ namespace Microsoft.OpenTelemetry;
 public class InstrumentationOptions
 {
     // Backing fields to track explicit user assignment vs defaults.
+    private bool? _enableMetrics;
+    private bool? _enableLogging;
     private bool? _enableAspNetCoreInstrumentation;
     private bool? _enableHttpClientInstrumentation;
     private bool? _enableSqlClientInstrumentation;
@@ -28,7 +30,11 @@ public class InstrumentationOptions
     /// Gets or sets a value indicating whether the metrics pipeline is enabled.
     /// When <c>false</c>, no <c>MeterProvider</c> is configured. Default: <c>true</c>.
     /// </summary>
-    public bool EnableMetrics { get; set; } = true;
+    public bool EnableMetrics
+    {
+        get => _enableMetrics ?? true;
+        set => _enableMetrics = value;
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether OpenTelemetry log export is enabled.
@@ -38,7 +44,11 @@ public class InstrumentationOptions
     /// Other logging providers (console logger, file logger, etc.) are not affected.
     /// Default: <c>true</c>.
     /// </summary>
-    public bool EnableLogging { get; set; } = true;
+    public bool EnableLogging
+    {
+        get => _enableLogging ?? true;
+        set => _enableLogging = value;
+    }
 
     // ── Auto-instrumentation libraries ──
 
@@ -93,6 +103,16 @@ public class InstrumentationOptions
         _enableSqlClientInstrumentation ??= false;
         _enableAzureSdkInstrumentation ??= false;
     }
+
+    /// <summary>
+    /// Returns <c>true</c> if <see cref="EnableMetrics"/> was explicitly assigned.
+    /// </summary>
+    internal bool MetricsExplicitlySet => _enableMetrics.HasValue;
+
+    /// <summary>
+    /// Returns <c>true</c> if <see cref="EnableLogging"/> was explicitly assigned.
+    /// </summary>
+    internal bool LoggingExplicitlySet => _enableLogging.HasValue;
 
     // ── GenAI / Agent instrumentation libraries ──
 

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -230,12 +230,12 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
                 builder.WithTracing(tracing => tracing.AddConsoleExporter());
             }
 
-            if (effectiveInstrumentation.EnableMetrics && !consoleTracesOnly)
+            if (effectiveInstrumentation.EnableMetrics && (!consoleTracesOnly || options.Instrumentation.MetricsExplicitlySet))
             {
                 builder.WithMetrics(metrics => metrics.AddConsoleExporter());
             }
 
-            if (effectiveInstrumentation.EnableLogging && !consoleTracesOnly)
+            if (effectiveInstrumentation.EnableLogging && (!consoleTracesOnly || options.Instrumentation.LoggingExplicitlySet))
             {
                 builder.WithLogging(logging => logging.AddConsoleExporter());
             }

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/InstrumentationOptionsTests.cs
@@ -1554,6 +1554,36 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
             Assert.Contains(exportedActivities, a =>
                 a.Source.Name == "Agent365Sdk");
         }
+
+        // ── Explicit metrics/logging override tracking ──
+
+        [Fact]
+        public void MetricsExplicitlySet_FalseByDefault()
+        {
+            var options = new InstrumentationOptions();
+            Assert.False(options.MetricsExplicitlySet);
+        }
+
+        [Fact]
+        public void MetricsExplicitlySet_TrueAfterAssignment()
+        {
+            var options = new InstrumentationOptions { EnableMetrics = true };
+            Assert.True(options.MetricsExplicitlySet);
+        }
+
+        [Fact]
+        public void LoggingExplicitlySet_FalseByDefault()
+        {
+            var options = new InstrumentationOptions();
+            Assert.False(options.LoggingExplicitlySet);
+        }
+
+        [Fact]
+        public void LoggingExplicitlySet_TrueAfterAssignment()
+        {
+            var options = new InstrumentationOptions { EnableLogging = true };
+            Assert.True(options.LoggingExplicitlySet);
+        }
     }
 }
 


### PR DESCRIPTION
In A365+Console mode, Console metrics and logs exporters were always suppressed via consoleTracesOnly, even when the user explicitly set EnableMetrics=true or EnableLogging=true. The user's explicit intent should override the automatic suppression.

Changes:
- InstrumentationOptions: Add nullable backing fields for EnableMetrics and EnableLogging to track explicit user assignment (same pattern as infra instrumentation options)
- Add MetricsExplicitlySet/LoggingExplicitlySet internal properties
- MicrosoftOpenTelemetryBuilderExtensions: Console metrics/logs exporter is now added when user explicitly sets EnableMetrics/EnableLogging=true, even in consoleTracesOnly mode
- Add 4 unit tests for explicit tracking behavior