### PR TITLE
Use dynamic filtering for extra attributes

### DIFF
--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/BaseDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/BaseDataBuilder.cs
@@ -14,52 +14,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
     /// </summary>
     public abstract class BaseDataBuilder<T> where T : BaseData
     {
-        // Reserved attribute keys managed by specific builder methods; extra attributes must NOT override these.
-        private static readonly HashSet<string> ReservedAttributeKeys = new HashSet<string>(StringComparer.Ordinal)
-        {
-            OpenTelemetryConstants.GenAiInputMessagesKey,
-            OpenTelemetryConstants.GenAiOutputMessagesKey,
-            OpenTelemetryConstants.GenAiAgentIdKey,
-            OpenTelemetryConstants.GenAiAgentNameKey,
-            OpenTelemetryConstants.GenAiAgentDescriptionKey,
-            OpenTelemetryConstants.GenAiAgentVersionKey,
-            OpenTelemetryConstants.AgentAUIDKey,
-            OpenTelemetryConstants.AgentEmailKey,
-            OpenTelemetryConstants.AgentBlueprintIdKey,
-            OpenTelemetryConstants.AgentPlatformIdKey,
-            OpenTelemetryConstants.TenantIdKey,
-            OpenTelemetryConstants.GenAiProviderNameKey,
-            OpenTelemetryConstants.ServerAddressKey,
-            OpenTelemetryConstants.ServerPortKey,
-            OpenTelemetryConstants.ChannelNameKey,
-            OpenTelemetryConstants.ChannelLinkKey,
-            OpenTelemetryConstants.UserIdKey,
-            OpenTelemetryConstants.UserEmailKey,
-            OpenTelemetryConstants.UserNameKey,
-            OpenTelemetryConstants.CallerAgentNameKey,
-            OpenTelemetryConstants.CallerAgentIdKey,
-            OpenTelemetryConstants.CallerAgentBlueprintIdKey,
-            OpenTelemetryConstants.CallerAgentAUIDKey,
-            OpenTelemetryConstants.CallerAgentEmailKey,
-            OpenTelemetryConstants.CallerAgentPlatformIdKey,
-            OpenTelemetryConstants.CallerAgentVersionKey,
-            OpenTelemetryConstants.CallerClientIpKey,
-            OpenTelemetryConstants.GenAiConversationIdKey,
-            OpenTelemetryConstants.SessionIdKey,
-            OpenTelemetryConstants.GenAiToolNameKey,
-            OpenTelemetryConstants.GenAiToolArgumentsKey,
-            OpenTelemetryConstants.GenAiToolCallIdKey,
-            OpenTelemetryConstants.GenAiToolDescriptionKey,
-            OpenTelemetryConstants.GenAiToolTypeKey,
-            OpenTelemetryConstants.GenAiToolCallResultKey,
-            OpenTelemetryConstants.GenAiOperationNameKey,
-            OpenTelemetryConstants.GenAiRequestModelKey,
-            OpenTelemetryConstants.GenAiUsageInputTokensKey,
-            OpenTelemetryConstants.GenAiUsageOutputTokensKey,
-            OpenTelemetryConstants.GenAiResponseFinishReasonsKey,
-            OpenTelemetryConstants.GenAiAgentThoughtProcessKey
-        };
-
         /// <summary>
         /// Adds attributes for input messages.
         /// </summary>
@@ -188,7 +142,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
         }
 
         /// <summary>
-        /// Adds extra attributes to the attributes dictionary while ignoring reserved keys.
+        /// Adds extra attributes to the attributes dictionary.
+        /// Extra attributes cannot override keys already set by the builder on this span.
         /// </summary>
         protected static void AddExtraAttributes(IDictionary<string, object?> attributes, IDictionary<string, object?>? extraAttributes)
         {
@@ -196,7 +151,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
 
             foreach (var kvp in extraAttributes)
             {
-                if ((kvp.Value != null && !ReservedAttributeKeys.Contains(kvp.Key)))
+                if (kvp.Value != null && !attributes.ContainsKey(kvp.Key))
                 {
                     attributes[kvp.Key] = kvp.Value;
                 }

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/DTOs/Builders/InvokeAgentDataBuilderTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/DTOs/Builders/InvokeAgentDataBuilderTests.cs
@@ -436,6 +436,31 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.DTOs.Builders
         }
 
         [TestMethod]
+        public void Build_AllowsRequestModel_ViaExtraAttributes_WhenNotSetByBuilder()
+        {
+            // Arrange
+            var endpoint = new Uri("https://example.com");
+            var agentDetails = new AgentDetails("agent-model", "ModelAgent");
+            var scopeDetails = new InvokeAgentScopeDetails(endpoint: endpoint);
+            var conversationId = "conv-model";
+            var extras = new Dictionary<string, object?>
+            {
+                {OpenTelemetryConstants.GenAiRequestModelKey, "gpt-4o"},
+            };
+
+            // Act
+            var telemetry = InvokeAgentDataBuilder.Build(
+                scopeDetails,
+                agentDetails,
+                conversationId,
+                extraAttributes: extras);
+
+            // Assert - gen_ai.request.model is allowed because InvokeAgentDataBuilder does not set it
+            telemetry.Attributes.Should().ContainKey(OpenTelemetryConstants.GenAiRequestModelKey)
+                .WhoseValue.Should().Be("gpt-4o");
+        }
+
+        [TestMethod]
         public void Build_WithAgentPlatformId_SetsExpectedAttributes()
         {
             // Arrange


### PR DESCRIPTION
Extra attributes can now add any key that the builder did not already set on the span, rather than being blocked by a hardcoded 40-key allowlist. This allows attributes like gen_ai.request.model to be set on invoke_agent spans via extraAttributes while still preventing overrides of builder-set keys.

Ported from https://github.com/microsoft/Agent365-dotnet/pull/254