### PR TITLE
fix: Add explicit Microsoft.Extensions dependencies for net8.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1 - 2026-05-01
+
+- Add explicit `Microsoft.Extensions.Logging` and `Microsoft.Extensions.Configuration.Binder` dependencies for net8.0 runtime compatibility
+
 ## 1.0.0 - 2026-05-01
 
 First stable release of the Microsoft OpenTelemetry distro for .NET.

--- a/src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj
+++ b/src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj
@@ -10,7 +10,7 @@
 
     <!-- NuGet packaging -->
     <PackageId>Microsoft.OpenTelemetry</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See CHANGELOG.md for release notes.</PackageReleaseNotes>
@@ -49,6 +49,12 @@
 
     <!-- Agent365 extensions (PrivateAssets=all: compile-time only, not propagated to consumers) -->
     <PackageReference Include="Microsoft.Agents.Builder" PrivateAssets="all" />
+
+    <!-- Microsoft.Agents.Builder (PrivateAssets=all) compiles against 10.x Microsoft.Extensions.*
+         but suppresses transitive flow. On net8.0, the shared framework only has 8.x assemblies.
+         These explicit dependencies ensure the 10.x assemblies are available at runtime. -->
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Problem

`Microsoft.Agents.Builder` is referenced with `PrivateAssets=all`, which compiles the distro against `Microsoft.Extensions.*` 10.x but **suppresses the dependencies from flowing to NuGet consumers**. On net8.0, the shared framework only ships 8.x assemblies, causing `FileNotFoundException` at runtime:

```
System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Extensions.Logging, Version=10.0.0.0'
```

This crash affects all net8.0 consumers of `Microsoft.OpenTelemetry` 1.0.0.

## Root Cause

The distro DLL references these 10.x assemblies (compiled against `Microsoft.Agents.Builder`), but since `PrivateAssets=all` prevents them from flowing as transitive dependencies, NuGet consumers on net8.0 only get the 8.x versions from the shared framework. The CLR cannot bind the 10.0.0.0 assembly references to the 8.0.0.0 assemblies.

Two assemblies needed explicit flowing dependencies:
- `Microsoft.Extensions.Logging` - not pulled in by any other flowing dependency
- `Microsoft.Extensions.Configuration.Binder` - pulled in at 8.x by other deps, but distro needs 10.x

## Fix

Add explicit `<PackageReference>` entries (without `PrivateAssets`) for both packages. This ensures NuGet consumers get the 10.x assemblies. All other `Microsoft.Extensions.*` 10.x assemblies are pulled in transitively by these two.

## Validation

| Check | Result |
|-------|--------|
| nuspec declares Configuration.Binder >= 10.0.2 | :white_check_mark: |
| nuspec declares Logging >= 10.0.2 | :white_check_mark: |
| All 12 Microsoft.Extensions.* assemblies resolve to 10.0.0.0 on net8.0 | :white_check_mark: |
| Console demo (net8.0) runs without crash | :white_check_mark: |
| ASP.NET Core demo (net8.0) runs without crash | :white_check_mark: |
| Solution builds with 0 errors, 0 warnings | :white_check_mark: |
| 1242 tests pass (net8.0 + net10.0) | :white_check_mark: |

## Changes

- `src/Microsoft.OpenTelemetry/Microsoft.OpenTelemetry.csproj` - Add `Microsoft.Extensions.Logging` and `Microsoft.Extensions.Configuration.Binder` as flowing dependencies; bump version to 1.0.1
- `CHANGELOG.md` - Add 1.0.1 entry