### PR TITLE
Port changes from a365 exporter

### DIFF
--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -389,6 +389,13 @@ Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOp
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.TokenResolver.set -> void
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.UseS2SEndpoint.get -> bool
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.UseS2SEndpoint.set -> void
+const Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.DefaultEndpointHost = "agent365.svc.cloud.microsoft" -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.MaxPayloadBytes.get -> long
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.MaxPayloadBytes.set -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.PayloadChunking
+static Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.PayloadChunking.EstimateValueBytes(object? value) -> long
+static Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.PayloadChunking.EstimateActivityBytes(System.Diagnostics.Activity! activity) -> long
+static Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.PayloadChunking.ChunkBySize<T>(System.Collections.Generic.IEnumerable<T>! items, System.Func<T, long>! getSize, long maxChunkBytes) -> System.Collections.Generic.List<System.Collections.Generic.List<T>!>!
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterType
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterType.Agent365Exporter = 0 -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterType
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterType.Agent365ExporterAsync = 1 -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterType

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -1,11 +1,12 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using Microsoft.Agents.A365.Observability.Runtime.Common;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using global::OpenTelemetry;
-using global::OpenTelemetry.Resources;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -27,6 +28,21 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         private readonly ExportFormatter _formatter;
         private readonly ILogger<Agent365ExporterCore> _logger;
 
+        // The ingest service performs a case-insensitive check for "chat", so we send the
+        // gen_ai.operation.name through unchanged. Both the lowercase canonical value and the
+        // InferenceOperationType.Chat enum name are accepted in this set so that activities
+        // tagged with either form are not filtered out by PartitionByIdentity.
+        private static readonly HashSet<string> GenAiOperationNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            InvokeAgentScope.OperationName,
+            ExecuteToolScope.OperationName,
+            OutputScope.OperationName,
+            "chat",
+            nameof(InferenceOperationType.Chat),
+        };
+
+        private enum AddResult { Added, NonGenAI, MissingIdentity, Null }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Agent365ExporterCore"/> class.
         /// </summary>
@@ -40,6 +56,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
 
         /// <summary>
         /// Partitions a batch of activities by tenant and agent identity.
+        /// Only genAI activities (those with a known gen_ai.operation.name) are included.
         /// </summary>
         /// <param name="batch">The collection of activities to partition.</param>
         /// <returns>
@@ -48,17 +65,23 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         public List<(string TenantId, string AgentId, List<Activity> Activities)> PartitionByIdentity(IEnumerable<Activity> batch)
         {
             var map = new Dictionary<(string tenant, string agent), List<Activity>>();
+            int nonGenAICount = 0;
+            int missingIdentityCount = 0;
 
             foreach (var activity in batch)
             {
-                Agent365ExporterCore.TryAddActivityToMap(activity, map);
+                var result = Agent365ExporterCore.TryAddActivityToMap(activity, map);
+                if (result == AddResult.NonGenAI) nonGenAICount++;
+                else if (result == AddResult.MissingIdentity) missingIdentityCount++;
             }
 
+            LogPartitionResults(map.Count, nonGenAICount, missingIdentityCount);
             return map.Select(kvp => (kvp.Key.tenant, kvp.Key.agent, kvp.Value)).ToList();
         }
 
         /// <summary>
         /// Partitions a batch of activities by tenant and agent identity.
+        /// Only genAI activities (those with a known gen_ai.operation.name) are included.
         /// </summary>
         /// <param name="batch">The collection of activities to partition.</param>
         /// <returns>
@@ -67,12 +90,17 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         public List<(string TenantId, string AgentId, List<Activity> Activities)> PartitionByIdentity(in Batch<Activity> batch)
         {
             var map = new Dictionary<(string tenant, string agent), List<Activity>>();
+            int nonGenAICount = 0;
+            int missingIdentityCount = 0;
 
             foreach (var activity in batch)
             {
-                Agent365ExporterCore.TryAddActivityToMap(activity, map);
+                var result = Agent365ExporterCore.TryAddActivityToMap(activity, map);
+                if (result == AddResult.NonGenAI) nonGenAICount++;
+                else if (result == AddResult.MissingIdentity) missingIdentityCount++;
             }
 
+            LogPartitionResults(map.Count, nonGenAICount, missingIdentityCount);
             return map.Select(kvp => (kvp.Key.tenant, kvp.Key.agent, kvp.Value)).ToList();
         }
 
@@ -138,8 +166,21 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             foreach (var g in groups)
             {
                 var (tenantId, agentId, activities) = g;
-                var json = _formatter.FormatMany(activities, resource);
-                using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                // Split the per-identity batch into byte-size chunks under MaxPayloadBytes.
+                // Per-span truncation already caps individual spans at 250 KB; this provides
+                // batch-level enforcement of the 1 MB server limit.
+                var chunks = PayloadChunking.ChunkBySize(
+                    activities,
+                    PayloadChunking.EstimateActivityBytes,
+                    options.MaxPayloadBytes);
+
+                if (chunks.Count > 1)
+                {
+                    this._logger?.LogInformation(
+                        "Agent365ExporterCore: Split {SpanCount} spans into {ChunkCount} chunks for tenantId {TenantId}, agentId {AgentId}.",
+                        activities.Count, chunks.Count, tenantId, agentId);
+                }
 
                 var endpointOverride = Environment.GetEnvironmentVariable("A365_OBSERVABILITY_DOMAIN_OVERRIDE");
                 var endpoint = !string.IsNullOrEmpty(endpointOverride)
@@ -148,11 +189,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
 
                 var endpointPath = BuildEndpointPath(tenantId, agentId, options.UseS2SEndpoint);
                 var requestUri = BuildRequestUri(endpoint, endpointPath);
-
-                using var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
-                {
-                    Content = content
-                };
 
                 string? token = null;
                 try
@@ -165,48 +201,71 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                     this._logger?.LogError(ex, "Agent365ExporterCore: TokenResolver threw for agent {AgentId} tenant {TenantId}.", agentId, tenantId);
                 }
 
-                if (!string.IsNullOrEmpty(token))
-                {
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-                }
-                else
+                if (string.IsNullOrEmpty(token))
                 {
                     this._logger?.LogWarning("Agent365ExporterCore: No token obtained. Skipping export for this identity.");
                     return ExportResult.Failure;
                 }
-                    
-                HttpResponseMessage? resp = null;
-                try
+
+                // Send each chunk; all-or-nothing: fail on first chunk failure so the batch processor retries.
+                for (int i = 0; i < chunks.Count; i++)
                 {
-                    this._logger?.LogDebug("Agent365ExporterCore: Sending {SpanCount} spans to {RequestUri}.", activities.Count, requestUri);
-                    resp = await sendAsync(request).ConfigureAwait(false);
-                    var correlationId = resp.Headers.Contains(CorrelationIdHeaderKey) ? resp.Headers.GetValues(CorrelationIdHeaderKey).FirstOrDefault() : null;
-                    this._logger?.LogDebug("Agent365ExporterCore: HTTP {StatusCode} exporting spans. '{HeaderKey}': '{CorrelationId}'.", (int)resp.StatusCode, CorrelationIdHeaderKey, correlationId);
-                    if (!resp.IsSuccessStatusCode)
+                    var chunk = chunks[i];
+                    var json = _formatter.FormatMany(chunk, resource);
+                    using var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                    using var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+                    {
+                        Content = content
+                    };
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+                    var bodyBytes = Encoding.UTF8.GetByteCount(json);
+                    this._logger?.LogDebug(
+                        "Agent365ExporterCore: Sending chunk {ChunkIndex} of {ChunkCount} ({SpanCount} spans, {BodyBytes} bytes) to {RequestUri}.",
+                        i + 1, chunks.Count, chunk.Count, bodyBytes, requestUri);
+
+                    try
+                    {
+                        using var resp = await sendAsync(request).ConfigureAwait(false);
+                        var correlationId = resp.Headers.Contains(CorrelationIdHeaderKey) ? resp.Headers.GetValues(CorrelationIdHeaderKey).FirstOrDefault() : null;
+                        this._logger?.LogDebug("Agent365ExporterCore: HTTP {StatusCode} exporting spans. '{HeaderKey}': '{CorrelationId}'.", (int)resp.StatusCode, CorrelationIdHeaderKey, correlationId);
+                        if (!resp.IsSuccessStatusCode)
+                        {
+                            this._logger?.LogWarning(
+                                "Agent365ExporterCore: Chunk {ChunkIndex} of {ChunkCount} failed; aborting batch.",
+                                i + 1, chunks.Count);
+                            return ExportResult.Failure;
+                        }
+                    }
+                    catch (HttpRequestException ex)
+                    {
+                        this._logger?.LogError(ex, "Agent365ExporterCore: Exception exporting spans.");
                         return ExportResult.Failure;
-                }
-                catch (Exception ex)
-                {
-                    this._logger?.LogError(ex, "Agent365ExporterCore: Exception exporting spans.");
-                    return ExportResult.Failure;
-                }
-                finally
-                {
-                    resp?.Dispose();
+                    }
+                    catch (TaskCanceledException ex)
+                    {
+                        this._logger?.LogError(ex, "Agent365ExporterCore: Exception exporting spans.");
+                        return ExportResult.Failure;
+                    }
                 }
             }
             return ExportResult.Success;
         }
 
-        private static void TryAddActivityToMap(Activity activity, Dictionary<(string tenant, string agent), List<Activity>> map)
+        private static AddResult TryAddActivityToMap(Activity activity, Dictionary<(string tenant, string agent), List<Activity>> map)
         {
-            if (activity is null) return;
+            if (activity is null) return AddResult.Null;
+
+            var operationName = activity.GetAttributeOrBaggage(OpenTelemetryConstants.GenAiOperationNameKey);
+            if (string.IsNullOrEmpty(operationName) || !GenAiOperationNames.Contains(operationName!))
+                return AddResult.NonGenAI;
 
             var tenant = activity.GetAttributeOrBaggage(OpenTelemetryConstants.TenantIdKey);
             var agent = activity.GetAttributeOrBaggage(OpenTelemetryConstants.GenAiAgentIdKey) ?? activity.GetAttributeOrBaggage(OpenTelemetryConstants.AgentPlatformIdKey);
 
             if (string.IsNullOrEmpty(tenant) || string.IsNullOrEmpty(agent))
-                return;
+                return AddResult.MissingIdentity;
 
             var key = (tenant!, agent!);
             if (!map.TryGetValue(key, out var list))
@@ -215,6 +274,19 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                 map[key] = list;
             }
             list.Add(activity);
+            return AddResult.Added;
+        }
+
+        private void LogPartitionResults(int groupCount, int nonGenAICount, int missingIdentityCount)
+        {
+            if (nonGenAICount > 0)
+                _logger?.LogDebug("[Agent365Exporter] {NonGenAICount} non-genAI spans filtered out", nonGenAICount);
+            if (missingIdentityCount > 0)
+                _logger?.LogDebug("[Agent365Exporter] {MissingIdentityCount} spans skipped due to missing tenant or agent ID", missingIdentityCount);
+
+            var skippedCount = nonGenAICount + missingIdentityCount;
+            if (skippedCount > 0)
+                _logger?.LogDebug("[Agent365Exporter] Partitioned into {GroupCount} identity groups ({SkippedCount} spans skipped)", groupCount, skippedCount);
         }
     }
 }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         /// <summary>
         /// The default endpoint host for Agent365 observability.
         /// </summary>
-        internal const string DefaultEndpointHost = "agent365.svc.cloud.microsoft";
+        public const string DefaultEndpointHost = "agent365.svc.cloud.microsoft";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Agent365ExporterOptions"/> class with default settings.
@@ -86,5 +86,13 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         /// Default is 512.
         /// </summary>
         public int MaxExportBatchSize { get; set; } = 512;
+
+        /// <summary>
+        /// Upper bound on HTTP request body size in bytes used by per-request payload chunking.
+        /// 100 KB headroom under the 1 MB server limit accounts for estimator error and JSON/envelope
+        /// overhead (for example, resource attributes and scope wrappers).
+        /// Default is 900,000 bytes.
+        /// </summary>
+        public long MaxPayloadBytes { get; set; } = 900_000;
     }
 }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/PayloadChunking.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/PayloadChunking.cs
@@ -1,0 +1,176 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
+{
+    /// <summary>
+    /// Heuristic span size estimation and byte-level chunking for OTLP/HTTP JSON payloads.
+    ///
+    /// The Agent 365 OTLP traces endpoint enforces a 1 MB request body limit. Per-span
+    /// truncation (250 KB cap inside <see cref="Common.ExportFormatter"/>) prevents any
+    /// single span from being too large; this class provides the second layer of defense
+    /// at the batch level by splitting batches into sub-batches whose cumulative estimated
+    /// size stays under <see cref="Agent365ExporterOptions.MaxPayloadBytes"/>.
+    /// </summary>
+    public static class PayloadChunking
+    {
+        /// <summary>
+        /// Overhead constant for OTLP JSON span fixed fields
+        /// (traceId, spanId, parentSpanId, kind, timestamps, status, scope wrapper, etc.).
+        /// Intentionally generous to account for serializer variance.
+        /// </summary>
+        private const int SpanBaseOverhead = 2000;
+
+        /// <summary>
+        /// Overhead per attribute in OTLP JSON format. Covers key/value JSON wrapping overhead.
+        /// </summary>
+        private const int AttrOverhead = 80;
+
+        /// <summary>
+        /// Overhead per event in OTLP JSON.
+        /// </summary>
+        private const int EventOverhead = 200;
+
+        /// <summary>
+        /// Estimates the serialized byte size of a single attribute value in OTLP/HTTP JSON.
+        /// </summary>
+        /// <param name="value">The attribute value to estimate.</param>
+        /// <returns>An over-estimate of the serialized size in bytes.</returns>
+        public static long EstimateValueBytes(object? value)
+        {
+            if (value is string s)
+            {
+                return 40 + Encoding.UTF8.GetByteCount(s);
+            }
+
+            if (value is IEnumerable enumerable && !(value is string))
+            {
+                long count = 0;
+                bool firstIsString = false;
+                long stringSum = 0;
+                bool sawAny = false;
+                foreach (var item in enumerable)
+                {
+                    if (!sawAny)
+                    {
+                        firstIsString = item is string;
+                        sawAny = true;
+                    }
+                    if (firstIsString)
+                    {
+                        stringSum += 40 + Encoding.UTF8.GetByteCount(item?.ToString() ?? string.Empty);
+                    }
+                    count++;
+                }
+
+                if (count == 0) return 60;
+                if (firstIsString) return 60 + stringSum;
+                return 60 + 50 * count;
+            }
+
+            return 40; // bool/int/float/null/other
+        }
+
+        /// <summary>
+        /// Heuristic estimator for the serialized size of an OTLP span produced from the
+        /// supplied <see cref="Activity"/> when emitted as OTLP/HTTP JSON.
+        ///
+        /// Uses generous constants tuned to over-estimate by ~25-50%, providing headroom
+        /// for JSON serializer variance (whitespace, enum representation, integer-as-string).
+        /// </summary>
+        /// <param name="activity">The activity to estimate.</param>
+        /// <returns>An over-estimate of the serialized OTLP span size in bytes.</returns>
+        public static long EstimateActivityBytes(Activity activity)
+        {
+            if (activity is null) throw new ArgumentNullException(nameof(activity));
+
+            long total = SpanBaseOverhead;
+
+            if (!string.IsNullOrEmpty(activity.DisplayName))
+            {
+                total += Encoding.UTF8.GetByteCount(activity.DisplayName);
+            }
+
+            foreach (var tag in activity.TagObjects)
+            {
+                total += AttrOverhead;
+                total += Encoding.UTF8.GetByteCount(tag.Key ?? string.Empty);
+                total += EstimateValueBytes(tag.Value);
+            }
+
+            if (activity.Events != null)
+            {
+                foreach (var ev in activity.Events)
+                {
+                    total += EventOverhead;
+                    total += Encoding.UTF8.GetByteCount(ev.Name ?? string.Empty);
+                    if (ev.Tags != null)
+                    {
+                        foreach (var tag in ev.Tags)
+                        {
+                            total += AttrOverhead;
+                            total += Encoding.UTF8.GetByteCount(tag.Key ?? string.Empty);
+                            total += EstimateValueBytes(tag.Value);
+                        }
+                    }
+                }
+            }
+
+            return total;
+        }
+
+        /// <summary>
+        /// Splits items into sub-batches whose cumulative estimated size stays under
+        /// <paramref name="maxChunkBytes"/>.
+        ///
+        /// Invariants:
+        /// <list type="bullet">
+        ///   <item><description>Input order is preserved across chunks.</description></item>
+        ///   <item><description>Empty input produces empty output.</description></item>
+        ///   <item><description>A single item whose size exceeds <paramref name="maxChunkBytes"/>
+        ///   forms its own single-item chunk (never silently dropped).</description></item>
+        ///   <item><description>No chunk is ever empty.</description></item>
+        /// </list>
+        /// </summary>
+        /// <typeparam name="T">Item type.</typeparam>
+        /// <param name="items">The items to chunk.</param>
+        /// <param name="getSize">Estimator function returning approximate serialized byte size of one item.</param>
+        /// <param name="maxChunkBytes">Upper bound on cumulative estimated size per chunk.</param>
+        /// <returns>An ordered list of non-empty chunks.</returns>
+        public static List<List<T>> ChunkBySize<T>(IEnumerable<T> items, Func<T, long> getSize, long maxChunkBytes)
+        {
+            if (items is null) throw new ArgumentNullException(nameof(items));
+            if (getSize is null) throw new ArgumentNullException(nameof(getSize));
+
+            var chunks = new List<List<T>>();
+            var current = new List<T>();
+            long currentBytes = 0;
+
+            foreach (var item in items)
+            {
+                long itemBytes = getSize(item);
+                if (current.Count > 0 && currentBytes + itemBytes > maxChunkBytes)
+                {
+                    chunks.Add(current);
+                    current = new List<T>();
+                    currentBytes = 0;
+                }
+                current.Add(item);
+                currentBytes += itemBytes;
+            }
+
+            if (current.Count > 0)
+            {
+                chunks.Add(current);
+            }
+
+            return chunks;
+        }
+    }
+}

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/Agent365ExporterTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/Agent365ExporterTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using FluentAssertions;
@@ -6,8 +6,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Agents.A365.Observability.Runtime.Common;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
-using global::OpenTelemetry;
-using global::OpenTelemetry.Resources;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
 using System.Diagnostics;
 using System.Reflection;
 using System.Net;
@@ -25,7 +25,7 @@ public sealed class Agent365ExporterTests
         "firstrelease", "prod", "production", "gov", "high", "dod", "mooncake", "ex", "rx"
     };
 
-    private static Activity CreateActivity(string? tenantId = null, string? agentId = null)
+    private static Activity CreateActivity(string? tenantId = null, string? agentId = null, string? operationName = "invoke_agent")
     {
         using var listener = new ActivityListener
         {
@@ -41,6 +41,10 @@ public sealed class Agent365ExporterTests
         if (activity == null)
             throw new InvalidOperationException("Failed to start activity. Ensure an ActivityListener is registered.");
 
+        if (operationName != null)
+        {
+            activity.SetTag(OpenTelemetryConstants.GenAiOperationNameKey, operationName);
+        }
         if (tenantId != null)
         {
             activity.SetTag(OpenTelemetryConstants.TenantIdKey, tenantId);
@@ -191,6 +195,25 @@ public sealed class Agent365ExporterTests
         groups.Should().HaveCount(2);
         groups.Should().Contain(g => g.TenantId == "tenant-1" && g.AgentId == "agent-1" && g.Activities.Count == 2);
         groups.Should().Contain(g => g.TenantId == "tenant-1" && g.AgentId == "agent-2" && g.Activities.Count == 1);
+    }
+
+    [TestMethod]
+    public void PartitionByIdentity_FiltersOutNonGenAISpans()
+    {
+        // Arrange
+        using var genaiSpan = CreateActivity("tenant-1", "agent-1", operationName: "invoke_agent");
+        using var httpSpan = CreateActivity("tenant-1", "agent-1", operationName: null);
+        using var dbSpan = CreateActivity("tenant-1", "agent-1", operationName: "some_random_op");
+        using var chatSpan = CreateActivity("tenant-1", "agent-1", operationName: "Chat");
+
+        var batch = CreateBatch(genaiSpan, httpSpan, dbSpan, chatSpan);
+
+        // Act
+        var groups = Agent365ExporterTests._agent365ExporterCore.PartitionByIdentity(in batch);
+
+        // Assert
+        groups.Should().HaveCount(1);
+        groups.Should().Contain(g => g.TenantId == "tenant-1" && g.AgentId == "agent-1" && g.Activities.Count == 2);
     }
 
     [TestMethod]

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/PayloadChunkingTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/PayloadChunkingTests.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
+using System.Diagnostics;
+
+namespace Microsoft.Agents.A365.Observability.Tests.Tracing.Exporters;
+
+[TestClass]
+public sealed class PayloadChunkingTests
+{
+    private static Activity CreateActivity(string displayName, IDictionary<string, object?>? tags = null)
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Agent365Sdk.Test.Chunking",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = _ => { },
+            ActivityStopped = _ => { }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var source = new ActivitySource("Agent365Sdk.Test.Chunking");
+        var activity = source.StartActivity(displayName, ActivityKind.Client)
+            ?? throw new InvalidOperationException("Failed to start activity.");
+        if (tags != null)
+        {
+            foreach (var kvp in tags)
+            {
+                activity.SetTag(kvp.Key, kvp.Value);
+            }
+        }
+        activity.Stop();
+        return activity;
+    }
+
+    // -----------------------------------------------------------------------
+    // EstimateValueBytes
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void EstimateValueBytes_String_ReturnsHeaderPlusUtf8ByteCount()
+    {
+        PayloadChunking.EstimateValueBytes("hello").Should().Be(40 + 5);
+    }
+
+    [TestMethod]
+    public void EstimateValueBytes_EmptyArray_ReturnsBaseOverhead()
+    {
+        PayloadChunking.EstimateValueBytes(Array.Empty<string>()).Should().Be(60);
+    }
+
+    [TestMethod]
+    public void EstimateValueBytes_StringArray_SumsPerElementOverhead()
+    {
+        PayloadChunking.EstimateValueBytes(new[] { "a", "bb" })
+            .Should().Be(60 + (40 + 1) + (40 + 2));
+    }
+
+    [TestMethod]
+    public void EstimateValueBytes_NumericArray_UsesFlatPerElementCost()
+    {
+        PayloadChunking.EstimateValueBytes(new[] { 1, 2 }).Should().Be(60 + 50 * 2);
+    }
+
+    [TestMethod]
+    public void EstimateValueBytes_Scalars_ReturnsScalarOverhead()
+    {
+        PayloadChunking.EstimateValueBytes(true).Should().Be(40);
+        PayloadChunking.EstimateValueBytes(42).Should().Be(40);
+        PayloadChunking.EstimateValueBytes(null).Should().Be(40);
+    }
+
+    // -----------------------------------------------------------------------
+    // EstimateActivityBytes
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void EstimateActivityBytes_GrowsWithAttributeContent()
+    {
+        var small = CreateActivity("test", new Dictionary<string, object?> { ["key"] = "val" });
+        var large = CreateActivity("test", new Dictionary<string, object?> { ["key"] = new string('x', 10_000) });
+
+        PayloadChunking.EstimateActivityBytes(large)
+            .Should().BeGreaterThan(PayloadChunking.EstimateActivityBytes(small));
+    }
+
+    [TestMethod]
+    public void EstimateActivityBytes_OverEstimatesActualJsonSize()
+    {
+        // A representative span: many attributes including some large strings.
+        var attrs = new Dictionary<string, object?>
+        {
+            ["gen_ai.system"] = "openai",
+            ["gen_ai.tool.arguments"] = new string('x', 1000),
+            ["gen_ai.tool.call_result"] = new string('y', 1000),
+        };
+        var activity = CreateActivity("test", attrs);
+
+        // The estimator targets the eventual OTLP JSON span shape (with traceId, spanId,
+        // status, scope wrapper, etc.). A simple Dictionary serialization is a strict
+        // lower bound, so the estimate should comfortably exceed it.
+        var dictJson = System.Text.Json.JsonSerializer.Serialize(attrs);
+        var actualLowerBound = System.Text.Encoding.UTF8.GetByteCount(dictJson);
+
+        PayloadChunking.EstimateActivityBytes(activity)
+            .Should().BeGreaterThan(actualLowerBound);
+    }
+
+    [TestMethod]
+    public void EstimateActivityBytes_NullActivity_Throws()
+    {
+        var act = () => PayloadChunking.EstimateActivityBytes(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // -----------------------------------------------------------------------
+    // ChunkBySize
+    // -----------------------------------------------------------------------
+
+    [TestMethod]
+    public void ChunkBySize_EmptyInput_ReturnsEmptyOutput()
+    {
+        var result = PayloadChunking.ChunkBySize(Array.Empty<int>(), x => x, 900_000);
+        result.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void ChunkBySize_SmallItemsFitInOneChunk()
+    {
+        var items = Enumerable.Range(0, 10).Select(i => 100).ToList();
+        var chunks = PayloadChunking.ChunkBySize(items, x => x, 900_000);
+        chunks.Should().HaveCount(1);
+        chunks[0].Should().HaveCount(10);
+    }
+
+    [TestMethod]
+    public void ChunkBySize_SplitsWhenCumulativeExceedsLimitAndPreservesOrder()
+    {
+        var items = Enumerable.Range(0, 5).Select(i => (Id: $"s{i}", Size: 300_000L)).ToList();
+        var chunks = PayloadChunking.ChunkBySize(items, x => x.Size, 900_000);
+        chunks.Count.Should().BeGreaterOrEqualTo(2);
+        chunks.SelectMany(c => c).Select(x => x.Id)
+            .Should().Equal("s0", "s1", "s2", "s3", "s4");
+    }
+
+    [TestMethod]
+    public void ChunkBySize_OversizeSingleItemGetsItsOwnChunk()
+    {
+        var chunks = PayloadChunking.ChunkBySize(
+            new[] { (Id: "big", Size: 2_000_000L) },
+            x => x.Size,
+            900_000);
+        chunks.Should().HaveCount(1);
+        chunks[0][0].Id.Should().Be("big");
+    }
+
+    [TestMethod]
+    public void ChunkBySize_MultiItemChunksRespectLimitAndAreNonEmpty()
+    {
+        var items = Enumerable.Range(0, 5).Select(i => (Id: $"s{i}", Size: 200_000L)).ToList();
+        var chunks = PayloadChunking.ChunkBySize(items, x => x.Size, 500_000);
+
+        foreach (var chunk in chunks)
+        {
+            chunk.Count.Should().BeGreaterThan(0);
+            if (chunk.Count > 1)
+            {
+                chunk.Sum(x => x.Size).Should().BeLessOrEqualTo(500_000);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ChunkBySize_NullItems_Throws()
+    {
+        var act = () => PayloadChunking.ChunkBySize<int>(null!, x => x, 100);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void ChunkBySize_NullGetSize_Throws()
+    {
+        var act = () => PayloadChunking.ChunkBySize<int>(new[] { 1 }, null!, 100);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION

- Filter A365 exports to only include genAI spans
- Add OTLP payload byte-size chunking to Agent365Exporter
- Add PayloadChunking utility and tests
- Add PayloadChunkingTests and updated Agent365ExporterTests