### PR TITLE
Update telemetry SDK name to microsoft-opentelemetry

### DIFF
--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         public const string TelemetrySdkNameKey = "telemetry.sdk.name";
         public const string TelemetrySdkLanguageKey = "telemetry.sdk.language";
         public const string TelemetrySdkVersionKey = "telemetry.sdk.version";
-        public const string TelemetrySdkNameValue = "A365ObservabilitySDK";
+        public const string TelemetrySdkNameValue = "microsoft-opentelemetry";
         public const string TelemetrySdkLanguageValue = "dotnet";
         
         /// <summary>


### PR DESCRIPTION
Change `TelemetrySdkNameValue` from `A365ObservabilitySDK` to `microsoft-opentelemetry` to align with the package distribution name.

Sibling PRs:
- Python: https://github.com/microsoft/opentelemetry-distro-python/pull/138
- JS: https://github.com/microsoft/opentelemetry-distro-javascript/pull/134