### PR TITLE
fix: add product context fallback for subchannels

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Read(//c/distro//**)",
-      "Read(//c/repos//**)",
-      "Read(//c/repos1//**)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//c/distro//**)",
+      "Read(//c/repos//**)",
+      "Read(//c/repos1//**)"
+    ]
+  }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
@@ -71,7 +71,30 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
         public static IEnumerable<KeyValuePair<string, object?>> GetChannelBaggagePairs(this ITurnContext turnContext)
         {
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.ChannelNameKey, turnContext.Activity?.ChannelId?.Channel);
-            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.ChannelLinkKey, turnContext.Activity?.ChannelId?.SubChannel);
+
+            var subChannel = turnContext.Activity?.ChannelId?.SubChannel;
+            if (string.IsNullOrWhiteSpace(subChannel) && turnContext.Activity?.ChannelData != null)
+            {
+                try
+                {
+                    var channelDataJson = turnContext.Activity.ChannelData.ToString();
+                    if (!string.IsNullOrWhiteSpace(channelDataJson))
+                    {
+                        using var doc = System.Text.Json.JsonDocument.Parse(channelDataJson);
+                        if (doc.RootElement.TryGetProperty("productContext", out var productContextElem) &&
+                            productContextElem.ValueKind == System.Text.Json.JsonValueKind.String)
+                        {
+                            subChannel = productContextElem.GetString();
+                        }
+                    }
+                }
+                catch
+                {
+                    // Ignore ChannelData parsing failures and keep subChannel fallback behavior.
+                }
+            }
+
+            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.ChannelLinkKey, subChannel);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
@@ -85,14 +85,37 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
             {
                 try
                 {
-                    var channelDataJson = turnContext.Activity.ChannelData.ToString();
-                    if (!string.IsNullOrWhiteSpace(channelDataJson))
+                    var channelData = turnContext.Activity.ChannelData;
+
+                    // Handle JsonElement directly (avoids ToString + reparse)
+                    if (channelData is System.Text.Json.JsonElement jsonElement)
                     {
-                        using var doc = System.Text.Json.JsonDocument.Parse(channelDataJson);
-                        if (doc.RootElement.TryGetProperty("productContext", out var productContextElem) &&
+                        if (jsonElement.TryGetProperty("productContext", out var productContextElem) &&
                             productContextElem.ValueKind == System.Text.Json.JsonValueKind.String)
                         {
                             subChannel = productContextElem.GetString();
+                        }
+                    }
+                    else if (channelData is System.Text.Json.Nodes.JsonObject jsonObject)
+                    {
+                        if (jsonObject.TryGetPropertyValue("productContext", out var node) &&
+                            node is System.Text.Json.Nodes.JsonValue val)
+                        {
+                            subChannel = val.ToString();
+                        }
+                    }
+                    else
+                    {
+                        // Fallback: serialize to string and parse
+                        var channelDataJson = channelData.ToString();
+                        if (!string.IsNullOrWhiteSpace(channelDataJson))
+                        {
+                            using var doc = System.Text.Json.JsonDocument.Parse(channelDataJson);
+                            if (doc.RootElement.TryGetProperty("productContext", out var elem) &&
+                                elem.ValueKind == System.Text.Json.JsonValueKind.String)
+                            {
+                                subChannel = elem.GetString();
+                            }
                         }
                     }
                 }
@@ -102,7 +125,7 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
                 }
             }
 
-            return subChannel;
+            return string.IsNullOrWhiteSpace(subChannel) ? null : subChannel;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
@@ -71,7 +71,15 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
         public static IEnumerable<KeyValuePair<string, object?>> GetChannelBaggagePairs(this ITurnContext turnContext)
         {
             yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.ChannelNameKey, turnContext.Activity?.ChannelId?.Channel);
+            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.ChannelLinkKey, ResolveSubChannel(turnContext));
+        }
 
+        /// <summary>
+        /// Resolves the sub-channel value from the turn context, falling back to
+        /// the <c>productContext</c> property in ChannelData when SubChannel is not set.
+        /// </summary>
+        internal static string? ResolveSubChannel(ITurnContext turnContext)
+        {
             var subChannel = turnContext.Activity?.ChannelId?.SubChannel;
             if (string.IsNullOrWhiteSpace(subChannel) && turnContext.Activity?.ChannelData != null)
             {
@@ -94,7 +102,7 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
                 }
             }
 
-            yield return new KeyValuePair<string, object?>(OpenTelemetryConstants.ChannelLinkKey, subChannel);
+            return subChannel;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Extensions/TurnContextExtensions.cs
@@ -86,14 +86,14 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
                 try
                 {
                     var channelData = turnContext.Activity.ChannelData;
+                    string? productContext = null;
 
-                    // Handle JsonElement directly (avoids ToString + reparse)
                     if (channelData is System.Text.Json.JsonElement jsonElement)
                     {
-                        if (jsonElement.TryGetProperty("productContext", out var productContextElem) &&
-                            productContextElem.ValueKind == System.Text.Json.JsonValueKind.String)
+                        if (jsonElement.TryGetProperty("productContext", out var pc) &&
+                            pc.ValueKind == System.Text.Json.JsonValueKind.String)
                         {
-                            subChannel = productContextElem.GetString();
+                            productContext = pc.GetString();
                         }
                     }
                     else if (channelData is System.Text.Json.Nodes.JsonObject jsonObject)
@@ -101,22 +101,26 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Extensions
                         if (jsonObject.TryGetPropertyValue("productContext", out var node) &&
                             node is System.Text.Json.Nodes.JsonValue val)
                         {
-                            subChannel = val.ToString();
+                            productContext = val.ToString();
                         }
                     }
                     else
                     {
-                        // Fallback: serialize to string and parse
-                        var channelDataJson = channelData.ToString();
-                        if (!string.IsNullOrWhiteSpace(channelDataJson))
+                        var json = channelData.ToString();
+                        if (!string.IsNullOrWhiteSpace(json))
                         {
-                            using var doc = System.Text.Json.JsonDocument.Parse(channelDataJson);
-                            if (doc.RootElement.TryGetProperty("productContext", out var elem) &&
-                                elem.ValueKind == System.Text.Json.JsonValueKind.String)
+                            using var doc = System.Text.Json.JsonDocument.Parse(json);
+                            if (doc.RootElement.TryGetProperty("productContext", out var pc) &&
+                                pc.ValueKind == System.Text.Json.JsonValueKind.String)
                             {
-                                subChannel = elem.GetString();
+                                productContext = pc.GetString();
                             }
                         }
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(productContext))
+                    {
+                        subChannel = productContext;
                     }
                 }
                 catch

--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/Middleware/OutputLoggingMiddleware.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/Middleware/OutputLoggingMiddleware.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Agents.A365.Observability.Hosting.Middleware
 
             return new Channel(
                 name: channelId.Channel,
-                link: channelId.SubChannel);
+                link: Extensions.TurnContextExtensions.ResolveSubChannel(turnContext));
         }
 
         private static SendActivitiesHandler CreateSendHandler(

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Hosting/Middleware/BaggageTurnMiddlewareTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Hosting/Middleware/BaggageTurnMiddlewareTests.cs
@@ -107,9 +107,103 @@ public class BaggageTurnMiddlewareTests
         baggageAfterMiddleware.Should().Be(baggageBeforeMiddleware);
     }
 
+    [TestMethod]
+    public async Task OnTurnAsync_ExtractsProductContextFromChannelData()
+    {
+        // Arrange
+        var middleware = new BaggageTurnMiddleware();
+        var channelData = new { productContext = "copilot-m365" };
+        var turnContext = CreateTurnContext(channelData: channelData);
+
+        string? capturedChannelLink = null;
+
+        NextDelegate next = (ct) =>
+        {
+            capturedChannelLink = Baggage.Current.GetBaggage(OpenTelemetryConstants.ChannelLinkKey);
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await middleware.OnTurnAsync(turnContext, next);
+
+        // Assert
+        capturedChannelLink.Should().Be("copilot-m365");
+    }
+
+    [TestMethod]
+    public async Task OnTurnAsync_SubChannelTakesPrecedenceOverProductContext()
+    {
+        // Arrange
+        var middleware = new BaggageTurnMiddleware();
+        var channelData = new { productContext = "copilot-m365" };
+        var turnContext = CreateTurnContext(subChannel: "explicit-subchannel", channelData: channelData);
+
+        string? capturedChannelLink = null;
+
+        NextDelegate next = (ct) =>
+        {
+            capturedChannelLink = Baggage.Current.GetBaggage(OpenTelemetryConstants.ChannelLinkKey);
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await middleware.OnTurnAsync(turnContext, next);
+
+        // Assert
+        capturedChannelLink.Should().Be("explicit-subchannel");
+    }
+
+    [TestMethod]
+    public async Task OnTurnAsync_ExtractsProductContextFromJsonStringChannelData()
+    {
+        // Arrange
+        var middleware = new BaggageTurnMiddleware();
+        var channelData = "{\"productContext\": \"copilot-teams\"}";
+        var turnContext = CreateTurnContext(channelData: channelData);
+
+        string? capturedChannelLink = null;
+
+        NextDelegate next = (ct) =>
+        {
+            capturedChannelLink = Baggage.Current.GetBaggage(OpenTelemetryConstants.ChannelLinkKey);
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await middleware.OnTurnAsync(turnContext, next);
+
+        // Assert
+        capturedChannelLink.Should().Be("copilot-teams");
+    }
+
+    [TestMethod]
+    public async Task OnTurnAsync_HandlesInvalidJsonChannelDataGracefully()
+    {
+        // Arrange
+        var middleware = new BaggageTurnMiddleware();
+        var channelData = "not-valid-json";
+        var turnContext = CreateTurnContext(channelData: channelData);
+
+        string? capturedChannelLink = null;
+
+        NextDelegate next = (ct) =>
+        {
+            capturedChannelLink = Baggage.Current.GetBaggage(OpenTelemetryConstants.ChannelLinkKey);
+            return Task.CompletedTask;
+        };
+
+        // Act
+        await middleware.OnTurnAsync(turnContext, next);
+
+        // Assert – should not throw and channel link should be null
+        capturedChannelLink.Should().BeNull();
+    }
+
     private static ITurnContext CreateTurnContext(
         string activityType = "message",
-        string? activityName = null)
+        string? activityName = null,
+        string? subChannel = null,
+        object? channelData = null)
     {
         var mockActivity = new Mock<IActivity>();
         mockActivity.Setup(a => a.Type).Returns(activityType);
@@ -133,7 +227,16 @@ public class BaggageTurnMiddlewareTests
         });
         mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
         mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
-        mockActivity.Setup(a => a.ChannelId).Returns(new ChannelId("test-channel"));
+        var channelId = new ChannelId("test-channel");
+        if (subChannel != null)
+        {
+            channelId.SubChannel = subChannel;
+        }
+        mockActivity.Setup(a => a.ChannelId).Returns(channelId);
+        if (channelData != null)
+        {
+            mockActivity.Setup(a => a.ChannelData).Returns(channelData);
+        }
 
         var mockTurnContext = new Mock<ITurnContext>();
         mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Hosting/Middleware/BaggageTurnMiddlewareTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Hosting/Middleware/BaggageTurnMiddlewareTests.cs
@@ -112,7 +112,10 @@ public class BaggageTurnMiddlewareTests
     {
         // Arrange
         var middleware = new BaggageTurnMiddleware();
-        var channelData = new { productContext = "copilot-m365" };
+        var channelData = new System.Text.Json.Nodes.JsonObject
+        {
+            ["productContext"] = "copilot-m365",
+        };
         var turnContext = CreateTurnContext(channelData: channelData);
 
         string? capturedChannelLink = null;
@@ -135,7 +138,10 @@ public class BaggageTurnMiddlewareTests
     {
         // Arrange
         var middleware = new BaggageTurnMiddleware();
-        var channelData = new { productContext = "copilot-m365" };
+        var channelData = new System.Text.Json.Nodes.JsonObject
+        {
+            ["productContext"] = "copilot-m365",
+        };
         var turnContext = CreateTurnContext(subChannel: "explicit-subchannel", channelData: channelData);
 
         string? capturedChannelLink = null;

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Hosting/Middleware/OutputLoggingMiddlewareTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Hosting/Middleware/OutputLoggingMiddlewareTests.cs
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using FluentAssertions;
 using Microsoft.Agents.A365.Observability.Hosting.Middleware;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
 using Microsoft.Agents.Builder;
 using Microsoft.Agents.Core.Models;
 using Moq;
+
+using DiagnosticsActivity = System.Diagnostics.Activity;
 
 namespace Microsoft.Agents.A365.Observability.Hosting.Tests.Middleware;
 
@@ -109,6 +113,100 @@ public class OutputLoggingMiddlewareTests
         mockTurnContext.Verify(tc => tc.OnSendActivities(It.IsAny<SendActivitiesHandler>()), Times.Once);
     }
 
+    [TestMethod]
+    public async Task OnTurnAsync_UsesProductContextFromChannelData_WhenSubChannelIsNotSet()
+    {
+        // Arrange
+        AppContext.SetSwitch(OpenTelemetryConstants.EnableOpenTelemetrySwitch, true);
+        var middleware = new OutputLoggingMiddleware();
+        var channelData = "{\"productContext\": \"copilot-m365\"}";
+        SendActivitiesHandler? capturedHandler = null;
+
+        var mockTurnContext = new Mock<ITurnContext>();
+        SetupTurnContext(mockTurnContext, channelData: channelData);
+        mockTurnContext.Setup(tc => tc.OnSendActivities(It.IsAny<SendActivitiesHandler>()))
+            .Callback<SendActivitiesHandler>(handler => capturedHandler = handler)
+            .Returns(mockTurnContext.Object);
+
+        NextDelegate next = (ct) => Task.CompletedTask;
+
+        // Act
+        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+
+        // Assert – invoke captured handler and inspect the span
+        capturedHandler.Should().NotBeNull();
+
+        var outgoingActivity = new Mock<IActivity>();
+        outgoingActivity.Setup(a => a.Type).Returns(ActivityTypes.Message);
+        outgoingActivity.Setup(a => a.Text).Returns("Hello output");
+        var activities = new List<IActivity> { outgoingActivity.Object };
+
+        DiagnosticsActivity? recordedSpan = null;
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == OpenTelemetryConstants.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = a => recordedSpan = a,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await capturedHandler(
+            mockTurnContext.Object,
+            activities,
+            () => Task.FromResult(Array.Empty<ResourceResponse>()));
+
+        recordedSpan.Should().NotBeNull();
+        recordedSpan!.TagObjects.Should().ContainKey(OpenTelemetryConstants.ChannelLinkKey)
+            .WhoseValue.Should().Be("copilot-m365");
+    }
+
+    [TestMethod]
+    public async Task OnTurnAsync_UsesSubChannel_WhenBothSubChannelAndProductContextArePresent()
+    {
+        // Arrange
+        AppContext.SetSwitch(OpenTelemetryConstants.EnableOpenTelemetrySwitch, true);
+        var middleware = new OutputLoggingMiddleware();
+        var channelData = "{\"productContext\": \"copilot-m365\"}";
+        SendActivitiesHandler? capturedHandler = null;
+
+        var mockTurnContext = new Mock<ITurnContext>();
+        SetupTurnContext(mockTurnContext, subChannel: "explicit-subchannel", channelData: channelData);
+        mockTurnContext.Setup(tc => tc.OnSendActivities(It.IsAny<SendActivitiesHandler>()))
+            .Callback<SendActivitiesHandler>(handler => capturedHandler = handler)
+            .Returns(mockTurnContext.Object);
+
+        NextDelegate next = (ct) => Task.CompletedTask;
+
+        // Act
+        await middleware.OnTurnAsync(mockTurnContext.Object, next);
+
+        // Assert – invoke captured handler and inspect the span
+        capturedHandler.Should().NotBeNull();
+
+        var outgoingActivity = new Mock<IActivity>();
+        outgoingActivity.Setup(a => a.Type).Returns(ActivityTypes.Message);
+        outgoingActivity.Setup(a => a.Text).Returns("Hello output");
+        var activities = new List<IActivity> { outgoingActivity.Object };
+
+        DiagnosticsActivity? recordedSpan = null;
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == OpenTelemetryConstants.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = a => recordedSpan = a,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await capturedHandler(
+            mockTurnContext.Object,
+            activities,
+            () => Task.FromResult(Array.Empty<ResourceResponse>()));
+
+        recordedSpan.Should().NotBeNull();
+        recordedSpan!.TagObjects.Should().ContainKey(OpenTelemetryConstants.ChannelLinkKey)
+            .WhoseValue.Should().Be("explicit-subchannel");
+    }
+
     private static ITurnContext CreateTurnContext()
     {
         var mockTurnContext = new Mock<ITurnContext>();
@@ -116,7 +214,7 @@ public class OutputLoggingMiddlewareTests
         return mockTurnContext.Object;
     }
 
-    private static void SetupTurnContext(Mock<ITurnContext> mockTurnContext)
+    private static void SetupTurnContext(Mock<ITurnContext> mockTurnContext, string? subChannel = null, object? channelData = null)
     {
         var mockActivity = new Mock<IActivity>();
         mockActivity.Setup(a => a.Type).Returns("message");
@@ -136,7 +234,19 @@ public class OutputLoggingMiddlewareTests
         });
         mockActivity.Setup(a => a.Conversation).Returns(new ConversationAccount { Id = "conv-id" });
         mockActivity.Setup(a => a.ServiceUrl).Returns("https://example.com");
-        mockActivity.Setup(a => a.ChannelId).Returns(new ChannelId("test-channel"));
+
+        var channelId = new ChannelId("test-channel");
+        if (subChannel != null)
+        {
+            channelId.SubChannel = subChannel;
+        }
+
+        mockActivity.Setup(a => a.ChannelId).Returns(channelId);
+
+        if (channelData != null)
+        {
+            mockActivity.Setup(a => a.ChannelData).Returns(channelData);
+        }
 
         mockTurnContext.Setup(tc => tc.Activity).Returns(mockActivity.Object);
         mockTurnContext.Setup(tc => tc.StackState).Returns(new TurnContextStateCollection());


### PR DESCRIPTION
fix: add product context fallback for subchannels

Ports the subchannel fallback from SDK PR:https://github.com/microsoft/Agent365-dotnet/pull/248.
Additionally, extracted a shared `ResolveSubChannel` helper in `TurnContextExtensions` and applied the same fallback to `OutputLoggingMiddleware.DeriveChannel()`, which was still reading `SubChannel` directly without the `productContext` fallback.