### PR TITLE
docs: Add Fabric/ADX and Aspire Dashboard getting started guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ builder.UseMicrosoftOpenTelemetry(o =>
 
 ---
 
+### 4. Microsoft Fabric / Azure Data Explorer
+
+Send traces, metrics, and logs to [Microsoft Fabric Real-Time Intelligence](https://learn.microsoft.com/en-us/fabric/real-time-intelligence/overview) or Azure Data Explorer via an OpenTelemetry Collector with the Azure Data Explorer exporter.
+
+```csharp
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Otlp;
+});
+```
+
+The app sends OTLP to a collector, which forwards to Fabric/ADX. No code changes needed — just configure the collector.
+
+📖 **Full guide:** [Fabric Getting Started](docs/fabric-getting-started.md)
+
+---
+
 ### Combining destinations
 
 ```csharp
@@ -268,12 +285,15 @@ builder.Services.AddLogging(logging => logging.AddConsole());
 - [Agent 365 Getting Started](docs/agent365-getting-started.md) — Add Agent365 observability using the distro
 - [Agent 365 Migration Guide](docs/agent365-migration.md) — Migrate from the standalone Agent365 SDK to the distro
 - [Agent 365 Migration Testing](docs/testing-agent365.md) — Detailed migration checklist with auto-instrumentation, env vars, and span comparison
+- [Fabric Getting Started](docs/fabric-getting-started.md) — Send telemetry to Microsoft Fabric / Azure Data Explorer via OTLP + OTel Collector
+- [Aspire Dashboard](docs/aspire-dashboard.md) — Validate telemetry locally with the .NET Aspire Dashboard
 
 ## Examples
 
 - [Azure.Monitor.OpenTelemetry.AspNetCore.Demo](examples/Azure.Monitor.OpenTelemetry.AspNetCore.Demo) — ASP.NET Core → Azure Monitor
 - [Microsoft.OpenTelemetry.Agent365.Demo](examples/Microsoft.OpenTelemetry.Agent365.Demo) — Agent Framework app → Agent365
 - [Microsoft.OpenTelemetry.AgentFramework.Demo](examples/Microsoft.OpenTelemetry.AgentFramework.Demo) — Agent Framework → OTLP / Azure Monitor
+- [Microsoft.OpenTelemetry.Fabric.Demo](examples/Microsoft.OpenTelemetry.Fabric.Demo) — ASP.NET Core → OTLP → OTel Collector → Microsoft Fabric / Azure Data Explorer
 
 ## AI-Assisted Setup & Migration Skills
 

--- a/docs/aspire-dashboard.md
+++ b/docs/aspire-dashboard.md
@@ -33,26 +33,24 @@ Set `ExportTarget.Otlp` so the distro sends telemetry to `localhost:4317` (the d
 
 ```csharp
 using Microsoft.OpenTelemetry;
-using OpenTelemetry;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        o.Exporters = ExportTarget.Otlp;
-    });
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Otlp;
+});
 
 var app = builder.Build();
 app.MapGet("/", () => "Hello!");
 app.Run();
 ```
 
-Run the app and send a few requests:
+Run the app and send a few requests (use the URL printed by `dotnet run`):
 
 ```bash
 dotnet run
-curl http://localhost:5000/
+curl http://localhost:<port>/
 ```
 
 Switch to the dashboard at `http://localhost:18888` — you should see traces, structured logs, and metrics appearing in real time.
@@ -72,12 +70,11 @@ Then start the collector. If you forget, you'll see a `port is already allocated
 You can send to the dashboard **and** Azure Monitor at the same time:
 
 ```csharp
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        o.Exporters = ExportTarget.Otlp | ExportTarget.AzureMonitor;
-        o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
-    });
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Otlp | ExportTarget.AzureMonitor;
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
+});
 ```
 
 ## References

--- a/docs/aspire-dashboard.md
+++ b/docs/aspire-dashboard.md
@@ -1,0 +1,87 @@
+# Local development with the Aspire Dashboard
+
+The [.NET Aspire Dashboard](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/overview) provides a local web UI for viewing traces, metrics, and logs during development — no Azure subscription required. It receives telemetry via OTLP (the same protocol the distro uses) and displays it in a browser.
+
+Use it to validate that your app is emitting the telemetry you expect before configuring a production destination like Azure Monitor or [Microsoft Fabric](fabric-getting-started.md).
+
+## Start the dashboard
+
+Run the Aspire Dashboard as a Docker container:
+
+```powershell
+docker run --rm -it -d `
+    -p 18888:18888 `
+    -p 4317:18889 `
+    -p 4318:18890 `
+    --name aspire-dashboard `
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+This exposes:
+
+| Endpoint | Purpose |
+|---|---|
+| `http://localhost:18888` | Dashboard web UI |
+| `http://localhost:4317` | OTLP gRPC receiver (traces, metrics, logs) |
+| `http://localhost:4318` | OTLP HTTP receiver |
+
+Open [http://localhost:18888](http://localhost:18888) in your browser — you'll see the dashboard with empty panels.
+
+## Configure your app
+
+Set `ExportTarget.Otlp` so the distro sends telemetry to `localhost:4317` (the dashboard):
+
+```csharp
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Otlp;
+    });
+
+var app = builder.Build();
+app.MapGet("/", () => "Hello!");
+app.Run();
+```
+
+Run the app and send a few requests:
+
+```bash
+dotnet run
+curl http://localhost:5000/
+```
+
+Switch to the dashboard at `http://localhost:18888` — you should see traces, structured logs, and metrics appearing in real time.
+
+## Stop the dashboard before using the OTel Collector
+
+The Aspire Dashboard and the OpenTelemetry Collector both listen on port **4317**. If you're following the [Fabric getting started guide](fabric-getting-started.md) or running any other OTel Collector setup, stop the dashboard first:
+
+```bash
+docker stop aspire-dashboard
+```
+
+Then start the collector. If you forget, you'll see a `port is already allocated` error.
+
+## Combining with other exporters
+
+You can send to the dashboard **and** Azure Monitor at the same time:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Otlp | ExportTarget.AzureMonitor;
+        o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
+    });
+```
+
+## References
+
+- [.NET Aspire Dashboard overview](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/overview)
+- [Aspire Dashboard standalone mode](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone)
+- [Fabric Getting Started](fabric-getting-started.md) — Send data to Microsoft Fabric / Azure Data Explorer via the OTel Collector

--- a/docs/fabric-getting-started.md
+++ b/docs/fabric-getting-started.md
@@ -1,0 +1,258 @@
+# Send OpenTelemetry data to Microsoft Fabric
+
+This guide walks you through sending traces, metrics, and logs from a .NET application to [Microsoft Fabric Real-Time Intelligence](https://learn.microsoft.com/en-us/fabric/real-time-intelligence/overview) (or Azure Data Explorer).
+
+## How it works
+
+Your .NET app doesn't connect to Fabric directly. Instead, it sends telemetry to an **OpenTelemetry Collector** running alongside it — either locally or in a cluster. The collector then forwards the data into your Fabric/ADX database.
+
+```
+┌──────────────┐     OTLP/gRPC     ┌──────────────────┐     Kusto Ingest     ┌─────────────────────────┐
+│  .NET App    │ ───────────────►  │  OTel Collector  │ ──────────────────►  │  Fabric / Azure Data    │
+│  (distro)    │    :4317          │  (ADX exporter)  │                      │  Explorer               │
+└──────────────┘                   └──────────────────┘                      └─────────────────────────┘
+```
+
+**What each component does:**
+
+- **Your .NET app** — uses `Microsoft.OpenTelemetry` to automatically capture HTTP requests, logs, and metrics, then exports them via OTLP (a standard telemetry protocol) on port 4317.
+- **OTel Collector** — a lightweight process that receives OTLP data and forwards it to one or more destinations. We use the [Azure Data Explorer exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter) plugin to write into Kusto tables.
+- **Fabric / ADX** — stores the telemetry in three KQL tables (traces, metrics, logs) that you can query with KQL.
+
+## Prerequisites
+
+- [.NET 8.0+ SDK](https://dotnet.microsoft.com/download)
+- An Azure Data Explorer cluster **or** a [Fabric KQL database](https://learn.microsoft.com/en-us/fabric/real-time-analytics/create-database) — a [free ADX cluster](https://dataexplorer.azure.com/freecluster) works for testing
+- Azure CLI installed and logged in (`az login`) — used for authentication
+- The `Microsoft.OpenTelemetry` NuGet package (installed in Step 3)
+
+> **Tip:** Before connecting to Fabric, you can verify your app emits telemetry correctly using the [Aspire Dashboard](aspire-dashboard.md) — a free, local viewer for traces, metrics, and logs. Once validated, stop the dashboard (`docker stop aspire-dashboard`) and continue with the steps below.
+
+## Step 1: Create target tables
+
+The collector writes telemetry into three pre-created tables. Open the [Azure Data Explorer web UI](https://dataexplorer.azure.com/) (or [Fabric KQL queryset](https://learn.microsoft.com/en-us/fabric/real-time-analytics/kusto-query-set)), select your database, and run each command below:
+
+```kql
+// Table for log records
+.create-merge table OTELLogs (Timestamp:datetime, ObservedTimestamp:datetime, TraceID:string, SpanID:string, SeverityText:string, SeverityNumber:int, Body:string, ResourceAttributes:dynamic, LogsAttributes:dynamic)
+
+// Table for metric data points
+.create-merge table OTELMetrics (Timestamp:datetime, MetricName:string, MetricType:string, MetricUnit:string, MetricDescription:string, MetricValue:real, Host:string, ResourceAttributes:dynamic, MetricAttributes:dynamic)
+
+// Table for distributed traces (spans)
+.create-merge table OTELTraces (TraceID:string, SpanID:string, ParentID:string, SpanName:string, SpanStatus:string, SpanKind:string, StartTime:datetime, EndTime:datetime, ResourceAttributes:dynamic, TraceAttributes:dynamic, Events:dynamic, Links:dynamic)
+```
+
+> **Tip:** `.create-merge` is safe to run multiple times — it creates the table if it doesn't exist, or merges new columns into an existing table.
+
+## Step 2: Grant permissions
+
+The collector needs permission to write data into your database. Run one of these commands in the same query window:
+
+**For local development** (uses your Azure CLI identity):
+
+```kql
+.add database MyDatabase ingestors ('aaduser=you@yourdomain.com') 'Dev testing'
+```
+
+**For production** (uses a service principal):
+
+```kql
+.add database MyDatabase ingestors ('aadapp=<ApplicationID>') 'OTel Collector'
+```
+
+> Replace `MyDatabase` with your actual database name, and `<ApplicationID>` with the client ID from your [Entra app registration](https://learn.microsoft.com/en-us/azure/data-explorer/provision-entra-id-app?tabs=portal).
+
+## Step 3: Create a .NET app with the distro
+
+Create a new ASP.NET Core app and install the distro:
+
+```bash
+dotnet new web -n FabricDemo
+cd FabricDemo
+dotnet add package Microsoft.OpenTelemetry
+```
+
+Replace `Program.cs` with:
+
+```csharp
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.Otlp;
+    });
+
+var app = builder.Build();
+app.MapGet("/", () => "Hello from distro → Fabric!");
+app.Run();
+```
+
+That's it for the app. The distro automatically instruments HTTP requests, captures logs, and collects metrics. Setting `ExportTarget.Otlp` sends everything to `http://localhost:4317` (the collector) via the OTLP protocol.
+
+> **Remote collector?** Set the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT=http://<collector-host>:4317` before running the app.
+
+## Step 4: Configure the OpenTelemetry Collector
+
+The collector sits between your app and Fabric/ADX. Create a file called `collector-config.yaml` in your project directory:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    send_batch_size: 512
+    timeout: 5s
+
+exporters:
+  azuredataexplorer:
+    cluster_uri: "https://<your-cluster>.kusto.windows.net"
+    # Authentication — pick one:
+    #   Option 1: DefaultAzureCredential (Azure CLI, Managed Identity, Workload Identity)
+    use_azure_auth: true
+    #   Option 2: Service principal with client secret
+    # application_id: "<client-id>"
+    # application_key: "<client-secret>"
+    # tenant_id: "<tenant-id>"
+
+    db_name: "<your-database>"
+    metrics_table_name: "OTELMetrics"
+    logs_table_name: "OTELLogs"
+    traces_table_name: "OTELTraces"
+    ingestion_type: "queued"   # or "managed" for streaming
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuredataexplorer]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuredataexplorer]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuredataexplorer]
+```
+
+**Update these placeholders:**
+
+| Placeholder | Replace with | Example |
+|---|---|---|
+| `<your-cluster>` | Your ADX cluster or Fabric KQL database URI | `mycluster.westus2.kusto.windows.net` |
+| `<your-database>` | The database name where you created the tables | `MyDatabase` |
+
+### Authentication options
+
+| Method | Config | When to use |
+|---|---|---|
+| **DefaultAzureCredential** | `use_azure_auth: true` | Local dev (`az login`), Managed Identity, Workload Identity (AKS) |
+| **Service principal** | `application_id` + `application_key` + `tenant_id` | CI/CD, headless environments |
+
+## Step 5: Download and run the collector
+
+> **Important:** If you're running the [Aspire Dashboard](aspire-dashboard.md), stop it first — both use port 4317:
+> ```bash
+> docker stop aspire-dashboard
+> ```
+
+The collector is a single binary. Download it, then run it with your config file.
+
+### Option A: Binary (recommended for getting started)
+
+1. Download the latest **otelcol-contrib** binary for your OS from [OTel Collector Contrib releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases) (look for `otelcol-contrib_*` assets).
+
+2. Make sure you're logged into Azure CLI (the collector uses this for authentication):
+
+   ```bash
+   az login
+   ```
+
+3. Run the collector:
+
+   ```bash
+   # Windows
+   otelcol-contrib.exe --config collector-config.yaml
+
+   # Linux / macOS
+   ./otelcol-contrib --config collector-config.yaml
+   ```
+
+4. You should see `Everything is ready. Begin running and processing data.` — the collector is now listening on port 4317.
+
+### Option B: Docker
+
+> **Note:** `use_azure_auth: true` requires Azure CLI inside the container. For Docker, use `application_id` + `application_key` + `tenant_id` in the config instead, or mount your Azure CLI credentials.
+
+```bash
+docker run --rm -p 4317:4317 -p 4318:4318 \
+  -v $(pwd)/collector-config.yaml:/etc/otelcol-contrib/config.yaml \
+  otel/opentelemetry-collector-contrib:0.121.0
+```
+
+### Option C: Kubernetes
+
+For production deployments, see the [Azure Data Explorer exporter docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter) for Kubernetes examples using Workload Identity.
+
+## Step 6: Run the app and verify
+
+With the collector running in one terminal, open a second terminal and start the app:
+
+```bash
+dotnet run
+```
+
+Send a few requests to generate telemetry:
+
+```bash
+curl http://localhost:5000/
+curl http://localhost:5000/weather
+```
+
+After the collector batch interval (5s default), query your tables in the ADX web UI:
+
+```kql
+// Check for traces (each HTTP request creates a span)
+OTELTraces | take 10
+
+// Check for logs (ASP.NET Core request logging)
+OTELLogs | take 10
+
+// Check for metrics (request counts, durations)
+OTELMetrics | take 10
+```
+
+> **Don't see data?** Check the collector terminal for errors. Common issues: wrong `cluster_uri`, missing permissions (re-run Step 2), or `az login` session expired.
+
+## Combining with Azure Monitor
+
+You can send to both Azure Monitor **and** Fabric simultaneously. The app exports via OTLP (collector → Fabric) and directly to Azure Monitor — no extra collector needed for Azure Monitor:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Otlp;
+        o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
+    });
+```
+
+## References
+
+- [Ingest data from OpenTelemetry to Azure Data Explorer](https://learn.microsoft.com/en-us/azure/data-explorer/open-telemetry-connector?tabs=command-line) — Full ADX + OTel Collector setup guide
+- [Create a Microsoft Entra app registration](https://learn.microsoft.com/en-us/azure/data-explorer/provision-entra-id-app?tabs=portal) — Service principal setup for ADX authentication
+- [Azure Data Explorer exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/azuredataexplorerexporter) — Collector plugin source code and configuration reference
+- [Fabric Real-Time Intelligence overview](https://learn.microsoft.com/en-us/fabric/real-time-intelligence/overview) — Microsoft Fabric's real-time analytics capability
+- [Example: Microsoft.OpenTelemetry.Fabric.Demo](../examples/Microsoft.OpenTelemetry.Fabric.Demo) — Working sample app with collector config

--- a/docs/fabric-getting-started.md
+++ b/docs/fabric-getting-started.md
@@ -77,22 +77,20 @@ Replace `Program.cs` with:
 
 ```csharp
 using Microsoft.OpenTelemetry;
-using OpenTelemetry;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        o.Exporters = ExportTarget.Otlp;
-    });
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.Otlp;
+});
 
 var app = builder.Build();
 app.MapGet("/", () => "Hello from distro → Fabric!");
 app.Run();
 ```
 
-That's it for the app. The distro automatically instruments HTTP requests, captures logs, and collects metrics. Setting `ExportTarget.Otlp` sends everything to `http://localhost:4317` (the collector) via the OTLP protocol.
+That's it for the app. `UseMicrosoftOpenTelemetry` automatically instruments HTTP requests, captures logs, and collects metrics. Setting `ExportTarget.Otlp` sends everything to `http://localhost:4317` (the collector) via the OTLP protocol.
 
 > **Remote collector?** Set the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT=http://<collector-host>:4317` before running the app.
 
@@ -151,7 +149,7 @@ service:
 
 | Placeholder | Replace with | Example |
 |---|---|---|
-| `<your-cluster>` | Your ADX cluster or Fabric KQL database URI | `mycluster.westus2.kusto.windows.net` |
+| `<your-cluster>` | Your cluster hostname (without `https://`) | `mycluster.westus2.kusto.windows.net` |
 | `<your-database>` | The database name where you created the tables | `MyDatabase` |
 
 ### Authentication options
@@ -214,11 +212,11 @@ With the collector running in one terminal, open a second terminal and start the
 dotnet run
 ```
 
-Send a few requests to generate telemetry:
+Send a few requests to generate telemetry (use the URL printed by `dotnet run`):
 
 ```bash
-curl http://localhost:5000/
-curl http://localhost:5000/weather
+curl http://localhost:<port>/
+curl http://localhost:<port>/weather
 ```
 
 After the collector batch interval (5s default), query your tables in the ADX web UI:
@@ -241,12 +239,11 @@ OTELMetrics | take 10
 You can send to both Azure Monitor **and** Fabric simultaneously. The app exports via OTLP (collector → Fabric) and directly to Azure Monitor — no extra collector needed for Azure Monitor:
 
 ```csharp
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Otlp;
-        o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
-    });
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    o.Exporters = ExportTarget.AzureMonitor | ExportTarget.Otlp;
+    o.AzureMonitor.ConnectionString = "InstrumentationKey=...";
+});
 ```
 
 ## References

--- a/examples/Microsoft.OpenTelemetry.Fabric.Demo/Microsoft.OpenTelemetry.Fabric.Demo.csproj
+++ b/examples/Microsoft.OpenTelemetry.Fabric.Demo/Microsoft.OpenTelemetry.Fabric.Demo.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.OpenTelemetry\Microsoft.OpenTelemetry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Microsoft.OpenTelemetry.Fabric.Demo/Program.cs
+++ b/examples/Microsoft.OpenTelemetry.Fabric.Demo/Program.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fabric Demo — OTLP → OTel Collector → Azure Data Explorer / Fabric
+//
+// Demonstrates using the Microsoft OpenTelemetry distro with the OTLP
+// exporter to send traces, metrics, and logs to Microsoft Fabric (Real-Time
+// Intelligence) or Azure Data Explorer via an OpenTelemetry Collector.
+//
+// The app exports via OTLP to a local or remote OTel Collector configured
+// with the Azure Data Explorer exporter. See the companion collector-config.yaml.
+//
+// Set OTEL_EXPORTER_OTLP_ENDPOINT to point to your collector (default: http://localhost:4317).
+// ────────────────────────────────────────────────────────────────────────────
+
+using Microsoft.OpenTelemetry;
+using OpenTelemetry;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOpenTelemetry()
+    .UseMicrosoftOpenTelemetry(o =>
+    {
+        // Export via OTLP to the OTel Collector.
+        // The collector forwards to Azure Data Explorer / Fabric.
+        o.Exporters = ExportTarget.Otlp;
+    });
+
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello from Microsoft.OpenTelemetry → Fabric!");
+app.MapGet("/weather", () => new { Temp = 72, City = "Seattle", Unit = "F" });
+
+app.Run();

--- a/examples/Microsoft.OpenTelemetry.Fabric.Demo/Program.cs
+++ b/examples/Microsoft.OpenTelemetry.Fabric.Demo/Program.cs
@@ -15,17 +15,15 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 using Microsoft.OpenTelemetry;
-using OpenTelemetry;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddOpenTelemetry()
-    .UseMicrosoftOpenTelemetry(o =>
-    {
-        // Export via OTLP to the OTel Collector.
-        // The collector forwards to Azure Data Explorer / Fabric.
-        o.Exporters = ExportTarget.Otlp;
-    });
+builder.UseMicrosoftOpenTelemetry(o =>
+{
+    // Export via OTLP to the OTel Collector.
+    // The collector forwards to Azure Data Explorer / Fabric.
+    o.Exporters = ExportTarget.Otlp;
+});
 
 var app = builder.Build();
 

--- a/examples/Microsoft.OpenTelemetry.Fabric.Demo/README.md
+++ b/examples/Microsoft.OpenTelemetry.Fabric.Demo/README.md
@@ -1,0 +1,44 @@
+# Microsoft.OpenTelemetry.Fabric.Demo
+
+ASP.NET Core app that sends traces, metrics, and logs to Microsoft Fabric Real-Time Intelligence (or Azure Data Explorer) via an OpenTelemetry Collector.
+
+## How to run
+
+### 1. Start the OTel Collector
+
+Edit `collector-config.yaml` — replace `<your-cluster>` and `<your-database>` with your values.
+
+```bash
+# Download otelcol-contrib from https://github.com/open-telemetry/opentelemetry-collector-releases/releases
+az login
+otelcol-contrib --config collector-config.yaml
+```
+
+### 2. Run the app
+
+In a second terminal:
+
+```bash
+dotnet run
+```
+
+### 3. Send requests
+
+```bash
+curl http://localhost:5000/
+curl http://localhost:5000/weather
+```
+
+### 4. Query your data
+
+In the [ADX web UI](https://dataexplorer.azure.com/):
+
+```kql
+OTELTraces | take 10
+OTELLogs | take 10
+OTELMetrics | take 10
+```
+
+## Full guide
+
+See [docs/fabric-getting-started.md](../../docs/fabric-getting-started.md) for table creation, permissions, authentication options, and deployment guidance.

--- a/examples/Microsoft.OpenTelemetry.Fabric.Demo/collector-config.yaml
+++ b/examples/Microsoft.OpenTelemetry.Fabric.Demo/collector-config.yaml
@@ -1,0 +1,49 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    send_batch_size: 512
+    timeout: 5s
+
+exporters:
+  azuredataexplorer:
+    cluster_uri: "https://<your-cluster>.kusto.windows.net"
+    # Authentication — pick one:
+    #   Option 1: DefaultAzureCredential (Azure CLI, Managed Identity, etc.)
+    use_azure_auth: true
+    #   Option 2: Service principal
+    # application_id: "<client-id>"
+    # application_key: "<client-secret>"
+    # tenant_id: "<tenant-id>"
+
+    db_name: "<your-database>"
+    metrics_table_name: "OTELMetrics"
+    logs_table_name: "OTELLogs"
+    traces_table_name: "OTELTraces"
+    ingestion_type: "queued"
+  debug:
+    verbosity: basic
+
+service:
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuredataexplorer, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuredataexplorer, debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuredataexplorer, debug]


### PR DESCRIPTION
## Summary

Add two new getting started guides and a working example for sending telemetry to Microsoft Fabric / Azure Data Explorer.

### New docs

- **[docs/fabric-getting-started.md](docs/fabric-getting-started.md)** — Step-by-step guide for sending traces, metrics, and logs to Fabric Real-Time Intelligence or Azure Data Explorer via the OTel Collector with the ADX exporter. Covers table creation, permissions, collector config (binary/Docker/K8s), authentication options, and troubleshooting.

- **[docs/aspire-dashboard.md](docs/aspire-dashboard.md)** — Local development guide using the .NET Aspire Dashboard as a free telemetry viewer. Includes Docker setup, port conflict warning (Aspire and OTel Collector both use 4317), and how to combine with other exporters.

### New example

- **[examples/Microsoft.OpenTelemetry.Fabric.Demo](examples/Microsoft.OpenTelemetry.Fabric.Demo)** — ASP.NET Core app with `ExportTarget.Otlp`, plus a `collector-config.yaml` template for the ADX exporter.

### README updates

- Added \\4. Microsoft Fabric / Azure Data Explorer\\ onboarding scenario
- Added doc and example links to the Documentation and Examples sections

### Validated

- Ran the Fabric Demo locally with OTel Collector contrib (native binary, Azure CLI auth)
- Confirmed all 3 signals (traces, metrics, logs) appear in ADX tables via KQL queries