### PR TITLE
Add ContextualTokenResolver with agentic user ID support

### DIFF
--- a/examples/Microsoft.OpenTelemetry.Agent365.Demo/Agent/MyAgent.cs
+++ b/examples/Microsoft.OpenTelemetry.Agent365.Demo/Agent/MyAgent.cs
@@ -59,6 +59,7 @@ namespace Agent365AgentFrameworkSampleAgent.Agent
 
         private readonly IChatClient? _chatClient = null;
         private readonly IConfiguration? _configuration = null;
+        private readonly MyTokenService? _tokenService = null;
         private readonly IExporterTokenCache<AgenticTokenStruct>? _agentTokenCache = null;
         private readonly ILogger<MyAgent>? _logger = null;
         private readonly IMcpToolRegistrationService? _toolService = null;
@@ -98,12 +99,14 @@ namespace Agent365AgentFrameworkSampleAgent.Agent
         public MyAgent(AgentApplicationOptions options,
             IChatClient chatClient,
             IConfiguration configuration,
+            MyTokenService tokenService,
             IExporterTokenCache<AgenticTokenStruct> agentTokenCache,
             IMcpToolRegistrationService toolService,
             ILogger<MyAgent> logger) : base(options)
         {
             _chatClient = chatClient;
             _configuration = configuration;
+            _tokenService = tokenService;
             _agentTokenCache = agentTokenCache;
             _logger = logger;
             _toolService = toolService;
@@ -217,6 +220,7 @@ namespace Agent365AgentFrameworkSampleAgent.Agent
                 "MessageProcessor",
                 turnContext,
                 turnState,
+                _tokenService!,
                 _agentTokenCache,
                 UserAuthorization,
                 ObservabilityAuthHandlerName ?? string.Empty,

--- a/examples/Microsoft.OpenTelemetry.Agent365.Demo/MyTokenService.cs
+++ b/examples/Microsoft.OpenTelemetry.Agent365.Demo/MyTokenService.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.A365.Observability.Runtime.Common;
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.App.UserAuth;
+using System.Collections.Concurrent;
+using System.IdentityModel.Tokens.Jwt;
+
+namespace Agent365AgentFrameworkSampleAgent;
+
+/// <summary>
+/// Manual token service demonstrating ContextualTokenResolver usage.
+/// Mirrors AgenticTokenCache behavior: stores per-turn credentials during the request,
+/// then resolves tokens at export time via UserAuthorization.ExchangeTurnTokenAsync.
+/// </summary>
+public sealed class MyTokenService
+{
+    private sealed class Entry
+    {
+        public UserAuthorization UserAuthorization { get; }
+        public ITurnContext TurnContext { get; }
+        public string AuthHandlerName { get; }
+        public string[] Scopes { get; }
+        public string? Token { get; set; }
+        public DateTimeOffset? ExpiresAt { get; set; }
+
+        public Entry(UserAuthorization userAuth, ITurnContext turnContext, string authHandlerName, string[] scopes)
+        {
+            UserAuthorization = userAuth;
+            TurnContext = turnContext;
+            AuthHandlerName = authHandlerName;
+            Scopes = scopes;
+        }
+    }
+
+    private readonly ConcurrentDictionary<string, Entry> _map = new();
+
+    /// <summary>
+    /// Registers credentials during the turn so they can be used at export time.
+    /// First registration per (agentId, tenantId) wins; subsequent calls are ignored.
+    /// </summary>
+    public void Register(string agentId, string tenantId, UserAuthorization userAuth, ITurnContext turnContext, string authHandlerName)
+    {
+        var scopes = EnvironmentUtils.GetObservabilityAuthenticationScope();
+        _map.TryAdd($"{agentId}:{tenantId}", new Entry(userAuth, turnContext, authHandlerName, scopes));
+    }
+
+    /// <summary>
+    /// Resolves an auth token for the given agent and tenant.
+    /// Uses cached token if still valid (>5 min until expiry), otherwise exchanges via UserAuthorization.
+    /// </summary>
+    public async Task<string?> GetTokenAsync(string agentId, string tenantId, string? agenticUserId)
+    {
+        if (!_map.TryGetValue($"{agentId}:{tenantId}", out var entry))
+            return null;
+
+        try
+        {
+            // Return cached token if still valid (>5 min buffer before expiry).
+            if (!string.IsNullOrEmpty(entry.Token) && entry.ExpiresAt > DateTimeOffset.UtcNow.AddMinutes(5))
+            {
+                return entry.Token;
+            }
+
+            // Exchange the turn token for an observability-scoped token.
+            var token = await entry.UserAuthorization.ExchangeTurnTokenAsync(
+                entry.TurnContext,
+                entry.AuthHandlerName,
+                exchangeConnection: null,
+                exchangeScopes: entry.Scopes).ConfigureAwait(false);
+
+            entry.Token = token;
+            entry.ExpiresAt = GetTokenExpiration(token);
+
+            return token;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static DateTimeOffset? GetTokenExpiration(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return null;
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwtToken = handler.ReadJwtToken(token);
+        return jwtToken.Payload.Expiration == null
+            ? null
+            : new DateTimeOffset(jwtToken.ValidTo, TimeSpan.Zero);
+    }
+}

--- a/examples/Microsoft.OpenTelemetry.Agent365.Demo/Program.cs
+++ b/examples/Microsoft.OpenTelemetry.Agent365.Demo/Program.cs
@@ -39,7 +39,7 @@ builder.Services.AddOpenTelemetry()
         if (useContextualResolver)
         {
             // ContextualTokenResolver: receives agentId, tenantId, and agenticUserId via context.
-            o.Agent365.Exporter.ContextualTokenResolver = async (context) =>
+            o.Agent365.ContextualTokenResolver = async (context) =>
             {
                 return await tokenService.GetTokenAsync(
                     context.Identity.AgentId, context.TenantId, context.Identity.AgenticUserId);

--- a/examples/Microsoft.OpenTelemetry.Agent365.Demo/Program.cs
+++ b/examples/Microsoft.OpenTelemetry.Agent365.Demo/Program.cs
@@ -42,7 +42,7 @@ builder.Services.AddOpenTelemetry()
             o.Agent365.Exporter.ContextualTokenResolver = async (context) =>
             {
                 return await tokenService.GetTokenAsync(
-                    context.AgentId, context.TenantId, context.AgenticUserId);
+                    context.Identity.AgentId, context.TenantId, context.Identity.AgenticUserId);
             };
         }
         // Otherwise: vanilla TokenResolver is auto-registered via AddAgenticTracingExporter (DI cache).

--- a/examples/Microsoft.OpenTelemetry.Agent365.Demo/Program.cs
+++ b/examples/Microsoft.OpenTelemetry.Agent365.Demo/Program.cs
@@ -23,13 +23,29 @@ using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Read toggle: "Contextual" uses ContextualTokenResolver, otherwise uses vanilla TokenResolver (auto DI cache).
+var useContextualResolver = builder.Configuration.GetValue<bool>("Observability:UseContextualTokenResolver");
+
+// Register the manual token service (used only when contextual resolver is active).
+var tokenService = new MyTokenService();
+builder.Services.AddSingleton(tokenService);
+
 // Setup Microsoft OpenTelemetry distro
 builder.Services.AddOpenTelemetry()
     .UseMicrosoftOpenTelemetry(o =>
     {
         o.Exporters = ExportTarget.Console | ExportTarget.Agent365;
-        // Token resolver is auto-registered via AddAgenticTracingExporter internally.
-        // To use a custom resolver, set: o.Agent365.Exporter.TokenResolver = ...
+
+        if (useContextualResolver)
+        {
+            // ContextualTokenResolver: receives agentId, tenantId, and agenticUserId via context.
+            o.Agent365.Exporter.ContextualTokenResolver = async (context) =>
+            {
+                return await tokenService.GetTokenAsync(
+                    context.AgentId, context.TenantId, context.AgenticUserId);
+            };
+        }
+        // Otherwise: vanilla TokenResolver is auto-registered via AddAgenticTracingExporter (DI cache).
     })
     .WithTracing(tracing => tracing
         .AddSource(

--- a/examples/Microsoft.OpenTelemetry.Agent365.Demo/appsettings.json
+++ b/examples/Microsoft.OpenTelemetry.Agent365.Demo/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "EnableAgent365Exporter": "true",
+
+  "Observability": {
+    "InstrumentationMode": "Auto",
+    "UseContextualTokenResolver": true
+  },
+
   "AgentApplication": {
     "StartTypingTimer": false,
     "RemoveRecipientMention": false,

--- a/examples/Microsoft.OpenTelemetry.Agent365.Demo/telemetry/A365OtelWrapper.cs
+++ b/examples/Microsoft.OpenTelemetry.Agent365.Demo/telemetry/A365OtelWrapper.cs
@@ -15,6 +15,7 @@ namespace Agent365AgentFrameworkSampleAgent.telemetry
             string operationName,
             ITurnContext turnContext,
             ITurnState turnState,
+            MyTokenService tokenService,
             IExporterTokenCache<AgenticTokenStruct>? agentTokenCache,
             UserAuthorization authSystem,
             string authHandlerName,
@@ -36,9 +37,13 @@ namespace Agent365AgentFrameworkSampleAgent.telemetry
                     .AgentId(agentId)
                     .Build();
 
-                    // Register observability token for the exporter
+                    // Register credentials for export-time token resolution.
                     try
                     {
+                        // Register with the manual token service (used by ContextualTokenResolver).
+                        tokenService.Register(agentId, tenantId, authSystem, turnContext, authHandlerName);
+
+                        // Also register with the DI token cache (used by vanilla TokenResolver).
                         agentTokenCache?.RegisterObservability(agentId, tenantId, new AgenticTokenStruct(
                             userAuthorization: authSystem,
                             turnContext: turnContext,

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -12,6 +12,8 @@ Microsoft.OpenTelemetry.Agent365Options.MaxQueueSize.get -> int
 Microsoft.OpenTelemetry.Agent365Options.MaxQueueSize.set -> void
 Microsoft.OpenTelemetry.Agent365Options.ScheduledDelayMilliseconds.get -> int
 Microsoft.OpenTelemetry.Agent365Options.ScheduledDelayMilliseconds.set -> void
+Microsoft.OpenTelemetry.Agent365Options.ContextualTokenResolver.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AsyncContextualTokenResolver?
+Microsoft.OpenTelemetry.Agent365Options.ContextualTokenResolver.set -> void
 Microsoft.OpenTelemetry.Agent365Options.TokenResolver.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AsyncAuthTokenResolver?
 Microsoft.OpenTelemetry.Agent365Options.TokenResolver.set -> void
 Microsoft.OpenTelemetry.Agent365Options.UseS2SEndpoint.get -> bool

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -1,10 +1,11 @@
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AsyncContextualTokenResolver
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AgentIdentity
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AgentIdentity.AgentIdentity(string! agentId, string? agenticUserId = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AgentIdentity.AgentId.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AgentIdentity.AgenticUserId.get -> string?
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext
-const Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.AgenticUserIdKey = "AgenticUserId" -> string!
-Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.TokenResolverContext(string! agentId, string! tenantId, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? metadata = null) -> void
-Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.AgentId.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.TokenResolverContext(Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AgentIdentity! identity, string! tenantId) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.Identity.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AgentIdentity!
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.TenantId.get -> string!
-Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.Metadata.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
-Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.AgenticUserId.get -> string?
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.ContextualTokenResolver.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AsyncContextualTokenResolver?
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.ContextualTokenResolver.set -> void

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -1,8 +1,10 @@
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AsyncContextualTokenResolver
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext
-Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.TokenResolverContext(string! agentId, string! tenantId, string? agenticUserId) -> void
+const Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.AgenticUserIdKey = "AgenticUserId" -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.TokenResolverContext(string! agentId, string! tenantId, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? metadata = null) -> void
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.AgentId.get -> string!
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.TenantId.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.Metadata.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.AgenticUserId.get -> string?
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.ContextualTokenResolver.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AsyncContextualTokenResolver?
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.ContextualTokenResolver.set -> void

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -1,0 +1,8 @@
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AsyncContextualTokenResolver
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.TokenResolverContext(string! agentId, string! tenantId, string? agenticUserId) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.AgentId.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.TenantId.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.AgenticUserId.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.ContextualTokenResolver.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AsyncContextualTokenResolver?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.ContextualTokenResolver.set -> void

--- a/src/Microsoft.OpenTelemetry/Agent365/Agent365Options.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Agent365Options.cs
@@ -28,12 +28,24 @@ public class Agent365Options
     }
 
     /// <summary>
-    /// Async delegate used to resolve the auth token. REQUIRED.
+    /// Async delegate used to resolve the auth token.
+    /// Either this or <see cref="ContextualTokenResolver"/> must be set.
+    /// When both are set, <see cref="ContextualTokenResolver"/> takes precedence.
     /// </summary>
     public AsyncAuthTokenResolver? TokenResolver
     {
         get => ExporterOptions.TokenResolver;
         set => ExporterOptions.TokenResolver = value;
+    }
+
+    /// <summary>
+    /// Async delegate used to resolve the auth token with rich context including the agentic user ID.
+    /// Takes precedence over <see cref="TokenResolver"/> when set.
+    /// </summary>
+    public AsyncContextualTokenResolver? ContextualTokenResolver
+    {
+        get => ExporterOptions.ContextualTokenResolver;
+        set => ExporterOptions.ContextualTokenResolver = value;
     }
 
     /// <summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
@@ -126,9 +126,9 @@ internal static class Agent365OpenTelemetryBuilderExtensions
                 // and setting TokenResolver are independent operations.
                 builder.Services.AddAgenticTracingExporter();
 
-                if (options.Exporter.TokenResolver != null)
+                if (options.Exporter.TokenResolver != null || options.Exporter.ContextualTokenResolver != null)
                 {
-                    // Inline TokenResolver provided — override the cache-based options.
+                    // Inline TokenResolver or ContextualTokenResolver provided — override the cache-based options.
                     // This singleton takes precedence over the one from AddAgenticTracingExporter().
                     builder.Services.AddSingleton(options.Exporter);
                 }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
@@ -126,7 +126,7 @@ internal static class Agent365OpenTelemetryBuilderExtensions
                 // and setting TokenResolver are independent operations.
                 builder.Services.AddAgenticTracingExporter();
 
-                if (options.Exporter.TokenResolver != null || options.Exporter.ContextualTokenResolver != null)
+                if (options.ExporterOptions.TokenResolver != null || options.ExporterOptions.ContextualTokenResolver != null)
                 {
                     // Inline TokenResolver or ContextualTokenResolver provided — override the cache-based options.
                     // This singleton takes precedence over the one from AddAgenticTracingExporter().

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365Exporter.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365Exporter.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _options = options ?? throw new ArgumentNullException(nameof(options));
 
-            if (_options.TokenResolver == null)
-                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver must be provided.");
+            if (_options.TokenResolver == null && _options.ContextualTokenResolver == null)
+                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver or Agent365ExporterOptions.ContextualTokenResolver must be provided.");
 
             _httpClient = httpClient ?? HttpClientFactory.CreateWithTimeout(options.ExporterTimeoutMilliseconds);
             _resource = resource ?? ResourceBuilder.CreateEmpty().Build();

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterAsync.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterAsync.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this._options = options ?? throw new ArgumentNullException(nameof(options));
 
-            if (_options.TokenResolver == null)
-                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver must be provided.");
+            if (_options.TokenResolver == null && _options.ContextualTokenResolver == null)
+                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver or Agent365ExporterOptions.ContextualTokenResolver must be provided.");
 
             this._httpClient = httpClient ?? HttpClientFactory.CreateWithTimeout(options.ExporterTimeoutMilliseconds);
             this._resource = resource ?? ResourceBuilder.CreateEmpty().Build();

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -197,10 +197,19 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                     // first activity in the group (1:1 relationship between agent and agentic user).
                     if (options.ContextualTokenResolver != null)
                     {
+                        Dictionary<string, string>? metadata = null;
                         var agenticUserId = activities.Count > 0
                             ? activities[0].GetAttributeOrBaggage(OpenTelemetryConstants.AgentAUIDKey)
                             : null;
-                        var context = new TokenResolverContext(agentId, tenantId, agenticUserId);
+                        if (agenticUserId != null)
+                        {
+                            metadata = new Dictionary<string, string>
+                            {
+                                [TokenResolverContext.AgenticUserIdKey] = agenticUserId,
+                            };
+                        }
+
+                        var context = new TokenResolverContext(agentId, tenantId, metadata);
                         token = await options.ContextualTokenResolver(context).ConfigureAwait(false);
                     }
                     else

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -193,7 +193,21 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                 string? token = null;
                 try
                 {
-                    token = await tokenResolver(agentId, tenantId).ConfigureAwait(false);
+                    // Prefer ContextualTokenResolver when set; extract agentic user ID from the
+                    // first activity in the group (1:1 relationship between agent and agentic user).
+                    if (options.ContextualTokenResolver != null)
+                    {
+                        var agenticUserId = activities.Count > 0
+                            ? activities[0].GetAttributeOrBaggage(OpenTelemetryConstants.AgentAUIDKey)
+                            : null;
+                        var context = new TokenResolverContext(agentId, tenantId, agenticUserId);
+                        token = await options.ContextualTokenResolver(context).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        token = await tokenResolver(agentId, tenantId).ConfigureAwait(false);
+                    }
+
                     this._logger?.LogDebug("Agent365ExporterCore: Obtained token for agent {AgentId} tenant {TenantId}.", agentId, tenantId);
                 }
                 catch (Exception ex)

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -197,19 +197,12 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                     // first activity in the group (1:1 relationship between agent and agentic user).
                     if (options.ContextualTokenResolver != null)
                     {
-                        Dictionary<string, string>? metadata = null;
                         var agenticUserId = activities.Count > 0
                             ? activities[0].GetAttributeOrBaggage(OpenTelemetryConstants.AgentAUIDKey)
                             : null;
-                        if (agenticUserId != null)
-                        {
-                            metadata = new Dictionary<string, string>
-                            {
-                                [TokenResolverContext.AgenticUserIdKey] = agenticUserId,
-                            };
-                        }
+                        var identity = new AgentIdentity(agentId, agenticUserId);
 
-                        var context = new TokenResolverContext(agentId, tenantId, metadata);
+                        var context = new TokenResolverContext(identity, tenantId);
                         token = await options.ContextualTokenResolver(context).ConfigureAwait(false);
                     }
                     else

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
@@ -13,6 +13,15 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
     public delegate Task<string?> AsyncAuthTokenResolver(string agentId, string tenantId);
 
     /// <summary>
+    /// Async delegate used by the exporter to obtain an auth token using rich context.
+    /// Provides additional fields (e.g. <see cref="TokenResolverContext.AgenticUserId"/>)
+    /// beyond what <see cref="AsyncAuthTokenResolver"/> offers.
+    /// Must be fast and non-blocking (use internal caching elsewhere).
+    /// Return null/empty to omit the Authorization header.
+    /// </summary>
+    public delegate Task<string?> AsyncContextualTokenResolver(TokenResolverContext context);
+
+    /// <summary>
     /// Delegate used by the exporter to resolve the endpoint host or URL for a given tenant id.
     /// The return value may be a bare host name (e.g. "agent365.svc.cloud.microsoft") or a full URL
     /// (e.g. "https://agent365.svc.cloud.microsoft").
@@ -46,9 +55,19 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         public string ClusterCategory { get; set; } = "production";
 
         /// <summary>
-        /// Async delegate used to resolve the auth token. REQUIRED.
+        /// Async delegate used to resolve the auth token.
+        /// Either this or <see cref="ContextualTokenResolver"/> must be set.
+        /// When both are set, <see cref="ContextualTokenResolver"/> takes precedence.
         /// </summary>
         public AsyncAuthTokenResolver? TokenResolver { get; set; }
+
+        /// <summary>
+        /// Async delegate used to resolve the auth token with rich context including the agentic user ID.
+        /// Takes precedence over <see cref="TokenResolver"/> when set.
+        /// When this resolver is active, the exporter partitions export batches by agentic user ID
+        /// in addition to tenant and agent, so each resolver call receives the correct user context.
+        /// </summary>
+        public AsyncContextualTokenResolver? ContextualTokenResolver { get; set; }
 
         /// <summary>
         /// Delegate used to resolve the endpoint host or URL for a given tenant id.

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
 
     /// <summary>
     /// Async delegate used by the exporter to obtain an auth token using rich context.
-    /// Provides additional fields (e.g. <see cref="TokenResolverContext.AgenticUserId"/>)
+    /// Provides additional fields (e.g. <see cref="TokenResolverContext.Identity"/>)
     /// beyond what <see cref="AsyncAuthTokenResolver"/> offers.
     /// Must be fast and non-blocking (use internal caching elsewhere).
     /// Return null/empty to omit the Authorization header.

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/AgentIdentity.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/AgentIdentity.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
+{
+    /// <summary>
+    /// Represents the identity of an agent and its acting user.
+    /// <para>
+    /// In the AI teammate scenario, <see cref="AgenticUserId"/> is 1:1 with <see cref="AgentId"/>.
+    /// In the S2S scenario, <see cref="AgenticUserId"/> will be null.
+    /// </para>
+    /// </summary>
+    public class AgentIdentity
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentIdentity"/> class.
+        /// </summary>
+        /// <param name="agentId">The agent identifier.</param>
+        /// <param name="agenticUserId">The agentic user identifier (AAD Object ID), or null in S2S scenarios.</param>
+        public AgentIdentity(string agentId, string? agenticUserId = null)
+        {
+            AgentId = agentId;
+            AgenticUserId = agenticUserId;
+        }
+
+        /// <summary>
+        /// Gets the agent identifier.
+        /// </summary>
+        public string AgentId { get; }
+
+        /// <summary>
+        /// Gets the agentic user identifier (AAD Object ID).
+        /// In the AI teammate scenario, this value is 1:1 with <see cref="AgentId"/>.
+        /// Will be null in the S2S scenario.
+        /// </summary>
+        public string? AgenticUserId { get; }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
+{
+    /// <summary>
+    /// Provides contextual information to the token resolver delegate.
+    /// This class is extensible — new properties can be added in future versions
+    /// without breaking existing resolver implementations.
+    /// </summary>
+    public class TokenResolverContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TokenResolverContext"/> class.
+        /// </summary>
+        /// <param name="agentId">The agent identifier.</param>
+        /// <param name="tenantId">The tenant identifier.</param>
+        /// <param name="agenticUserId">The optional agentic user identifier.</param>
+        public TokenResolverContext(string agentId, string tenantId, string? agenticUserId)
+        {
+            AgentId = agentId;
+            TenantId = tenantId;
+            AgenticUserId = agenticUserId;
+        }
+
+        /// <summary>
+        /// Gets the agent identifier.
+        /// </summary>
+        public string AgentId { get; }
+
+        /// <summary>
+        /// Gets the tenant identifier.
+        /// </summary>
+        public string TenantId { get; }
+
+        /// <summary>
+        /// Gets the agentic user identifier, or <c>null</c> if not available.
+        /// </summary>
+        public string? AgenticUserId { get; }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
@@ -1,62 +1,38 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-
 namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
 {
     /// <summary>
     /// Provides contextual information to the token resolver delegate.
     /// <para>
-    /// <see cref="AgentId"/> and <see cref="TenantId"/> identify the cache key.
-    /// Additional contextual data (e.g. agentic user ID, which is the AAD Object ID) is available via the
-    /// <see cref="Metadata"/> dictionary and corresponding convenience accessors.
+    /// <see cref="Identity"/> provides first-class access to agent identity fields (agent ID,
+    /// agentic user ID). <see cref="TenantId"/> and <see cref="Identity"/>
+    /// together identify the cache key.
     /// </para>
     /// </summary>
     public class TokenResolverContext
     {
         /// <summary>
-        /// Well-known metadata key for the agentic user identifier (AAD Object ID).
-        /// In the AI teammate scenario, the agentic user ID is 1:1 with the agent ID.
-        /// This value will be null in the S2S scenario.
-        /// </summary>
-        public const string AgenticUserIdKey = "AgenticUserId";
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="TokenResolverContext"/> class.
         /// </summary>
-        /// <param name="agentId">The agent identifier (cache key).</param>
+        /// <param name="identity">The agent identity associated with this request.</param>
         /// <param name="tenantId">The tenant identifier (cache key).</param>
-        /// <param name="metadata">Optional metadata dictionary with additional context.</param>
-        public TokenResolverContext(string agentId, string tenantId, IReadOnlyDictionary<string, string>? metadata = null)
+        public TokenResolverContext(AgentIdentity identity, string tenantId)
         {
-            AgentId = agentId;
+            Identity = identity;
             TenantId = tenantId;
-            Metadata = metadata ?? new Dictionary<string, string>();
         }
 
         /// <summary>
-        /// Gets the agent identifier (part of the cache key).
+        /// Gets the agent identity associated with this token resolution request.
+        /// Contains the agent ID and agentic user ID (AAD Object ID) as first-class properties.
         /// </summary>
-        public string AgentId { get; }
+        public AgentIdentity Identity { get; }
 
         /// <summary>
         /// Gets the tenant identifier (part of the cache key).
         /// </summary>
         public string TenantId { get; }
-
-        /// <summary>
-        /// Gets additional contextual metadata associated with this token resolution request.
-        /// Use well-known keys such as <see cref="AgenticUserIdKey"/> or custom keys as needed.
-        /// </summary>
-        public IReadOnlyDictionary<string, string> Metadata { get; }
-
-        /// <summary>
-        /// Gets the agentic user identifier (AAD Object ID) from metadata, or <c>null</c> if not present.
-        /// In the AI teammate scenario, this value is 1:1 with <see cref="AgentId"/>.
-        /// Convenience accessor for <c>Metadata[<see cref="AgenticUserIdKey"/>]</c>.
-        /// </summary>
-        public string? AgenticUserId =>
-            Metadata.TryGetValue(AgenticUserIdKey, out var value) ? value : null;
     }
 }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
@@ -9,14 +9,14 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
     /// Provides contextual information to the token resolver delegate.
     /// <para>
     /// <see cref="AgentId"/> and <see cref="TenantId"/> identify the cache key.
-    /// Additional contextual data (e.g. agentic user ID) is available via the
+    /// Additional contextual data (e.g. agentic user ID, which is the AAD Object ID) is available via the
     /// <see cref="Metadata"/> dictionary and corresponding convenience accessors.
     /// </para>
     /// </summary>
     public class TokenResolverContext
     {
         /// <summary>
-        /// Well-known metadata key for the agentic user identifier.
+        /// Well-known metadata key for the agentic user identifier (AAD Object ID).
         /// </summary>
         public const string AgenticUserIdKey = "AgenticUserId";
 
@@ -50,7 +50,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         public IReadOnlyDictionary<string, string> Metadata { get; }
 
         /// <summary>
-        /// Gets the agentic user identifier from metadata, or <c>null</c> if not present.
+        /// Gets the agentic user identifier (AAD Object ID) from metadata, or <c>null</c> if not present.
         /// Convenience accessor for <c>Metadata[<see cref="AgenticUserIdKey"/>]</c>.
         /// </summary>
         public string? AgenticUserId =>

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
@@ -1,41 +1,59 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
 {
     /// <summary>
     /// Provides contextual information to the token resolver delegate.
-    /// This class is extensible — new properties can be added in future versions
-    /// without breaking existing resolver implementations.
+    /// <para>
+    /// <see cref="AgentId"/> and <see cref="TenantId"/> identify the cache key.
+    /// Additional contextual data (e.g. agentic user ID) is available via the
+    /// <see cref="Metadata"/> dictionary and corresponding convenience accessors.
+    /// </para>
     /// </summary>
     public class TokenResolverContext
     {
         /// <summary>
+        /// Well-known metadata key for the agentic user identifier.
+        /// </summary>
+        public const string AgenticUserIdKey = "AgenticUserId";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TokenResolverContext"/> class.
         /// </summary>
-        /// <param name="agentId">The agent identifier.</param>
-        /// <param name="tenantId">The tenant identifier.</param>
-        /// <param name="agenticUserId">The optional agentic user identifier.</param>
-        public TokenResolverContext(string agentId, string tenantId, string? agenticUserId)
+        /// <param name="agentId">The agent identifier (cache key).</param>
+        /// <param name="tenantId">The tenant identifier (cache key).</param>
+        /// <param name="metadata">Optional metadata dictionary with additional context.</param>
+        public TokenResolverContext(string agentId, string tenantId, IReadOnlyDictionary<string, string>? metadata = null)
         {
             AgentId = agentId;
             TenantId = tenantId;
-            AgenticUserId = agenticUserId;
+            Metadata = metadata ?? new Dictionary<string, string>();
         }
 
         /// <summary>
-        /// Gets the agent identifier.
+        /// Gets the agent identifier (part of the cache key).
         /// </summary>
         public string AgentId { get; }
 
         /// <summary>
-        /// Gets the tenant identifier.
+        /// Gets the tenant identifier (part of the cache key).
         /// </summary>
         public string TenantId { get; }
 
         /// <summary>
-        /// Gets the agentic user identifier, or <c>null</c> if not available.
+        /// Gets additional contextual metadata associated with this token resolution request.
+        /// Use well-known keys such as <see cref="AgenticUserIdKey"/> or custom keys as needed.
         /// </summary>
-        public string? AgenticUserId { get; }
+        public IReadOnlyDictionary<string, string> Metadata { get; }
+
+        /// <summary>
+        /// Gets the agentic user identifier from metadata, or <c>null</c> if not present.
+        /// Convenience accessor for <c>Metadata[<see cref="AgenticUserIdKey"/>]</c>.
+        /// </summary>
+        public string? AgenticUserId =>
+            Metadata.TryGetValue(AgenticUserIdKey, out var value) ? value : null;
     }
 }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/TokenResolverContext.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
     {
         /// <summary>
         /// Well-known metadata key for the agentic user identifier (AAD Object ID).
+        /// In the AI teammate scenario, the agentic user ID is 1:1 with the agent ID.
+        /// This value will be null in the S2S scenario.
         /// </summary>
         public const string AgenticUserIdKey = "AgenticUserId";
 
@@ -51,6 +53,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
 
         /// <summary>
         /// Gets the agentic user identifier (AAD Object ID) from metadata, or <c>null</c> if not present.
+        /// In the AI teammate scenario, this value is 1:1 with <see cref="AgentId"/>.
         /// Convenience accessor for <c>Metadata[<see cref="AgenticUserIdKey"/>]</c>.
         /// </summary>
         public string? AgenticUserId =>

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -103,7 +103,7 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             if (!string.IsNullOrWhiteSpace(options.AzureMonitor.ConnectionString)
                 || HasAzureMonitorConnectionString(builder.Services))
                 exporters |= ExportTarget.AzureMonitor;
-            if (options.Agent365.Exporter.TokenResolver != null || options.Agent365.Exporter.ContextualTokenResolver != null)
+            if (options.Agent365.TokenResolver != null || options.Agent365.ContextualTokenResolver != null)
                 exporters |= ExportTarget.Agent365;
             
         }
@@ -180,7 +180,7 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
         {
             o.SkipExporter = !exporters.HasFlag(ExportTarget.Agent365);
             o.TokenResolver = options.Agent365.TokenResolver;
-            o.ContextualTokenResolver = options.Agent365.Exporter.ContextualTokenResolver;
+            o.ContextualTokenResolver = options.Agent365.ContextualTokenResolver;
             o.DomainResolver = options.Agent365.DomainResolver;
             o.ClusterCategory = options.Agent365.ClusterCategory;
             o.UseS2SEndpoint = options.Agent365.UseS2SEndpoint;

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -103,7 +103,7 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             if (!string.IsNullOrWhiteSpace(options.AzureMonitor.ConnectionString)
                 || HasAzureMonitorConnectionString(builder.Services))
                 exporters |= ExportTarget.AzureMonitor;
-            if (options.Agent365.Exporter.TokenResolver != null)
+            if (options.Agent365.Exporter.TokenResolver != null || options.Agent365.Exporter.ContextualTokenResolver != null)
                 exporters |= ExportTarget.Agent365;
             
         }
@@ -180,6 +180,7 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
         {
             o.SkipExporter = !exporters.HasFlag(ExportTarget.Agent365);
             o.Exporter.TokenResolver = options.Agent365.Exporter.TokenResolver;
+            o.Exporter.ContextualTokenResolver = options.Agent365.Exporter.ContextualTokenResolver;
             o.Exporter.DomainResolver = options.Agent365.Exporter.DomainResolver;
             o.Exporter.UseS2SEndpoint = options.Agent365.Exporter.UseS2SEndpoint;
             o.Exporter.MaxQueueSize = options.Agent365.Exporter.MaxQueueSize;

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/ContextualTokenResolverTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/ContextualTokenResolverTests.cs
@@ -1,0 +1,343 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Agents.A365.Observability.Runtime.Common;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Microsoft.Agents.A365.Observability.Tests.Tracing.Exporters;
+
+[TestClass]
+public sealed class ContextualTokenResolverTests
+{
+    #region Helpers
+
+    private static Activity CreateActivity(
+        string? tenantId = null,
+        string? agentId = null,
+        string? agenticUserId = null,
+        string? operationName = "invoke_agent")
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Agent365Sdk.CtxResolver",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStarted = _ => { },
+            ActivityStopped = _ => { }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var source = new ActivitySource("Agent365Sdk.CtxResolver");
+        var activity = source.StartActivity("test-span", ActivityKind.Client)
+            ?? throw new InvalidOperationException("Failed to start activity.");
+
+        if (operationName != null)
+            activity.SetTag(OpenTelemetryConstants.GenAiOperationNameKey, operationName);
+        if (tenantId != null)
+            activity.SetTag(OpenTelemetryConstants.TenantIdKey, tenantId);
+        if (agentId != null)
+            activity.SetTag(OpenTelemetryConstants.GenAiAgentIdKey, agentId);
+        if (agenticUserId != null)
+            activity.SetTag(OpenTelemetryConstants.AgentAUIDKey, agenticUserId);
+
+        activity.Stop();
+        return activity;
+    }
+
+    private static Batch<Activity> CreateBatch(params Activity[] activities)
+    {
+        var batchType = typeof(Batch<Activity>);
+        var ctor = batchType
+            .GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault();
+
+        if (ctor == null)
+            Assert.Inconclusive("Could not locate internal Batch<Activity> constructor.");
+
+        var circularBufferType = batchType.Assembly.GetType("OpenTelemetry.Internal.CircularBuffer`1")!
+            .MakeGenericType(typeof(Activity));
+        var buffer = Activator.CreateInstance(circularBufferType, activities.Length)
+            ?? throw new InvalidOperationException("Could not create CircularBuffer<Activity>.");
+
+        var addMethod = circularBufferType.GetMethod("Add");
+        foreach (var act in activities)
+            addMethod!.Invoke(buffer, new object[] { act });
+
+        return (Batch<Activity>)ctor.Invoke(new object[] { buffer, activities.Length });
+    }
+
+    private static readonly Agent365ExporterCore Core = new(
+        new ExportFormatter(NullLogger<ExportFormatter>.Instance),
+        NullLogger<Agent365ExporterCore>.Instance);
+
+    private static Agent365Exporter CreateExporter(Agent365ExporterOptions options)
+    {
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddService("unit-test-service", serviceVersion: "1.0.0")
+            .Build();
+
+        return new Agent365Exporter(Core, NullLogger<Agent365Exporter>.Instance, options, resource);
+    }
+
+    #endregion
+
+    // ───────────────────── TokenResolverContext tests ─────────────────────
+
+    [TestMethod]
+    public void TokenResolverContext_Constructor_SetsKeyFields()
+    {
+        var ctx = new TokenResolverContext("agent-1", "tenant-1");
+
+        ctx.AgentId.Should().Be("agent-1");
+        ctx.TenantId.Should().Be("tenant-1");
+        ctx.Metadata.Should().BeEmpty();
+        ctx.AgenticUserId.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void TokenResolverContext_WithMetadata_ExposesAgenticUserId()
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            [TokenResolverContext.AgenticUserIdKey] = "user-42"
+        };
+        var ctx = new TokenResolverContext("agent-1", "tenant-1", metadata);
+
+        ctx.AgenticUserId.Should().Be("user-42");
+        ctx.Metadata.Should().ContainKey(TokenResolverContext.AgenticUserIdKey);
+    }
+
+    [TestMethod]
+    public void TokenResolverContext_WithoutAgenticUserId_ReturnsNull()
+    {
+        var metadata = new Dictionary<string, string>
+        {
+            ["SomeOtherKey"] = "value"
+        };
+        var ctx = new TokenResolverContext("agent-1", "tenant-1", metadata);
+
+        ctx.AgenticUserId.Should().BeNull();
+        ctx.Metadata.Should().HaveCount(1);
+    }
+
+    [TestMethod]
+    public void TokenResolverContext_NullMetadata_DefaultsToEmptyDictionary()
+    {
+        var ctx = new TokenResolverContext("agent-1", "tenant-1", metadata: null);
+
+        ctx.Metadata.Should().NotBeNull();
+        ctx.Metadata.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void TokenResolverContext_AgenticUserIdKey_HasExpectedValue()
+    {
+        TokenResolverContext.AgenticUserIdKey.Should().Be("AgenticUserId");
+    }
+
+    // ──────────── Constructor validation: either resolver accepted ────────────
+
+    [TestMethod]
+    public void Constructor_ContextualTokenResolverOnly_DoesNotThrow()
+    {
+        var options = new Agent365ExporterOptions
+        {
+            ContextualTokenResolver = _ => Task.FromResult<string?>("token")
+        };
+
+        Action act = () => CreateExporter(options);
+
+        act.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void Constructor_TokenResolverOnly_DoesNotThrow()
+    {
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (_, _) => Task.FromResult<string?>("token")
+        };
+
+        Action act = () => CreateExporter(options);
+
+        act.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void Constructor_BothResolvers_DoesNotThrow()
+    {
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (_, _) => Task.FromResult<string?>("token"),
+            ContextualTokenResolver = _ => Task.FromResult<string?>("ctx-token")
+        };
+
+        Action act = () => CreateExporter(options);
+
+        act.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void Constructor_NeitherResolver_Throws()
+    {
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = null,
+            ContextualTokenResolver = null
+        };
+
+        Action act = () => CreateExporter(options);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("TokenResolver");
+    }
+
+    // ──────── ContextualTokenResolver precedence during export ────────
+
+    [TestMethod]
+    public void Export_ContextualResolverSet_ReceivesContext()
+    {
+        TokenResolverContext? captured = null;
+        var options = new Agent365ExporterOptions
+        {
+            ContextualTokenResolver = ctx =>
+            {
+                captured = ctx;
+                return Task.FromResult<string?>("ctx-token");
+            }
+        };
+
+        var exporter = CreateExporter(options);
+        using var act = CreateActivity("tenant-1", "agent-1", agenticUserId: "user-99");
+        var batch = CreateBatch(act);
+        exporter.Export(in batch);
+
+        captured.Should().NotBeNull();
+        captured!.AgentId.Should().Be("agent-1");
+        captured.TenantId.Should().Be("tenant-1");
+        captured.AgenticUserId.Should().Be("user-99");
+    }
+
+    [TestMethod]
+    public void Export_ContextualResolverSet_WithoutAgenticUserId_ContextHasNullUserId()
+    {
+        TokenResolverContext? captured = null;
+        var options = new Agent365ExporterOptions
+        {
+            ContextualTokenResolver = ctx =>
+            {
+                captured = ctx;
+                return Task.FromResult<string?>("ctx-token");
+            }
+        };
+
+        var exporter = CreateExporter(options);
+        using var act = CreateActivity("tenant-1", "agent-1", agenticUserId: null);
+        var batch = CreateBatch(act);
+        exporter.Export(in batch);
+
+        captured.Should().NotBeNull();
+        captured!.AgenticUserId.Should().BeNull();
+        captured.Metadata.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void Export_BothResolversSet_ContextualTakesPrecedence()
+    {
+        bool vanillaCalled = false;
+        TokenResolverContext? captured = null;
+
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (_, _) =>
+            {
+                vanillaCalled = true;
+                return Task.FromResult<string?>("vanilla-token");
+            },
+            ContextualTokenResolver = ctx =>
+            {
+                captured = ctx;
+                return Task.FromResult<string?>("ctx-token");
+            }
+        };
+
+        var exporter = CreateExporter(options);
+        using var act = CreateActivity("tenant-1", "agent-1", agenticUserId: "user-1");
+        var batch = CreateBatch(act);
+        exporter.Export(in batch);
+
+        vanillaCalled.Should().BeFalse("ContextualTokenResolver should take precedence");
+        captured.Should().NotBeNull();
+        captured!.AgentId.Should().Be("agent-1");
+    }
+
+    [TestMethod]
+    public void Export_OnlyVanillaResolverSet_VanillaCalled()
+    {
+        bool vanillaCalled = false;
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (agentId, tenantId) =>
+            {
+                vanillaCalled = true;
+                return Task.FromResult<string?>("vanilla-token");
+            }
+        };
+
+        var exporter = CreateExporter(options);
+        using var act = CreateActivity("tenant-1", "agent-1");
+        var batch = CreateBatch(act);
+        exporter.Export(in batch);
+
+        vanillaCalled.Should().BeTrue("vanilla TokenResolver should be called when ContextualTokenResolver is null");
+    }
+
+    [TestMethod]
+    public void Export_NoIdentityActivities_ContextualResolverNotCalled()
+    {
+        bool called = false;
+        var options = new Agent365ExporterOptions
+        {
+            ContextualTokenResolver = _ =>
+            {
+                called = true;
+                return Task.FromResult<string?>("token");
+            }
+        };
+
+        var exporter = CreateExporter(options);
+        using var act = CreateActivity(); // no tenant/agent
+        var batch = CreateBatch(act);
+        var result = exporter.Export(in batch);
+
+        result.Should().Be(ExportResult.Success);
+        called.Should().BeFalse("resolver should not be called for activities without identity");
+    }
+
+    // ───────── Agent365ExporterOptions property tests ─────────
+
+    [TestMethod]
+    public void Agent365ExporterOptions_ContextualTokenResolver_DefaultsToNull()
+    {
+        var options = new Agent365ExporterOptions();
+        options.ContextualTokenResolver.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Agent365ExporterOptions_ContextualTokenResolver_CanBeSet()
+    {
+        AsyncContextualTokenResolver resolver = _ => Task.FromResult<string?>("token");
+        var options = new Agent365ExporterOptions
+        {
+            ContextualTokenResolver = resolver
+        };
+
+        options.ContextualTokenResolver.Should().BeSameAs(resolver);
+    }
+}

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/ContextualTokenResolverTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/ContextualTokenResolverTests.cs
@@ -92,53 +92,50 @@ public sealed class ContextualTokenResolverTests
     [TestMethod]
     public void TokenResolverContext_Constructor_SetsKeyFields()
     {
-        var ctx = new TokenResolverContext("agent-1", "tenant-1");
+        var identity = new AgentIdentity("agent-1");
+        var ctx = new TokenResolverContext(identity, "tenant-1");
 
-        ctx.AgentId.Should().Be("agent-1");
+        ctx.Identity.AgentId.Should().Be("agent-1");
         ctx.TenantId.Should().Be("tenant-1");
-        ctx.Metadata.Should().BeEmpty();
-        ctx.AgenticUserId.Should().BeNull();
+        ctx.Identity.Should().BeSameAs(identity);
+        ctx.Identity.AgenticUserId.Should().BeNull();
     }
 
     [TestMethod]
-    public void TokenResolverContext_WithMetadata_ExposesAgenticUserId()
+    public void TokenResolverContext_WithIdentity_ExposesAgenticUserId()
     {
-        var metadata = new Dictionary<string, string>
-        {
-            [TokenResolverContext.AgenticUserIdKey] = "user-42"
-        };
-        var ctx = new TokenResolverContext("agent-1", "tenant-1", metadata);
+        var identity = new AgentIdentity("agent-1", "user-42");
+        var ctx = new TokenResolverContext(identity, "tenant-1");
 
-        ctx.AgenticUserId.Should().Be("user-42");
-        ctx.Metadata.Should().ContainKey(TokenResolverContext.AgenticUserIdKey);
+        ctx.Identity.AgenticUserId.Should().Be("user-42");
+        ctx.Identity.AgentId.Should().Be("agent-1");
     }
 
     [TestMethod]
     public void TokenResolverContext_WithoutAgenticUserId_ReturnsNull()
     {
-        var metadata = new Dictionary<string, string>
-        {
-            ["SomeOtherKey"] = "value"
-        };
-        var ctx = new TokenResolverContext("agent-1", "tenant-1", metadata);
+        var identity = new AgentIdentity("agent-1");
+        var ctx = new TokenResolverContext(identity, "tenant-1");
 
-        ctx.AgenticUserId.Should().BeNull();
-        ctx.Metadata.Should().HaveCount(1);
+        ctx.Identity.AgenticUserId.Should().BeNull();
     }
 
     [TestMethod]
-    public void TokenResolverContext_NullMetadata_DefaultsToEmptyDictionary()
+    public void AgentIdentity_Constructor_SetsProperties()
     {
-        var ctx = new TokenResolverContext("agent-1", "tenant-1", metadata: null);
+        var id = new AgentIdentity("agent-1", "user-1");
 
-        ctx.Metadata.Should().NotBeNull();
-        ctx.Metadata.Should().BeEmpty();
+        id.AgentId.Should().Be("agent-1");
+        id.AgenticUserId.Should().Be("user-1");
     }
 
     [TestMethod]
-    public void TokenResolverContext_AgenticUserIdKey_HasExpectedValue()
+    public void AgentIdentity_NullAgenticUserId_IsAllowed()
     {
-        TokenResolverContext.AgenticUserIdKey.Should().Be("AgenticUserId");
+        var id = new AgentIdentity("agent-1");
+
+        id.AgentId.Should().Be("agent-1");
+        id.AgenticUserId.Should().BeNull();
     }
 
     // ──────────── Constructor validation: either resolver accepted ────────────
@@ -219,9 +216,9 @@ public sealed class ContextualTokenResolverTests
         exporter.Export(in batch);
 
         captured.Should().NotBeNull();
-        captured!.AgentId.Should().Be("agent-1");
+        captured!.Identity.AgentId.Should().Be("agent-1");
         captured.TenantId.Should().Be("tenant-1");
-        captured.AgenticUserId.Should().Be("user-99");
+        captured.Identity.AgenticUserId.Should().Be("user-99");
     }
 
     [TestMethod]
@@ -243,8 +240,7 @@ public sealed class ContextualTokenResolverTests
         exporter.Export(in batch);
 
         captured.Should().NotBeNull();
-        captured!.AgenticUserId.Should().BeNull();
-        captured.Metadata.Should().BeEmpty();
+        captured!.Identity.AgenticUserId.Should().BeNull();
     }
 
     [TestMethod]
@@ -274,7 +270,7 @@ public sealed class ContextualTokenResolverTests
 
         vanillaCalled.Should().BeFalse("ContextualTokenResolver should take precedence");
         captured.Should().NotBeNull();
-        captured!.AgentId.Should().Be("agent-1");
+        captured!.Identity.AgentId.Should().Be("agent-1");
     }
 
     [TestMethod]


### PR DESCRIPTION
Introduce a non-breaking AsyncContextualTokenResolver delegate and TokenResolverContext class that allows the agentic user ID to be passed alongside agent and tenant IDs during token resolution.

- Add TokenResolverContext with AgentId, TenantId, AgenticUserId
- Add AsyncContextualTokenResolver delegate and ContextualTokenResolver property on Agent365ExporterOptions
- Update Agent365ExporterCore to prefer ContextualTokenResolver when set
- Update exporter constructors to accept either resolver
- Forward ContextualTokenResolver through MicrosoftOpenTelemetryBuilderExtensions
- Update demo app with config toggle and manual token service example

**Testing**

Successful export using the updated token resolver

<img width="2222" height="1257" alt="image" src="https://github.com/user-attachments/assets/e7dbd5ae-aae5-482c-b599-af90ce340f4f" />
