### PR TITLE
fix: Decouple A365 exporter from Microsoft.Agents.Builder dependency

### DIFF
--- a/src/Microsoft.OpenTelemetry/Agent365/Hosting/ObservabilityServiceCollectionExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Hosting/ObservabilityServiceCollectionExtensions.cs
@@ -9,6 +9,11 @@ namespace Microsoft.Agents.A365.Observability.Hosting
     /// <summary>
     /// Provides extension methods for configuring Microsoft Agent 365 SDK with OpenTelemetry tracing.
     /// </summary>
+    /// <remarks>
+    /// These methods register infrastructure that depends on Microsoft.Agents.Builder at runtime.
+    /// They are opt-in for Agent Framework apps and should NOT be called unless the consumer
+    /// has Microsoft.Agents.Builder available in their dependency graph.
+    /// </remarks>
     internal static class ObservabilityServiceCollectionExtensions
     {
         /// <summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.Agents.A365.Observability.Runtime;
 using Microsoft.Agents.A365.Observability.Runtime.Common;
 using Microsoft.Agents.A365.Observability.Extensions.SemanticKernel;
-using Microsoft.Agents.A365.Observability.Hosting;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
@@ -120,19 +119,7 @@ internal static class Agent365OpenTelemetryBuilderExtensions
             // Agent365 Exporter (enabled when not skipped)
             if (!options.SkipExporter)
             {
-                // Always register the token cache so DI consumers (e.g., agents
-                // injecting IExporterTokenCache<AgenticTokenStruct>) can resolve it.
-                // This matches the base A365 SDK behavior where AddAgenticTracingExporter()
-                // and setting TokenResolver are independent operations.
-                builder.Services.AddAgenticTracingExporter();
-
-                if (options.ExporterOptions.TokenResolver != null || options.ExporterOptions.ContextualTokenResolver != null)
-                {
-                    // Inline TokenResolver or ContextualTokenResolver provided — override the cache-based options.
-                    // This singleton takes precedence over the one from AddAgenticTracingExporter().
-                    builder.Services.AddSingleton(options.ExporterOptions);
-                }
-
+                builder.Services.AddSingleton(options.ExporterOptions);
                 tracing.AddAgent365Exporter();
             }
             });

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365Exporter.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365Exporter.cs
@@ -43,7 +43,10 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             _options = options ?? throw new ArgumentNullException(nameof(options));
 
             if (_options.TokenResolver == null && _options.ContextualTokenResolver == null)
-                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver or Agent365ExporterOptions.ContextualTokenResolver must be provided.");
+                throw new ArgumentNullException(nameof(options.TokenResolver),
+                    "Agent365 exporter requires a TokenResolver or ContextualTokenResolver. " +
+                    "Configure one via UseMicrosoftOpenTelemetry(o => o.Agent365.TokenResolver = ...) or " +
+                    "UseMicrosoftOpenTelemetry(o => o.Agent365.ContextualTokenResolver = ...).");
 
             _httpClient = httpClient ?? HttpClientFactory.CreateWithTimeout(options.ExporterTimeoutMilliseconds);
             _resource = resource ?? ResourceBuilder.CreateEmpty().Build();

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterAsync.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterAsync.cs
@@ -45,7 +45,10 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             this._options = options ?? throw new ArgumentNullException(nameof(options));
 
             if (_options.TokenResolver == null && _options.ContextualTokenResolver == null)
-                throw new ArgumentNullException(nameof(options.TokenResolver), "Agent365ExporterOptions.TokenResolver or Agent365ExporterOptions.ContextualTokenResolver must be provided.");
+                throw new ArgumentNullException(nameof(options.TokenResolver),
+                    "Agent365 exporter requires a TokenResolver or ContextualTokenResolver. " +
+                    "Configure one via UseMicrosoftOpenTelemetry(o => o.Agent365.TokenResolver = ...) or " +
+                    "UseMicrosoftOpenTelemetry(o => o.Agent365.ContextualTokenResolver = ...).");
 
             this._httpClient = httpClient ?? HttpClientFactory.CreateWithTimeout(options.ExporterTimeoutMilliseconds);
             this._resource = resource ?? ResourceBuilder.CreateEmpty().Build();

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/TokenCacheDiTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/TokenCacheDiTests.cs
@@ -15,10 +15,10 @@ namespace Microsoft.OpenTelemetry.Agent365.Tests
     public class TokenCacheDiTests
     {
         [Fact]
-        public void CustomTokenResolver_IExporterTokenCache_StillRegistered()
+        public void CustomTokenResolver_ExporterOptions_RegisteredDirectly()
         {
-            // Issue #42: Setting custom TokenResolver should NOT prevent
-            // IExporterTokenCache<AgenticTokenStruct> from being registered.
+            // When a custom TokenResolver is provided, Agent365ExporterOptions should be
+            // registered as a singleton instance (no AgenticTokenCache dependency).
             var services = new ServiceCollection();
             services.AddOpenTelemetry()
                 .UseMicrosoftOpenTelemetry(o =>
@@ -28,55 +28,39 @@ namespace Microsoft.OpenTelemetry.Agent365.Tests
                         Task.FromResult<string?>("custom-token");
                 });
 
-            // IExporterTokenCache<AgenticTokenStruct> must be resolvable
-            Assert.Contains(services, s =>
-                s.ServiceType == typeof(IExporterTokenCache<AgenticTokenStruct>));
-        }
-
-        [Fact]
-        public void CustomTokenResolver_ExporterOptions_Overridden()
-        {
-            // When a custom TokenResolver is provided, the Agent365ExporterOptions
-            // singleton should use the inline resolver, not the cache-based one.
-            var services = new ServiceCollection();
-            services.AddOpenTelemetry()
-                .UseMicrosoftOpenTelemetry(o =>
-                {
-                    o.Exporters = ExportTarget.Agent365;
-                    o.Agent365.TokenResolver = (agentId, tenantId) =>
-                        Task.FromResult<string?>("custom-token");
-                });
-
-            // Agent365ExporterOptions should be registered (both cache-based and inline)
+            // Agent365ExporterOptions should be registered directly (instance, not factory)
             var exporterOptionsDescriptors = services
                 .Where(s => s.ServiceType == typeof(Agent365ExporterOptions))
                 .ToList();
 
-            // Should have at least 2: one from AddAgenticTracingExporter (factory) + one inline (instance)
-            Assert.True(exporterOptionsDescriptors.Count >= 2,
-                $"Expected at least 2 Agent365ExporterOptions registrations, got {exporterOptionsDescriptors.Count}");
+            Assert.Single(exporterOptionsDescriptors);
+            Assert.NotNull(exporterOptionsDescriptors[0].ImplementationInstance);
         }
 
         [Fact]
-        public void NoTokenResolver_IExporterTokenCache_Registered()
+        public void CustomTokenResolver_AgenticTokenCache_NotRegistered()
         {
-            // Without custom TokenResolver, IExporterTokenCache should still be registered.
+            // Fix for issue #103: With a custom TokenResolver, AgenticTokenCache
+            // should NOT be auto-registered (it depends on Microsoft.Agents.Builder).
             var services = new ServiceCollection();
             services.AddOpenTelemetry()
                 .UseMicrosoftOpenTelemetry(o =>
                 {
                     o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.TokenResolver = (agentId, tenantId) =>
+                        Task.FromResult<string?>("custom-token");
                 });
 
-            Assert.Contains(services, s =>
+            Assert.DoesNotContain(services, s =>
                 s.ServiceType == typeof(IExporterTokenCache<AgenticTokenStruct>));
         }
 
         [Fact]
-        public void NoTokenResolver_ExporterOptions_SingleRegistration()
+        public void NoTokenResolver_DoesNotThrow_AgenticTokenCacheNotRegistered()
         {
-            // Without custom TokenResolver, only the cache-based Agent365ExporterOptions
-            // should be registered (no inline override).
+            // Without a TokenResolver, the SDK must not crash the host app.
+            // Agent365ExporterOptions is registered (exporter logs error and becomes no-op),
+            // but AgenticTokenCache is NOT auto-registered (no Microsoft.Agents.Builder dependency).
             var services = new ServiceCollection();
             services.AddOpenTelemetry()
                 .UseMicrosoftOpenTelemetry(o =>
@@ -84,12 +68,14 @@ namespace Microsoft.OpenTelemetry.Agent365.Tests
                     o.Exporters = ExportTarget.Agent365;
                 });
 
-            var inlineDescriptors = services
-                .Where(s => s.ServiceType == typeof(Agent365ExporterOptions)
-                         && s.ImplementationInstance != null)
-                .ToList();
+            // Agent365ExporterOptions is registered (exporter handles missing resolver gracefully)
+            Assert.Contains(services, s =>
+                s.ServiceType == typeof(Agent365ExporterOptions));
 
-            Assert.Empty(inlineDescriptors);
+            // No AgenticTokenCache registered
+            Assert.DoesNotContain(services, s =>
+                s.ServiceType == typeof(IExporterTokenCache<AgenticTokenStruct>));
         }
+
     }
 }


### PR DESCRIPTION
## Summary

Fixes #103 — FileNotFoundException when using A365 exporter without Microsoft.Agents.Builder at runtime.

## Problem

The A365 exporter unconditionally called \AddAgenticTracingExporter()\ which registered \AgenticTokenCache\ depending on \Microsoft.Agents.Builder\ types (\ITurnContext\, \UserAuthorization\). Since PR #23 marked that package as \PrivateAssets=all\, the assembly wasn't available at runtime for consumers who don't use Agent Framework.

## Fix

- **Stop auto-registering \AgenticTokenCache\** — the exporter now registers user-provided \Agent365ExporterOptions\ directly
- **\AgenticTokenCache\ becomes opt-in** — only for Agent Framework apps that explicitly call \AddAgenticTracingExporter()\
- **Clear error messaging** — exporter constructor throws \ArgumentNullException\ with actionable guidance when no \TokenResolver\ is configured

## Alignment with other SDKs

This aligns with the JavaScript and Python distros which also do NOT auto-register \AgenticTokenCache\ and require the user to provide a token resolver.

## Testing

- All 422 Agent365 tests pass
- Updated \TokenCacheDiTests\ and exporter constructor tests to reflect new behavior