### PR TITLE
chore: Remove workaround PackageReference entries from examples

### DIFF
--- a/examples/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/Azure.Monitor.OpenTelemetry.AspNetCore.Demo.csproj
+++ b/examples/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/Azure.Monitor.OpenTelemetry.AspNetCore.Demo.csproj
@@ -8,11 +8,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.OpenTelemetry\Microsoft.OpenTelemetry.csproj" />
-    <!-- Explicit refs needed for ProjectReference builds: Microsoft.Agents.Builder (PrivateAssets=all)
-         pulls in 10.x Microsoft.Extensions.* which conflict with the net8.0 shared framework.
-         Real NuGet consumers don't need these — PrivateAssets suppresses the transitive flow. -->
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
 </Project>

--- a/examples/Microsoft.OpenTelemetry.Console.Demo/Microsoft.OpenTelemetry.Console.Demo.csproj
+++ b/examples/Microsoft.OpenTelemetry.Console.Demo/Microsoft.OpenTelemetry.Console.Demo.csproj
@@ -12,11 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.OpenTelemetry\Microsoft.OpenTelemetry.csproj" />
-    <!-- Explicit refs needed for ProjectReference builds: Microsoft.Agents.Builder (PrivateAssets=all)
-         pulls in 10.x Microsoft.Extensions.* which conflict with the net8.0 shared framework.
-         Real NuGet consumers don't need these — PrivateAssets suppresses the transitive flow. -->
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Remove the temporary `Microsoft.Extensions.Configuration.Binder` and `Microsoft.Extensions.Logging` `PackageReference` entries from both example csprojs.

These were added as a workaround for the net8.0 assembly version conflict caused by `Microsoft.Agents.Builder` (`PrivateAssets=all`) pulling in 10.x `Microsoft.Extensions.*` assemblies.

Now that the distro's own csproj includes these as flowing dependencies (added in #76 / 1.0.1), ProjectReference builds pick them up automatically and the workaround is no longer needed.

## Changes

- `examples/Azure.Monitor.OpenTelemetry.AspNetCore.Demo/Azure.Monitor.OpenTelemetry.AspNetCore.Demo.csproj` — remove 5-line workaround block
- `examples/Microsoft.OpenTelemetry.Console.Demo/Microsoft.OpenTelemetry.Console.Demo.csproj` — remove 5-line workaround block

## Verification

- Solution builds with 0 errors, 0 warnings
- Both demos run successfully on net8.0 without the workaround entries