### PR TITLE
Add Feature SDKStats reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added Feature SDKStats reporting for distro-enabled features. Publishes a `Feature` gauge on the `MicrosoftOpenTelemetryFeatureSdkStatsMeter` meter; the Azure Monitor exporter's Statsbeat MeterProvider subscribes to it and ships the metric on the existing 24-hour cadence. Reported regardless of which exporter the customer selected (Azure Monitor, OTLP, Console, or Agent365) — when Azure Monitor isn't selected, an inert `AzureMonitorMetricExporter` is held to trigger the Statsbeat pipeline and `cikey` is reported as the literal `"N/A"`. Honors `APPLICATIONINSIGHTS_STATSBEAT_DISABLED=true`.
+- All Statsbeat traffic emitted while running under the distro is routed to the distro-owned ingestion endpoints (`https://us.stats.monitor.azure.com/` and `https://eudb.stats.monitor.azure.com/`) instead of the legacy Application Insights internal resources. Implemented via the new `Azure.Monitor.OpenTelemetry.Exporter.RouteStatsbeatToDistroEndpoint` AppContext switch, which the distro sets at the top of `UseMicrosoftOpenTelemetry` before any `AzureMonitorMetricExporter` is constructed. Requires `Azure.Monitor.OpenTelemetry.Exporter` 1.9.0-beta.1 or later.
 
 ## 1.0.3 - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Added Feature SDKStats reporting for distro-enabled features. Publishes a `Feature` gauge on the `MicrosoftOpenTelemetryFeatureSdkStatsMeter` meter; the Azure Monitor exporter's Statsbeat MeterProvider subscribes to it and ships the metric on the existing 24-hour cadence. Reported regardless of which exporter the customer selected (Azure Monitor, OTLP, Console, or Agent365) — when Azure Monitor isn't selected, an inert `AzureMonitorMetricExporter` is held to trigger the Statsbeat pipeline and `cikey` is reported as the literal `"N/A"`. Honors `APPLICATIONINSIGHTS_STATSBEAT_DISABLED=true`.
-- All Statsbeat traffic emitted while running under the distro is routed to the distro-owned ingestion endpoints (`https://us.stats.monitor.azure.com/` and `https://eudb.stats.monitor.azure.com/`) instead of the legacy Application Insights internal resources. Implemented via the new `Azure.Monitor.OpenTelemetry.Exporter.RouteStatsbeatToDistroEndpoint` AppContext switch, which the distro sets at the top of `UseMicrosoftOpenTelemetry` before any `AzureMonitorMetricExporter` is constructed. Requires `Azure.Monitor.OpenTelemetry.Exporter` 1.9.0-beta.1 or later.
+- Added SDK statistics reporting and routed it to a dedicated Microsoft ingestion path. Honors `APPLICATIONINSIGHTS_STATSBEAT_DISABLED=true`. Requires `Azure.Monitor.OpenTelemetry.Exporter` 1.9.0-beta.1 or later.
 
 ## 1.0.3 - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added Feature SDKStats reporting for distro-enabled features. Publishes a `Feature` gauge on the `MicrosoftOpenTelemetryFeatureSdkStatsMeter` meter; the Azure Monitor exporter's Statsbeat MeterProvider subscribes to it and ships the metric on the existing 24-hour cadence. Reported regardless of which exporter the customer selected (Azure Monitor, OTLP, Console, or Agent365) — when Azure Monitor isn't selected, an inert `AzureMonitorMetricExporter` is held to trigger the Statsbeat pipeline and `cikey` is reported as the literal `"N/A"`. Honors `APPLICATIONINSIGHTS_STATSBEAT_DISABLED=true`.
+
 ## 1.0.3 - 2026-05-22
 
 - Fix `gen_ai.tool.arguments` attribute name to `gen_ai.tool.call.arguments` ([#88](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/88))

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/AzureMonitorAspNetCoreEventSource.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/AzureMonitorAspNetCoreEventSource.cs
@@ -126,5 +126,20 @@ namespace Microsoft.OpenTelemetry
 
         [Event(15, Message = "Invalid sampler argument '{1}' for sampler '{0}'. Ignoring.", Level = EventLevel.Warning)]
         public void InvalidSamplerArgument(string samplerType, string samplerArg) => WriteEvent(15, samplerType, samplerArg);
+
+        [NonEvent]
+        public void DistroFeatureSdkStatsCallbackFailed(System.Exception ex)
+        {
+            if (IsEnabled(EventLevel.Warning))
+            {
+                DistroFeatureSdkStatsCallbackFailed(ex.FlattenException().ToInvariantString());
+            }
+        }
+
+        [Event(16, Message = "Distro Feature SDKStats gauge callback failed: {0}", Level = EventLevel.Warning)]
+        public void DistroFeatureSdkStatsCallbackFailed(string exceptionMessage) => WriteEvent(16, exceptionMessage);
+
+        [Event(17, Message = "Distro Feature SDKStats disabled by environment variable APPLICATIONINSIGHTS_STATSBEAT_DISABLED.", Level = EventLevel.Informational)]
+        public void DistroFeatureSdkStatsDisabledByEnvVar() => WriteEvent(17);
     }
 }

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/EnvironmentVariableConstants.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/EnvironmentVariableConstants.cs
@@ -11,4 +11,17 @@ internal static class EnvironmentVariableConstants
     internal const string APPLICATIONINSIGHTS_CONNECTION_STRING = "APPLICATIONINSIGHTS_CONNECTION_STRING";
     internal const string OTEL_TRACES_SAMPLER = "OTEL_TRACES_SAMPLER";
     internal const string OTEL_TRACES_SAMPLER_ARG = "OTEL_TRACES_SAMPLER_ARG";
+
+    /// <summary>
+    /// Kill switch shared with the Azure Monitor exporter: when set to <c>"true"</c>
+    /// (case-insensitive), the distro skips registering its Feature SDKStats producer.
+    /// </summary>
+    internal const string APPLICATIONINSIGHTS_STATSBEAT_DISABLED = "APPLICATIONINSIGHTS_STATSBEAT_DISABLED";
+
+    /// <summary>
+    /// Customer-facing SDK stats opt-in. When set to <c>"false"</c> (case-insensitive),
+    /// the Azure Monitor exporter enables Customer SDK Stats and the distro reports the
+    /// <see cref="SdkStats.DistroFeature.CustomerSdkStats"/> feature bit.
+    /// </summary>
+    internal const string APPLICATIONINSIGHTS_SDKSTATS_DISABLED = "APPLICATIONINSIGHTS_SDKSTATS_DISABLED";
 }

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/ResourceProviderHelper.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/Internals/ResourceProviderHelper.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using OpenTelemetry;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.Internals
+{
+    /// <summary>
+    /// Detects the Azure resource provider (App Service, Functions, AKS, VM) hosting the
+    /// current process and reports the operating system. Mirrors the precedence and timeout
+    /// behavior used by the Azure Monitor exporter's <c>AzureMonitorStatsbeat</c> so that
+    /// distro-emitted Feature SDKStats carry the same <c>rp</c>/<c>os</c> dimension values as
+    /// the exporter's <c>Attach</c> metric.
+    /// </summary>
+    internal static class ResourceProviderHelper
+    {
+        /// <summary>Azure Instance Metadata Service endpoint used for VM detection.</summary>
+        internal const string AzureMetadataServiceUrl =
+            "http://169.254.169.254/metadata/instance/compute?api-version=2017-08-01&format=json";
+
+        private const string FunctionsWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
+        private const string WebsiteSiteName = "WEBSITE_SITE_NAME";
+        private const string AksArmNamespaceId = "AKS_ARM_NAMESPACE_ID";
+
+        private static readonly object s_lock = new();
+        private static bool s_detected;
+        private static string s_resourceProvider = "unknown";
+        private static string s_operatingSystem = GetOs();
+
+        /// <summary>
+        /// Returns the detected resource provider name: <c>functions</c>, <c>appsvc</c>,
+        /// <c>aks</c>, <c>vm</c>, or <c>unknown</c>. Cached after the first call.
+        /// </summary>
+        internal static string GetResourceProvider()
+        {
+            EnsureDetected();
+            return s_resourceProvider;
+        }
+
+        /// <summary>
+        /// Returns the operating system name: <c>windows</c>, <c>linux</c>, <c>osx</c>, or
+        /// <c>unknown</c>. May be overridden from IMDS when the resource provider is <c>vm</c>.
+        /// </summary>
+        internal static string GetOperatingSystem()
+        {
+            EnsureDetected();
+            return s_operatingSystem;
+        }
+
+        /// <summary>
+        /// Returns the attach mode reported alongside Feature SDKStats. Always <c>Manual</c>
+        /// for the distro today; auto-attach scenarios will be wired here when supported.
+        /// </summary>
+        internal static string GetAttachMode() => "Manual";
+
+        /// <summary>
+        /// Resets the cached detection state. Test-only.
+        /// </summary>
+        internal static void ResetForTesting()
+        {
+            lock (s_lock)
+            {
+                s_detected = false;
+                s_resourceProvider = "unknown";
+                s_operatingSystem = GetOs();
+            }
+        }
+
+        private static void EnsureDetected()
+        {
+            if (s_detected)
+            {
+                return;
+            }
+
+            lock (s_lock)
+            {
+                if (s_detected)
+                {
+                    return;
+                }
+
+                s_resourceProvider = DetectResourceProvider();
+                s_detected = true;
+            }
+        }
+
+        private static string DetectResourceProvider()
+        {
+            // Precedence mirrors AzureMonitorStatsbeat.SetResourceProviderDetails:
+            // Functions → AppSvc → AKS → IMDS (VM) → unknown.
+            try
+            {
+                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(FunctionsWorkerRuntime)))
+                {
+                    return "functions";
+                }
+
+                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebsiteSiteName)))
+                {
+                    return "appsvc";
+                }
+
+                if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(AksArmNamespaceId)))
+                {
+                    return "aks";
+                }
+            }
+            catch (Exception)
+            {
+                // Reading environment variables can throw under restricted security policies.
+                // Treat as "unknown" rather than letting the gauge callback fail.
+                return "unknown";
+            }
+
+            return TryGetVmMetadata() ? "vm" : "unknown";
+        }
+
+        private static bool TryGetVmMetadata()
+        {
+            try
+            {
+                // Suppress instrumentation so this internal HTTP call doesn't generate
+                // an HttpClient activity / metric of its own.
+                using var _ = SuppressInstrumentationScope.Begin();
+                using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+                httpClient.DefaultRequestHeaders.Add("Metadata", "True");
+
+                var responseString = httpClient.GetStringAsync(new Uri(AzureMetadataServiceUrl)).GetAwaiter().GetResult();
+                using var document = JsonDocument.Parse(responseString);
+
+                if (document.RootElement.TryGetProperty("osType", out var osType) && osType.ValueKind == JsonValueKind.String)
+                {
+                    var value = osType.GetString();
+                    s_operatingSystem = string.IsNullOrEmpty(value) ? "unknown" : value!.ToLowerInvariant();
+                }
+
+                return true;
+            }
+            catch (Exception)
+            {
+                // Non-VM environments will throw (169.254.169.254 unreachable). Silently
+                // fall back to "unknown" — this is best-effort telemetry, not user-visible.
+                return false;
+            }
+        }
+
+        private static string GetOs()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "windows";
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return "linux";
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return "osx";
+            }
+
+            return "unknown";
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeature.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeature.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
+{
+    /// <summary>
+    /// Bit flags reported by the Microsoft OpenTelemetry distro as the <c>feature</c> dimension
+    /// of <c>type=0</c> Feature SDKStats (see the SDKStats specification).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each set bit represents a distro feature that is enabled in the current process. Values
+    /// are stable; new bits must be appended only — never renumbered — because backend Kusto
+    /// decoders are keyed off these indexes.
+    /// </para>
+    /// <para>
+    /// This bit space is owned by the distro and is independent from the classic Application
+    /// Insights SDK's <c>StatsbeatFeatures</c> bit space, which targets a different meter
+    /// (<c>FeatureStatsbeatMeter</c>).
+    /// </para>
+    /// </remarks>
+    [Flags]
+    internal enum DistroFeature : ulong
+    {
+        /// <summary>No features reported.</summary>
+        None = 0,
+
+        /// <summary>The Microsoft OpenTelemetry distro is in use.</summary>
+        Distro = 1UL << 0,
+
+        /// <summary>Microsoft Entra ID (AAD) authentication is configured.</summary>
+        AadHandling = 1UL << 1,
+
+        /// <summary>Live Metrics is enabled.</summary>
+        LiveMetrics = 1UL << 2,
+
+        /// <summary>Standard metrics emission is enabled.</summary>
+        StandardMetrics = 1UL << 3,
+
+        /// <summary>Performance counters emission is enabled.</summary>
+        PerfCounters = 1UL << 4,
+
+        /// <summary>Offline (disk-based) retry persistence is enabled.</summary>
+        DiskRetry = 1UL << 5,
+
+        /// <summary>Customer-facing SDK stats are enabled.</summary>
+        CustomerSdkStats = 1UL << 6,
+
+        /// <summary>Trace-based log sampling is enabled.</summary>
+        TraceBasedLogsSampler = 1UL << 7,
+
+        /// <summary>The Azure Monitor exporter is selected.</summary>
+        ExporterAzureMonitor = 1UL << 8,
+
+        /// <summary>The OTLP exporter is selected.</summary>
+        ExporterOtlp = 1UL << 9,
+
+        /// <summary>The Agent365 exporter is selected.</summary>
+        ExporterAgent365 = 1UL << 10,
+
+        /// <summary>The Console exporter is selected.</summary>
+        ExporterConsole = 1UL << 11,
+
+        /// <summary>
+        /// Microsoft Agent Framework wiring is active. Currently always set because the distro
+        /// wires <c>UseAgentFramework</c> unconditionally. Becomes dynamic when an opt-out is
+        /// introduced.
+        /// </summary>
+        AgentFramework = 1UL << 12,
+
+        /// <summary>
+        /// Agent365-only mode (Agent365 exporter selected with no Azure Monitor and no OTLP
+        /// exporter) — infrastructure instrumentation is suppressed by default.
+        /// </summary>
+        A365OnlyMode = 1UL << 13,
+
+        // Bits 14-63 reserved for future features. Do not renumber.
+    }
+}

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSdkStats.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSdkStats.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using Microsoft.OpenTelemetry.AzureMonitor.Internals;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
+{
+    /// <summary>
+    /// Owns the distro's Feature SDKStats meter and observable gauge. The Azure Monitor
+    /// exporter's Statsbeat <c>MeterProvider</c> subscribes to the meter name advertised by
+    /// this class (see <c>StatsbeatConstants.DistroFeatureSdkStatsMeterName</c> in the
+    /// exporter), so measurements are exported on the existing 24-hour Statsbeat cadence
+    /// without any further wiring on the distro side.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The class is a process-wide singleton because the underlying <see cref="Meter"/> is a
+    /// process-wide resource and the exporter's MeterProvider subscribes by name. Subsequent
+    /// <see cref="Initialize"/> calls atomically swap the snapshot reference so the most
+    /// recent <c>UseMicrosoftOpenTelemetry</c> configuration wins; this keeps the disposable
+    /// surface of the class minimal and matches the lifecycle of the singleton MeterProvider.
+    /// </para>
+    /// <para>
+    /// Per the SDKStats specification, the gauge returns an empty measurement when the
+    /// configured features bit mask is <see cref="DistroFeature.None"/>.
+    /// </para>
+    /// </remarks>
+    internal sealed class DistroFeatureSdkStats : IDisposable
+    {
+        /// <summary>
+        /// Meter name owned by the distro for Feature SDKStats. Must match the constant
+        /// subscribed by the Azure Monitor exporter's Statsbeat <see cref="Meter"/> provider.
+        /// </summary>
+        internal const string MeterName = "MicrosoftOpenTelemetryFeatureSdkStatsMeter";
+
+        /// <summary>Metric name per the SDKStats spec.</summary>
+        internal const string MetricName = "Feature";
+
+        /// <summary>Meter version reported alongside <see cref="MeterName"/>.</summary>
+        internal const string MeterVersion = "1.0";
+
+        private static DistroFeatureSdkStats? s_instance;
+        private static readonly object s_lock = new();
+
+        private readonly Meter _meter;
+        private DistroFeatureSnapshot? _snapshot;
+        private IDisposable? _statsbeatExporterPin;
+
+        private DistroFeatureSdkStats()
+        {
+            _meter = new Meter(MeterName, MeterVersion);
+            _meter.CreateObservableGauge(MetricName, this.Observe);
+        }
+
+        /// <summary>The active singleton, if <see cref="Initialize"/> has been called.</summary>
+        internal static DistroFeatureSdkStats? Instance => s_instance;
+
+        /// <summary>
+        /// Registers (or updates) the distro Feature SDKStats producer with the supplied
+        /// snapshot. Safe to call repeatedly; the most recent snapshot wins.
+        /// </summary>
+        /// <param name="snapshot">Bit map + cikey + distro version describing the configuration.</param>
+        /// <param name="statsbeatExporterPin">
+        /// Optional <see cref="IDisposable"/> kept alive for the lifetime of this singleton.
+        /// Used by the distro to pin an inert <c>AzureMonitorMetricExporter</c> whose
+        /// construction side-effect creates the Statsbeat <c>MeterProvider</c> that ships
+        /// our <c>Feature</c> measurement when the customer hasn't selected the Azure
+        /// Monitor exporter. Pass <see langword="null"/> when the customer's own Azure
+        /// Monitor exporter already triggers Statsbeat for the process.
+        /// </param>
+        internal static DistroFeatureSdkStats Initialize(
+            DistroFeatureSnapshot snapshot,
+            IDisposable? statsbeatExporterPin = null)
+        {
+            if (snapshot is null)
+            {
+                throw new ArgumentNullException(nameof(snapshot));
+            }
+
+            if (s_instance is null)
+            {
+                lock (s_lock)
+                {
+                    s_instance ??= new DistroFeatureSdkStats();
+                }
+            }
+
+            Volatile.Write(ref s_instance!._snapshot, snapshot);
+
+            // The first pin wins for the process lifetime. If a second call supplies a pin
+            // while one is already held, dispose the redundant one immediately — the cached
+            // transmitter behind it lives in TransmitterFactory and will continue to serve
+            // the already-attached Statsbeat MeterProvider.
+            if (statsbeatExporterPin != null)
+            {
+                if (Interlocked.CompareExchange(ref s_instance._statsbeatExporterPin, statsbeatExporterPin, null) != null)
+                {
+                    try { statsbeatExporterPin.Dispose(); } catch { /* best effort */ }
+                }
+            }
+
+            return s_instance;
+        }
+
+        /// <summary>
+        /// Releases the singleton instance and disposes the underlying meter. Test-only;
+        /// production code keeps the singleton alive for the lifetime of the process.
+        /// </summary>
+        internal static void ResetForTesting()
+        {
+            lock (s_lock)
+            {
+                s_instance?.Dispose();
+                s_instance = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            _meter.Dispose();
+            try { _statsbeatExporterPin?.Dispose(); } catch { /* best effort */ }
+        }
+
+        private Measurement<long> Observe()
+        {
+            try
+            {
+                var snapshot = Volatile.Read(ref _snapshot);
+                if (snapshot is null || snapshot.Features == DistroFeature.None)
+                {
+                    // SDKStats spec: "Don't send feature/instrumentation SDKStats when the
+                    // feature/instrumentation list is empty."
+                    return new Measurement<long>();
+                }
+
+                return new Measurement<long>(
+                    (long)snapshot.Features,
+                    new KeyValuePair<string, object?>("rp", ResourceProviderHelper.GetResourceProvider()),
+                    new KeyValuePair<string, object?>("attach", ResourceProviderHelper.GetAttachMode()),
+                    new KeyValuePair<string, object?>("cikey", snapshot.CustomerInstrumentationKey),
+                    new KeyValuePair<string, object?>("feature", (long)snapshot.Features),
+                    new KeyValuePair<string, object?>("type", 0),
+                    new KeyValuePair<string, object?>("os", ResourceProviderHelper.GetOperatingSystem()),
+                    new KeyValuePair<string, object?>("language", "dotnet"),
+                    new KeyValuePair<string, object?>("version", snapshot.DistroVersion));
+            }
+            catch (Exception ex)
+            {
+                AzureMonitorAspNetCoreEventSource.Log.DistroFeatureSdkStatsCallbackFailed(ex);
+                return new Measurement<long>();
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSdkStats.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSdkStats.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Threading;
 using Microsoft.OpenTelemetry.AzureMonitor.Internals;
@@ -24,8 +25,11 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
     /// surface of the class minimal and matches the lifecycle of the singleton MeterProvider.
     /// </para>
     /// <para>
-    /// Per the SDKStats specification, the gauge returns an empty measurement when the
-    /// configured features bit mask is <see cref="DistroFeature.None"/>.
+    /// Per the SDKStats specification, the gauge returns no measurements when the
+    /// configured features bit mask is <see cref="DistroFeature.None"/>. The
+    /// <see cref="Func{TResult}"/> of <see cref="IEnumerable{T}"/> overload is used (not the
+    /// single-<c>Measurement</c> overload) so an empty result actually skips emission
+    /// instead of publishing a phantom zero-valued data point with no tags.
     /// </para>
     /// </remarks>
     internal sealed class DistroFeatureSdkStats : IDisposable
@@ -45,14 +49,21 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
         private static DistroFeatureSdkStats? s_instance;
         private static readonly object s_lock = new();
 
+        private static readonly IEnumerable<Measurement<long>> EmptyMeasurements = Array.Empty<Measurement<long>>();
+
         private readonly Meter _meter;
-        private DistroFeatureSnapshot? _snapshot;
+        private DistroFeatureSnapshot _snapshot;
         private IDisposable? _statsbeatExporterPin;
 
-        private DistroFeatureSdkStats()
+        private DistroFeatureSdkStats(DistroFeatureSnapshot snapshot)
         {
+            // Snapshot is assigned before the meter is created and before the instance is
+            // published to s_instance, so any reader that observes the instance via the
+            // public Instance property is guaranteed to see a fully-initialized object
+            // (no narrow window where _snapshot is null).
+            _snapshot = snapshot;
             _meter = new Meter(MeterName, MeterVersion);
-            _meter.CreateObservableGauge(MetricName, this.Observe);
+            _meter.CreateObservableGauge<long>(MetricName, this.Observe);
         }
 
         /// <summary>The active singleton, if <see cref="Initialize"/> has been called.</summary>
@@ -80,29 +91,42 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
                 throw new ArgumentNullException(nameof(snapshot));
             }
 
-            if (s_instance is null)
+            DistroFeatureSdkStats current;
+            lock (s_lock)
             {
-                lock (s_lock)
+                if (s_instance is null)
                 {
-                    s_instance ??= new DistroFeatureSdkStats();
+                    // First call: construct with the snapshot already set, then publish.
+                    // The ordering here matters — assigning s_instance only after the
+                    // constructor returns guarantees Instance never exposes a partially
+                    // initialized object.
+                    s_instance = new DistroFeatureSdkStats(snapshot);
+                }
+                else
+                {
+                    // Subsequent call: swap snapshot under the lock so writes are ordered
+                    // with respect to instance publish. Observe() pairs this with a
+                    // Volatile.Read for cross-thread visibility on platforms with weak
+                    // memory models.
+                    Volatile.Write(ref s_instance._snapshot, snapshot);
+                }
+
+                current = s_instance;
+
+                // The first pin wins for the process lifetime. If a second call supplies a
+                // pin while one is already held, dispose the redundant one immediately —
+                // the cached transmitter behind it lives in TransmitterFactory and will
+                // continue to serve the already-attached Statsbeat MeterProvider.
+                if (statsbeatExporterPin != null)
+                {
+                    if (Interlocked.CompareExchange(ref current._statsbeatExporterPin, statsbeatExporterPin, null) != null)
+                    {
+                        try { statsbeatExporterPin.Dispose(); } catch { /* best effort */ }
+                    }
                 }
             }
 
-            Volatile.Write(ref s_instance!._snapshot, snapshot);
-
-            // The first pin wins for the process lifetime. If a second call supplies a pin
-            // while one is already held, dispose the redundant one immediately — the cached
-            // transmitter behind it lives in TransmitterFactory and will continue to serve
-            // the already-attached Statsbeat MeterProvider.
-            if (statsbeatExporterPin != null)
-            {
-                if (Interlocked.CompareExchange(ref s_instance._statsbeatExporterPin, statsbeatExporterPin, null) != null)
-                {
-                    try { statsbeatExporterPin.Dispose(); } catch { /* best effort */ }
-                }
-            }
-
-            return s_instance;
+            return current;
         }
 
         /// <summary>
@@ -124,19 +148,30 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
             try { _statsbeatExporterPin?.Dispose(); } catch { /* best effort */ }
         }
 
-        private Measurement<long> Observe()
+        private IEnumerable<Measurement<long>> Observe()
         {
+            DistroFeatureSnapshot snapshot;
             try
             {
-                var snapshot = Volatile.Read(ref _snapshot);
-                if (snapshot is null || snapshot.Features == DistroFeature.None)
+                snapshot = Volatile.Read(ref _snapshot);
+                if (snapshot.Features == DistroFeature.None)
                 {
                     // SDKStats spec: "Don't send feature/instrumentation SDKStats when the
-                    // feature/instrumentation list is empty."
-                    return new Measurement<long>();
+                    // feature/instrumentation list is empty." Returning an empty enumerable
+                    // (not a default Measurement) is required to truly skip emission for
+                    // this collection cycle.
+                    return EmptyMeasurements;
                 }
+            }
+            catch (Exception ex)
+            {
+                AzureMonitorAspNetCoreEventSource.Log.DistroFeatureSdkStatsCallbackFailed(ex);
+                return EmptyMeasurements;
+            }
 
-                return new Measurement<long>(
+            try
+            {
+                var measurement = new Measurement<long>(
                     (long)snapshot.Features,
                     new KeyValuePair<string, object?>("rp", ResourceProviderHelper.GetResourceProvider()),
                     new KeyValuePair<string, object?>("attach", ResourceProviderHelper.GetAttachMode()),
@@ -146,11 +181,13 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
                     new KeyValuePair<string, object?>("os", ResourceProviderHelper.GetOperatingSystem()),
                     new KeyValuePair<string, object?>("language", "dotnet"),
                     new KeyValuePair<string, object?>("version", snapshot.DistroVersion));
+
+                return new[] { measurement };
             }
             catch (Exception ex)
             {
                 AzureMonitorAspNetCoreEventSource.Log.DistroFeatureSdkStatsCallbackFailed(ex);
-                return new Measurement<long>();
+                return EmptyMeasurements;
             }
         }
     }

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSnapshot.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSnapshot.cs
@@ -26,6 +26,19 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
             this.DistroVersion = distroVersion;
         }
 
+        /// <summary>
+        /// Test-only factory that constructs a snapshot with an arbitrary feature bit mask.
+        /// <see cref="Build"/> always sets at least
+        /// <see cref="DistroFeature.Distro"/> | <see cref="DistroFeature.AgentFramework"/>, so
+        /// tests that need to exercise the spec-mandated empty-features short-circuit (which
+        /// <see cref="Build"/> can never produce) use this entry point.
+        /// </summary>
+        internal static DistroFeatureSnapshot CreateForTesting(
+            DistroFeature features,
+            string customerInstrumentationKey,
+            string distroVersion) =>
+            new DistroFeatureSnapshot(features, customerInstrumentationKey, distroVersion);
+
         /// <summary>Bit map of distro features enabled in the current process.</summary>
         internal DistroFeature Features { get; }
 
@@ -37,19 +50,26 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
 
         /// <summary>
         /// Builds a snapshot from a fully-finalized set of distro options. The customer
-        /// instrumentation key is extracted from the Azure Monitor connection string when
+        /// instrumentation key is extracted from the supplied connection string when
         /// present; for OTLP-only, Console-only, or Agent365-only deployments where no
         /// connection string is configured, <see cref="CustomerInstrumentationKey"/> is set
         /// to the literal <c>"N/A"</c> (per the SDKStats spec convention for Network stats,
         /// extended here for consistency).
         /// </summary>
         /// <param name="options">The distro options after defaults and auto-detection have been applied.</param>
+        /// <param name="connectionString">
+        /// The effective Azure Monitor connection string for the process. Passed explicitly so
+        /// the caller can resolve it from <see cref="MicrosoftOpenTelemetryOptions"/>,
+        /// <c>IConfiguration</c>, or environment variables without the snapshot writing back
+        /// into the user-supplied options instance.
+        /// </param>
         /// <param name="effectiveExporters">The exporter selection resolved by the distro.</param>
         /// <param name="customerSdkStatsEnabled">Whether customer-facing SDK stats are enabled.</param>
         /// <param name="a365OnlyMode">Whether the distro entered Agent365-only mode.</param>
         /// <param name="distroVersion">The distro assembly version string.</param>
         internal static DistroFeatureSnapshot? Build(
             MicrosoftOpenTelemetryOptions options,
+            string? connectionString,
             ExportTarget effectiveExporters,
             bool customerSdkStatsEnabled,
             bool a365OnlyMode,
@@ -60,7 +80,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
                 return null;
             }
 
-            var ikey = TryExtractInstrumentationKey(options.AzureMonitor.ConnectionString);
+            var ikey = TryExtractInstrumentationKey(connectionString);
             if (string.IsNullOrEmpty(ikey))
             {
                 // No customer connection string (OTLP/Console/A365-only deployment).

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSnapshot.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSnapshot.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
+{
+    /// <summary>
+    /// Immutable snapshot of the distro feature flags reported on a given
+    /// <c>UseMicrosoftOpenTelemetry</c> invocation, plus the customer instrumentation key
+    /// extracted from the Azure Monitor connection string.
+    /// </summary>
+    internal sealed class DistroFeatureSnapshot
+    {
+        /// <summary>
+        /// Literal value reported as <c>cikey</c> when no Azure Monitor connection string
+        /// is configured (OTLP-only, Console-only, or Agent365-only deployments). Mirrors
+        /// the SDKStats spec convention for Network stats.
+        /// </summary>
+        internal const string NoCustomerInstrumentationKey = "N/A";
+
+        private DistroFeatureSnapshot(DistroFeature features, string customerInstrumentationKey, string distroVersion)
+        {
+            this.Features = features;
+            this.CustomerInstrumentationKey = customerInstrumentationKey;
+            this.DistroVersion = distroVersion;
+        }
+
+        /// <summary>Bit map of distro features enabled in the current process.</summary>
+        internal DistroFeature Features { get; }
+
+        /// <summary>Customer instrumentation key (without the surrounding connection-string envelope).</summary>
+        internal string CustomerInstrumentationKey { get; }
+
+        /// <summary>Version string of the distro package.</summary>
+        internal string DistroVersion { get; }
+
+        /// <summary>
+        /// Builds a snapshot from a fully-finalized set of distro options. The customer
+        /// instrumentation key is extracted from the Azure Monitor connection string when
+        /// present; for OTLP-only, Console-only, or Agent365-only deployments where no
+        /// connection string is configured, <see cref="CustomerInstrumentationKey"/> is set
+        /// to the literal <c>"N/A"</c> (per the SDKStats spec convention for Network stats,
+        /// extended here for consistency).
+        /// </summary>
+        /// <param name="options">The distro options after defaults and auto-detection have been applied.</param>
+        /// <param name="effectiveExporters">The exporter selection resolved by the distro.</param>
+        /// <param name="customerSdkStatsEnabled">Whether customer-facing SDK stats are enabled.</param>
+        /// <param name="a365OnlyMode">Whether the distro entered Agent365-only mode.</param>
+        /// <param name="distroVersion">The distro assembly version string.</param>
+        internal static DistroFeatureSnapshot? Build(
+            MicrosoftOpenTelemetryOptions options,
+            ExportTarget effectiveExporters,
+            bool customerSdkStatsEnabled,
+            bool a365OnlyMode,
+            string distroVersion)
+        {
+            if (options is null)
+            {
+                return null;
+            }
+
+            var ikey = TryExtractInstrumentationKey(options.AzureMonitor.ConnectionString);
+            if (string.IsNullOrEmpty(ikey))
+            {
+                // No customer connection string (OTLP/Console/A365-only deployment).
+                // Per the SDKStats spec, report the cikey dimension as the literal "N/A"
+                // rather than omitting it, so backend KQL queries don't need to filter
+                // out missing rows.
+                ikey = NoCustomerInstrumentationKey;
+            }
+
+            var features = DistroFeature.Distro;
+
+            // AzureMonitor-scoped feature flags.
+            if (options.AzureMonitor.Credential != null)
+            {
+                features |= DistroFeature.AadHandling;
+            }
+
+            if (options.AzureMonitor.EnableLiveMetrics)
+            {
+                features |= DistroFeature.LiveMetrics;
+            }
+
+            if (options.AzureMonitor.EnableStandardMetrics)
+            {
+                features |= DistroFeature.StandardMetrics;
+            }
+
+            if (options.AzureMonitor.EnablePerfCounters)
+            {
+                features |= DistroFeature.PerfCounters;
+            }
+
+            if (!options.AzureMonitor.DisableOfflineStorage)
+            {
+                features |= DistroFeature.DiskRetry;
+            }
+
+            if (options.AzureMonitor.EnableTraceBasedLogsSampler)
+            {
+                features |= DistroFeature.TraceBasedLogsSampler;
+            }
+
+            if (customerSdkStatsEnabled)
+            {
+                features |= DistroFeature.CustomerSdkStats;
+            }
+
+            // Exporter selection.
+            if (effectiveExporters.HasFlag(ExportTarget.AzureMonitor))
+            {
+                features |= DistroFeature.ExporterAzureMonitor;
+            }
+
+            if (effectiveExporters.HasFlag(ExportTarget.Otlp))
+            {
+                features |= DistroFeature.ExporterOtlp;
+            }
+
+            if (effectiveExporters.HasFlag(ExportTarget.Agent365))
+            {
+                features |= DistroFeature.ExporterAgent365;
+            }
+
+            if (effectiveExporters.HasFlag(ExportTarget.Console))
+            {
+                features |= DistroFeature.ExporterConsole;
+            }
+
+            // Distro behavior flags.
+            features |= DistroFeature.AgentFramework; // UseAgentFramework is unconditional today.
+
+            if (a365OnlyMode)
+            {
+                features |= DistroFeature.A365OnlyMode;
+            }
+
+            return new DistroFeatureSnapshot(features, ikey!, distroVersion);
+        }
+
+        /// <summary>
+        /// Extracts the <c>InstrumentationKey</c> value from an Application Insights
+        /// connection string. Returns <see langword="null"/> when not present.
+        /// </summary>
+        internal static string? TryExtractInstrumentationKey(string? connectionString)
+        {
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                return null;
+            }
+
+            // Connection strings are semicolon-separated "Key=Value" pairs and the key matching
+            // performed by the exporter is case-insensitive. Mirror that here without taking a
+            // dependency on the exporter's internal parser.
+            foreach (var rawSegment in connectionString!.Split(';'))
+            {
+                var segment = rawSegment.Trim();
+                if (segment.Length == 0)
+                {
+                    continue;
+                }
+
+                var eqIndex = segment.IndexOf('=');
+                if (eqIndex <= 0 || eqIndex == segment.Length - 1)
+                {
+                    continue;
+                }
+
+                var key = segment.Substring(0, eqIndex).Trim();
+                if (string.Equals(key, "InstrumentationKey", StringComparison.OrdinalIgnoreCase))
+                {
+                    var value = segment.Substring(eqIndex + 1).Trim();
+                    return value.Length == 0 ? null : value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -91,6 +91,17 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
 
         builder.Services.AddSingleton(UseMicrosoftOpenTelemetryRegistration.Instance);
 
+        // Route ALL Statsbeat emitted in this process to the distro-owned Statsbeat
+        // ingestion endpoint (us.stats.monitor.azure.com / eudb.stats.monitor.azure.com)
+        // instead of the existing Application Insights internal resources. The switch is
+        // honored by Azure.Monitor.OpenTelemetry.Exporter's AzureMonitorStatsbeat and
+        // applies to every AzureMonitorMetricExporter constructed after this point —
+        // including the customer's own exporter when running under the distro. Must be
+        // set before any exporter is constructed (the ctor triggers Statsbeat init).
+        AppContext.SetSwitch(
+            "Azure.Monitor.OpenTelemetry.Exporter.RouteStatsbeatToDistroEndpoint",
+            true);
+
         var options = new MicrosoftOpenTelemetryOptions();
         configure(options);
 

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -91,15 +91,14 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
 
         builder.Services.AddSingleton(UseMicrosoftOpenTelemetryRegistration.Instance);
 
-        // Route ALL Statsbeat emitted in this process to the distro-owned Statsbeat
-        // ingestion endpoint (us.stats.monitor.azure.com / eudb.stats.monitor.azure.com)
-        // instead of the existing Application Insights internal resources. The switch is
-        // honored by Azure.Monitor.OpenTelemetry.Exporter's AzureMonitorStatsbeat and
-        // applies to every AzureMonitorMetricExporter constructed after this point —
-        // including the customer's own exporter when running under the distro. Must be
-        // set before any exporter is constructed (the ctor triggers Statsbeat init).
+        // Route SDK statistics emitted in this process to the distro-owned ingestion
+        // endpoints instead of the legacy internal Application Insights resources. The
+        // switch is honored by Azure.Monitor.OpenTelemetry.Exporter's AzureMonitorStatsbeat
+        // and applies to every AzureMonitorMetricExporter constructed after this point —
+        // including the customer's own exporter when running under the distro. Must be set
+        // before any exporter is constructed (the ctor triggers SDK statistics init).
         AppContext.SetSwitch(
-            "Azure.Monitor.OpenTelemetry.Exporter.RouteStatsbeatToDistroEndpoint",
+            "Azure.Monitor.OpenTelemetry.Exporter.RouteSdkStatsToDistroEndpoint",
             true);
 
         var options = new MicrosoftOpenTelemetryOptions();

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -376,18 +376,20 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
                     Microsoft.OpenTelemetry.AzureMonitor.Internals.EnvironmentVariableConstants.APPLICATIONINSIGHTS_SDKSTATS_DISABLED);
                 var customerSdkStatsEnabled = string.Equals(customerSdkStatsDisabled, "false", StringComparison.OrdinalIgnoreCase);
 
-                // Snapshot the distro options (captured by the outer call) and patch the
-                // connection string from the post-DI AzureMonitorOptions if the caller didn't
-                // provide one directly.
-                var effectiveConnectionString = ResolveEffectiveConnectionString(sp, options.AzureMonitor.ConnectionString);
-                if (!string.IsNullOrEmpty(effectiveConnectionString)
-                    && string.IsNullOrEmpty(options.AzureMonitor.ConnectionString))
-                {
-                    options.AzureMonitor.ConnectionString = effectiveConnectionString;
-                }
+                // Resolve the effective connection string the exporter will use at transmit
+                // time without writing it back into the caller-supplied options instance.
+                // The customer's MicrosoftOpenTelemetryOptions is treated as immutable once
+                // configure(options) returns; mutating it from a deferred callback would be
+                // a surprising side effect on an object that may still be referenced by user
+                // code or other configurators.
+                var effectiveConnectionString =
+                    !string.IsNullOrEmpty(options.AzureMonitor.ConnectionString)
+                        ? options.AzureMonitor.ConnectionString
+                        : ResolveEffectiveConnectionString(sp);
 
                 var snapshot = Microsoft.OpenTelemetry.AzureMonitor.SdkStats.DistroFeatureSnapshot.Build(
                     options,
+                    effectiveConnectionString,
                     effectiveExporters,
                     customerSdkStatsEnabled,
                     a365OnlyMode,
@@ -465,13 +467,8 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
         }
     }
 
-    private static string? ResolveEffectiveConnectionString(IServiceProvider sp, string? directConnectionString)
+    private static string? ResolveEffectiveConnectionString(IServiceProvider sp)
     {
-        if (!string.IsNullOrEmpty(directConnectionString))
-        {
-            return directConnectionString;
-        }
-
         try
         {
             // The distro's AzureMonitorOptions is bound from IConfiguration and the

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using global::OpenTelemetry;
 using global::OpenTelemetry.Trace;
 using global::OpenTelemetry.Metrics;
@@ -309,7 +310,171 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
             }
         }
 
+        // --- Distro Feature SDKStats ---
+        // Publishes a single observable gauge on a distro-owned meter. The Azure Monitor
+        // exporter's Statsbeat MeterProvider subscribes to that meter by name and ships
+        // the measurements on the existing 24-hour Statsbeat cadence.
+        //
+        // The producer is registered regardless of which exporter the customer selected.
+        // When Azure Monitor is selected, the customer's own AzureMonitorMetricExporter
+        // construction already creates the Statsbeat MeterProvider. When it is not, the
+        // distro instantiates an inert AzureMonitorMetricExporter purely for its ctor-time
+        // side effect of creating the Statsbeat MeterProvider (see RegisterDistroFeatureSdkStats).
+        // Either way, the Feature gauge flows through Statsbeat to the Microsoft-owned
+        // SDKStats Application Insights resource.
+        RegisterDistroFeatureSdkStats(builder.Services, options, exporters, a365OnlyMode);
+
         return builder;
+    }
+
+    private static void RegisterDistroFeatureSdkStats(
+        IServiceCollection services,
+        MicrosoftOpenTelemetryOptions options,
+        ExportTarget effectiveExporters,
+        bool a365OnlyMode)
+    {
+        // Kill switch is checked at registration time so we don't even attach the MeterProvider
+        // configurator when stats are disabled.
+        string? disabled;
+        try
+        {
+            disabled = Environment.GetEnvironmentVariable(
+                Microsoft.OpenTelemetry.AzureMonitor.Internals.EnvironmentVariableConstants.APPLICATIONINSIGHTS_STATSBEAT_DISABLED);
+        }
+        catch (Exception)
+        {
+            disabled = null;
+        }
+
+        if (string.Equals(disabled, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            Microsoft.OpenTelemetry.AzureMonitorAspNetCoreEventSource.Log.DistroFeatureSdkStatsDisabledByEnvVar();
+            return;
+        }
+
+        // Defer snapshot construction until the MeterProvider builds: by then the exporter's
+        // AzureMonitorOptions has been populated from IConfiguration and environment variables,
+        // so the connection string (and the customer iKey we extract from it) is the same value
+        // the exporter is actually using.
+        services.ConfigureOpenTelemetryMeterProvider((sp, _) =>
+        {
+            try
+            {
+                // Mirror the exporter's opt-in semantics: APPLICATIONINSIGHTS_SDKSTATS_DISABLED
+                // must be set to "false" to enable customer SDK stats.
+                var customerSdkStatsDisabled = Environment.GetEnvironmentVariable(
+                    Microsoft.OpenTelemetry.AzureMonitor.Internals.EnvironmentVariableConstants.APPLICATIONINSIGHTS_SDKSTATS_DISABLED);
+                var customerSdkStatsEnabled = string.Equals(customerSdkStatsDisabled, "false", StringComparison.OrdinalIgnoreCase);
+
+                // Snapshot the distro options (captured by the outer call) and patch the
+                // connection string from the post-DI AzureMonitorOptions if the caller didn't
+                // provide one directly.
+                var effectiveConnectionString = ResolveEffectiveConnectionString(sp, options.AzureMonitor.ConnectionString);
+                if (!string.IsNullOrEmpty(effectiveConnectionString)
+                    && string.IsNullOrEmpty(options.AzureMonitor.ConnectionString))
+                {
+                    options.AzureMonitor.ConnectionString = effectiveConnectionString;
+                }
+
+                var snapshot = Microsoft.OpenTelemetry.AzureMonitor.SdkStats.DistroFeatureSnapshot.Build(
+                    options,
+                    effectiveExporters,
+                    customerSdkStatsEnabled,
+                    a365OnlyMode,
+                    Microsoft.OpenTelemetry.AzureMonitor.Internals.SdkVersion.Value);
+
+                if (snapshot is null)
+                {
+                    return;
+                }
+
+                // When the customer hasn't selected Azure Monitor, no AzureMonitorMetricExporter
+                // is constructed in this process — which means the Statsbeat MeterProvider that
+                // subscribes to our distro meter never comes up. To plug that gap, we build an
+                // inert exporter pointed at a placeholder connection string. We never attach it
+                // to any reader, so it ships nothing itself; we hold it solely for its ctor-time
+                // side effect of triggering Statsbeat initialization (which then subscribes to
+                // our meter by name and ships the Feature measurement to the Microsoft Statsbeat
+                // resource on the standard 24-hour cadence).
+                IDisposable? statsbeatPin = null;
+                if (!effectiveExporters.HasFlag(ExportTarget.AzureMonitor))
+                {
+                    statsbeatPin = TryCreateStatsbeatPin();
+                }
+
+                Microsoft.OpenTelemetry.AzureMonitor.SdkStats.DistroFeatureSdkStats.Initialize(snapshot, statsbeatPin);
+            }
+            catch (Exception ex)
+            {
+                // Stats are best-effort; never let registration failures break user instrumentation.
+                Microsoft.OpenTelemetry.AzureMonitorAspNetCoreEventSource.Log.DistroFeatureSdkStatsCallbackFailed(ex);
+            }
+        });
+    }
+
+    /// <summary>
+    /// Constructs an inert <see cref="Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorMetricExporter"/>
+    /// whose only purpose is to trigger the Statsbeat <c>MeterProvider</c> side effect inside
+    /// the exporter's transmitter factory. The exporter is never attached to any reader.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Uses a placeholder connection string with <c>InstrumentationKey=N/A</c> routed to the
+    /// non-EU Statsbeat ingestion region. <see cref="Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions.DisableOfflineStorage"/>
+    /// is set to <c>true</c> so no offline-retry directory is created (the inert exporter
+    /// never receives metrics, but we defend against any incidental I/O).
+    /// </para>
+    /// <para>
+    /// Returns <see langword="null"/> if construction fails for any reason. Stats are
+    /// best-effort — a failure here must not break customer instrumentation.
+    /// </para>
+    /// </remarks>
+    private static IDisposable? TryCreateStatsbeatPin()
+    {
+        try
+        {
+            // Default routing: non-EU. The exporter team owns EU vs non-EU region selection
+            // based on the IngestionEndpoint host; westus-0 matches the non-EU pattern.
+            // "N/A" cikey is consistent with the SDKStats spec convention for deployments
+            // without a customer Application Insights resource.
+            const string placeholderConnectionString =
+                "InstrumentationKey=N/A;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/";
+
+            var exporterOptions = new Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorExporterOptions
+            {
+                ConnectionString = placeholderConnectionString,
+                DisableOfflineStorage = true,
+            };
+
+            return new Azure.Monitor.OpenTelemetry.Exporter.AzureMonitorMetricExporter(exporterOptions);
+        }
+        catch (Exception ex)
+        {
+            Microsoft.OpenTelemetry.AzureMonitorAspNetCoreEventSource.Log.DistroFeatureSdkStatsCallbackFailed(ex);
+            return null;
+        }
+    }
+
+    private static string? ResolveEffectiveConnectionString(IServiceProvider sp, string? directConnectionString)
+    {
+        if (!string.IsNullOrEmpty(directConnectionString))
+        {
+            return directConnectionString;
+        }
+
+        try
+        {
+            // The distro's AzureMonitorOptions is bound from IConfiguration and the
+            // APPLICATIONINSIGHTS_CONNECTION_STRING env var by DefaultAzureMonitorOptions.
+            // Reading IOptions<AzureMonitorOptions> from DI yields the same effective
+            // connection string the exporter will use at transmit time.
+            var amOptions = sp.GetService<IOptions<Microsoft.OpenTelemetry.AzureMonitorOptions>>()?.Value;
+            return amOptions?.ConnectionString;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
     }
 
     /// <summary>

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSdkStatsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSdkStatsTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
 
             var snapshot = DistroFeatureSnapshot.Build(
                 options,
+                ValidConnectionString,
                 ExportTarget.AzureMonitor,
                 customerSdkStatsEnabled: false,
                 a365OnlyMode: false,
@@ -51,13 +52,24 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
         }
 
         [Fact]
-        public void Observe_WhenFeaturesAreNone_ReturnsEmptyMeasurement()
+        public void Observe_WhenFeaturesAreNone_EmitsNoMeasurement()
         {
-            // Without Initialize being called, the singleton hasn't been created yet, so the
-            // meter has no instruments — the collected list should contain no measurement
-            // attributed to our meter (the helper filters by meter name).
-            var collected = CollectObservableMeasurements();
-            Assert.Empty(collected);
+            // Exercises the spec-mandated short-circuit: when the snapshot's feature mask is
+            // DistroFeature.None, the observable gauge MUST return zero measurements (not a
+            // default Measurement<long>(), which would still publish a phantom zero data point
+            // with no tags). Use the internal test factory to construct a None-masked snapshot
+            // directly — DistroFeatureSnapshot.Build always sets at least Distro|AgentFramework
+            // so it cannot produce a None snapshot through the normal code path.
+            var snapshot = DistroFeatureSnapshot.CreateForTesting(
+                DistroFeature.None,
+                customerInstrumentationKey: "N/A",
+                distroVersion: "9.9.9-none");
+
+            DistroFeatureSdkStats.Initialize(snapshot);
+
+            var measurements = CollectObservableMeasurements();
+
+            Assert.Empty(measurements);
         }
 
         [Fact]
@@ -71,6 +83,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
 
             var snapshot = DistroFeatureSnapshot.Build(
                 options,
+                connectionString: null,
                 ExportTarget.Otlp,
                 customerSdkStatsEnabled: false,
                 a365OnlyMode: false,
@@ -94,7 +107,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
             var options = new MicrosoftOpenTelemetryOptions();
             options.AzureMonitor.ConnectionString = ValidConnectionString;
             var snapshot = DistroFeatureSnapshot.Build(
-                options, ExportTarget.AzureMonitor, false, false, "9.9.9-pin")!;
+                options, ValidConnectionString, ExportTarget.AzureMonitor, false, false, "9.9.9-pin")!;
 
             var pin = new TrackingDisposable();
             DistroFeatureSdkStats.Initialize(snapshot, pin);
@@ -114,7 +127,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
             var options = new MicrosoftOpenTelemetryOptions();
             options.AzureMonitor.ConnectionString = ValidConnectionString;
             var snapshot = DistroFeatureSnapshot.Build(
-                options, ExportTarget.AzureMonitor, false, false, "9.9.9-pin")!;
+                options, ValidConnectionString, ExportTarget.AzureMonitor, false, false, "9.9.9-pin")!;
 
             var firstPin = new TrackingDisposable();
             var secondPin = new TrackingDisposable();

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSdkStatsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSdkStatsTests.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using Microsoft.OpenTelemetry.AzureMonitor.SdkStats;
+using Xunit;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
+{
+    [Collection(nameof(DistroFeatureSdkStatsCollection))]
+    public class DistroFeatureSdkStatsTests
+    {
+        private const string ValidConnectionString =
+            "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/";
+
+        public DistroFeatureSdkStatsTests()
+        {
+            DistroFeatureSdkStats.ResetForTesting();
+        }
+
+        [Fact]
+        public void Observe_ReturnsMeasurementWithExpectedTags()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.AzureMonitor.ConnectionString = ValidConnectionString;
+
+            var snapshot = DistroFeatureSnapshot.Build(
+                options,
+                ExportTarget.AzureMonitor,
+                customerSdkStatsEnabled: false,
+                a365OnlyMode: false,
+                distroVersion: "9.9.9-test")!;
+
+            DistroFeatureSdkStats.Initialize(snapshot);
+
+            var measurements = CollectObservableMeasurements();
+
+            var match = Assert.Single(measurements, m => m.tags.TryGetValue("version", out var v) && (string?)v == "9.9.9-test");
+
+            // The numeric value equals the feature mask.
+            Assert.Equal((long)snapshot.Features, match.value);
+
+            Assert.Equal("dotnet", match.tags["language"]);
+            Assert.Equal(0, match.tags["type"]);
+            Assert.Equal(snapshot.CustomerInstrumentationKey, match.tags["cikey"]);
+            Assert.Equal((long)snapshot.Features, match.tags["feature"]);
+            Assert.True(match.tags.ContainsKey("rp"));
+            Assert.True(match.tags.ContainsKey("attach"));
+            Assert.True(match.tags.ContainsKey("os"));
+        }
+
+        [Fact]
+        public void Observe_WhenFeaturesAreNone_ReturnsEmptyMeasurement()
+        {
+            // Without Initialize being called, the singleton hasn't been created yet, so the
+            // meter has no instruments — the collected list should contain no measurement
+            // attributed to our meter (the helper filters by meter name).
+            var collected = CollectObservableMeasurements();
+            Assert.Empty(collected);
+        }
+
+        [Fact]
+        public void Observe_WithoutAzureMonitorConnectionString_UsesNAForCikey()
+        {
+            // Deployments without Azure Monitor (OTLP-only, Console-only, A365-only) still
+            // report Feature SDKStats; the spec convention is to populate the cikey dimension
+            // with the literal "N/A" so backend KQL doesn't need to filter out missing rows.
+            var options = new MicrosoftOpenTelemetryOptions();
+            // No ConnectionString set.
+
+            var snapshot = DistroFeatureSnapshot.Build(
+                options,
+                ExportTarget.Otlp,
+                customerSdkStatsEnabled: false,
+                a365OnlyMode: false,
+                distroVersion: "9.9.9-otlp-only");
+
+            Assert.NotNull(snapshot);
+            Assert.Equal(DistroFeatureSnapshot.NoCustomerInstrumentationKey, snapshot!.CustomerInstrumentationKey);
+            Assert.Equal("N/A", snapshot.CustomerInstrumentationKey);
+
+            DistroFeatureSdkStats.Initialize(snapshot);
+            var measurements = CollectObservableMeasurements();
+
+            var match = Assert.Single(measurements, m => m.tags.TryGetValue("version", out var v) && (string?)v == "9.9.9-otlp-only");
+            Assert.Equal("N/A", match.tags["cikey"]);
+            Assert.Equal((long)snapshot.Features, match.value);
+        }
+
+        [Fact]
+        public void Initialize_WithStatsbeatPin_DisposesPinOnReset()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.AzureMonitor.ConnectionString = ValidConnectionString;
+            var snapshot = DistroFeatureSnapshot.Build(
+                options, ExportTarget.AzureMonitor, false, false, "9.9.9-pin")!;
+
+            var pin = new TrackingDisposable();
+            DistroFeatureSdkStats.Initialize(snapshot, pin);
+
+            Assert.False(pin.Disposed);
+
+            DistroFeatureSdkStats.ResetForTesting();
+
+            Assert.True(pin.Disposed);
+        }
+
+        [Fact]
+        public void Initialize_SecondPin_IsDisposedImmediately()
+        {
+            // The first pin wins for the process lifetime; a second pin supplied while one
+            // is already held must be disposed immediately so we don't leak a transmitter.
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.AzureMonitor.ConnectionString = ValidConnectionString;
+            var snapshot = DistroFeatureSnapshot.Build(
+                options, ExportTarget.AzureMonitor, false, false, "9.9.9-pin")!;
+
+            var firstPin = new TrackingDisposable();
+            var secondPin = new TrackingDisposable();
+
+            DistroFeatureSdkStats.Initialize(snapshot, firstPin);
+            DistroFeatureSdkStats.Initialize(snapshot, secondPin);
+
+            Assert.False(firstPin.Disposed);
+            Assert.True(secondPin.Disposed);
+        }
+
+        private sealed class TrackingDisposable : System.IDisposable
+        {
+            public bool Disposed { get; private set; }
+
+            public void Dispose() => Disposed = true;
+        }
+
+        private static List<(long value, Dictionary<string, object?> tags)> CollectObservableMeasurements()
+        {
+            var results = new List<(long value, Dictionary<string, object?> tags)>();
+
+            using var listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == DistroFeatureSdkStats.MeterName
+                        && instrument.Name == DistroFeatureSdkStats.MetricName)
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+            {
+                var dict = new Dictionary<string, object?>(tags.Length);
+                for (int i = 0; i < tags.Length; i++)
+                {
+                    dict[tags[i].Key] = tags[i].Value;
+                }
+                results.Add((value, dict));
+            });
+            listener.Start();
+            listener.RecordObservableInstruments();
+            return results;
+        }
+    }
+
+    [CollectionDefinition(nameof(DistroFeatureSdkStatsCollection), DisableParallelization = true)]
+    public class DistroFeatureSdkStatsCollection
+    {
+        // The DistroFeatureSdkStats singleton is process-wide; serialize tests that touch it.
+    }
+}

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSnapshotTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSnapshotTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.OpenTelemetry.AzureMonitor.SdkStats;
+using Xunit;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
+{
+    public class DistroFeatureSnapshotTests
+    {
+        private const string ValidConnectionString =
+            "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westus-0.in.applicationinsights.azure.com/";
+
+        [Fact]
+        public void Build_WithoutConnectionString_UsesNAForCikey()
+        {
+            // For OTLP-only / Console-only / Agent365-only deployments there is no customer
+            // Application Insights connection string. Per the SDKStats spec convention, the
+            // cikey dimension is reported as the literal "N/A" so backend KQL queries don't
+            // have to filter out missing rows.
+            var options = new MicrosoftOpenTelemetryOptions();
+
+            var snapshot = DistroFeatureSnapshot.Build(
+                options,
+                ExportTarget.Otlp,
+                customerSdkStatsEnabled: false,
+                a365OnlyMode: false,
+                distroVersion: "1.0.0");
+
+            Assert.NotNull(snapshot);
+            Assert.Equal("N/A", snapshot!.CustomerInstrumentationKey);
+            Assert.Equal(DistroFeatureSnapshot.NoCustomerInstrumentationKey, snapshot.CustomerInstrumentationKey);
+            // Always-on bits still set even without a customer connection string.
+            Assert.True(snapshot.Features.HasFlag(DistroFeature.Distro));
+            Assert.True(snapshot.Features.HasFlag(DistroFeature.AgentFramework));
+            Assert.True(snapshot.Features.HasFlag(DistroFeature.ExporterOtlp));
+            Assert.False(snapshot.Features.HasFlag(DistroFeature.ExporterAzureMonitor));
+        }
+
+        [Fact]
+        public void Build_WithMinimalConnectionString_SetsBaseFeatures()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.AzureMonitor.ConnectionString = ValidConnectionString;
+            // Force-disable everything that defaults to true so we can observe the minimal bit set.
+            options.AzureMonitor.EnableLiveMetrics = false;
+            options.AzureMonitor.EnableStandardMetrics = false;
+            options.AzureMonitor.EnablePerfCounters = false;
+            options.AzureMonitor.DisableOfflineStorage = true;
+            options.AzureMonitor.EnableTraceBasedLogsSampler = false;
+
+            var snapshot = DistroFeatureSnapshot.Build(
+                options,
+                ExportTarget.None,
+                customerSdkStatsEnabled: false,
+                a365OnlyMode: false,
+                distroVersion: "1.0.0");
+
+            Assert.NotNull(snapshot);
+            // DISTRO and AGENT_FRAMEWORK are always set; nothing else when everything is off.
+            var expected = DistroFeature.Distro | DistroFeature.AgentFramework;
+            Assert.Equal(expected, snapshot!.Features);
+            Assert.Equal("00000000-0000-0000-0000-000000000000", snapshot.CustomerInstrumentationKey);
+            Assert.Equal("1.0.0", snapshot.DistroVersion);
+        }
+
+        [Fact]
+        public void Build_WithAllDefaults_SetsExpectedFeatureBits()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.AzureMonitor.ConnectionString = ValidConnectionString;
+            // Defaults: LiveMetrics=true, StandardMetrics=true, PerfCounters=true,
+            // DisableOfflineStorage=false (so DiskRetry=true), TraceBasedLogsSampler=true.
+
+            var snapshot = DistroFeatureSnapshot.Build(
+                options,
+                ExportTarget.AzureMonitor,
+                customerSdkStatsEnabled: false,
+                a365OnlyMode: false,
+                distroVersion: "1.0.0");
+
+            Assert.NotNull(snapshot);
+
+            var expected =
+                DistroFeature.Distro
+                | DistroFeature.LiveMetrics
+                | DistroFeature.StandardMetrics
+                | DistroFeature.PerfCounters
+                | DistroFeature.DiskRetry
+                | DistroFeature.TraceBasedLogsSampler
+                | DistroFeature.ExporterAzureMonitor
+                | DistroFeature.AgentFramework;
+
+            Assert.Equal(expected, snapshot!.Features);
+        }
+
+        [Fact]
+        public void Build_WithAllExportersAndCustomerSdkStats_SetsAllExpectedBits()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.AzureMonitor.ConnectionString = ValidConnectionString;
+
+            var snapshot = DistroFeatureSnapshot.Build(
+                options,
+                ExportTarget.AzureMonitor | ExportTarget.Otlp | ExportTarget.Agent365 | ExportTarget.Console,
+                customerSdkStatsEnabled: true,
+                a365OnlyMode: false,
+                distroVersion: "1.0.0");
+
+            Assert.NotNull(snapshot);
+            Assert.True(snapshot!.Features.HasFlag(DistroFeature.ExporterAzureMonitor));
+            Assert.True(snapshot.Features.HasFlag(DistroFeature.ExporterOtlp));
+            Assert.True(snapshot.Features.HasFlag(DistroFeature.ExporterAgent365));
+            Assert.True(snapshot.Features.HasFlag(DistroFeature.ExporterConsole));
+            Assert.True(snapshot.Features.HasFlag(DistroFeature.CustomerSdkStats));
+        }
+
+        [Fact]
+        public void Build_WithA365OnlyMode_SetsA365OnlyModeBit()
+        {
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.AzureMonitor.ConnectionString = ValidConnectionString;
+
+            var snapshot = DistroFeatureSnapshot.Build(
+                options,
+                ExportTarget.Agent365,
+                customerSdkStatsEnabled: false,
+                a365OnlyMode: true,
+                distroVersion: "1.0.0");
+
+            Assert.NotNull(snapshot);
+            Assert.True(snapshot!.Features.HasFlag(DistroFeature.A365OnlyMode));
+        }
+
+        [Theory]
+        [InlineData("InstrumentationKey=abc-123", "abc-123")]
+        [InlineData("InstrumentationKey=abc-123;IngestionEndpoint=https://x", "abc-123")]
+        [InlineData("IngestionEndpoint=https://x;InstrumentationKey=abc-123", "abc-123")]
+        [InlineData("instrumentationkey=abc-123", "abc-123")] // case-insensitive
+        [InlineData("InstrumentationKey = abc-123 ;X=Y", "abc-123")] // whitespace tolerant
+        [InlineData(" ; ;InstrumentationKey=abc-123; ", "abc-123")] // tolerates empty segments
+        public void TryExtractInstrumentationKey_ParsesValidStrings(string connectionString, string expected)
+        {
+            Assert.Equal(expected, DistroFeatureSnapshot.TryExtractInstrumentationKey(connectionString));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("IngestionEndpoint=https://x")]
+        [InlineData("=value-without-key")]
+        [InlineData("InstrumentationKey=")]
+        [InlineData("NoEqualsSign")]
+        public void TryExtractInstrumentationKey_ReturnsNullForInvalidStrings(string? connectionString)
+        {
+            Assert.Null(DistroFeatureSnapshot.TryExtractInstrumentationKey(connectionString));
+        }
+    }
+}

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSnapshotTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSnapshotTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
 
             var snapshot = DistroFeatureSnapshot.Build(
                 options,
+                connectionString: null,
                 ExportTarget.Otlp,
                 customerSdkStatsEnabled: false,
                 a365OnlyMode: false,
@@ -51,6 +52,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
 
             var snapshot = DistroFeatureSnapshot.Build(
                 options,
+                ValidConnectionString,
                 ExportTarget.None,
                 customerSdkStatsEnabled: false,
                 a365OnlyMode: false,
@@ -74,6 +76,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
 
             var snapshot = DistroFeatureSnapshot.Build(
                 options,
+                ValidConnectionString,
                 ExportTarget.AzureMonitor,
                 customerSdkStatsEnabled: false,
                 a365OnlyMode: false,
@@ -102,6 +105,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
 
             var snapshot = DistroFeatureSnapshot.Build(
                 options,
+                ValidConnectionString,
                 ExportTarget.AzureMonitor | ExportTarget.Otlp | ExportTarget.Agent365 | ExportTarget.Console,
                 customerSdkStatsEnabled: true,
                 a365OnlyMode: false,
@@ -123,6 +127,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
 
             var snapshot = DistroFeatureSnapshot.Build(
                 options,
+                ValidConnectionString,
                 ExportTarget.Agent365,
                 customerSdkStatsEnabled: false,
                 a365OnlyMode: true,

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroSdkStatsRoutingSwitchTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroSdkStatsRoutingSwitchTests.cs
@@ -9,12 +9,12 @@ using Xunit;
 namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
 {
     [Collection(nameof(DistroFeatureSdkStatsCollection))]
-    public class DistroStatsbeatRoutingSwitchTests
+    public class DistroSdkStatsRoutingSwitchTests
     {
-        private const string SwitchName = "Azure.Monitor.OpenTelemetry.Exporter.RouteStatsbeatToDistroEndpoint";
+        private const string SwitchName = "Azure.Monitor.OpenTelemetry.Exporter.RouteSdkStatsToDistroEndpoint";
 
         [Fact]
-        public void UseMicrosoftOpenTelemetry_SetsRouteStatsbeatToDistroEndpointAppContextSwitch()
+        public void UseMicrosoftOpenTelemetry_SetsRouteSdkStatsToDistroEndpointAppContextSwitch()
         {
             // Ensure a clean starting state. The switch may be left "on" by a previous test
             // in the same process; reset to false to verify UseMicrosoftOpenTelemetry sets it.
@@ -25,7 +25,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
 
             Assert.True(
                 AppContext.TryGetSwitch(SwitchName, out var enabled) && enabled,
-                "UseMicrosoftOpenTelemetry should set the distro Statsbeat routing AppContext switch.");
+                "UseMicrosoftOpenTelemetry should set the distro SDK statistics routing AppContext switch.");
         }
     }
 }

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroStatsbeatRoutingSwitchTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroStatsbeatRoutingSwitchTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using Xunit;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
+{
+    [Collection(nameof(DistroFeatureSdkStatsCollection))]
+    public class DistroStatsbeatRoutingSwitchTests
+    {
+        private const string SwitchName = "Azure.Monitor.OpenTelemetry.Exporter.RouteStatsbeatToDistroEndpoint";
+
+        [Fact]
+        public void UseMicrosoftOpenTelemetry_SetsRouteStatsbeatToDistroEndpointAppContextSwitch()
+        {
+            // Ensure a clean starting state. The switch may be left "on" by a previous test
+            // in the same process; reset to false to verify UseMicrosoftOpenTelemetry sets it.
+            AppContext.SetSwitch(SwitchName, false);
+
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry().UseMicrosoftOpenTelemetry(_ => { });
+
+            Assert.True(
+                AppContext.TryGetSwitch(SwitchName, out var enabled) && enabled,
+                "UseMicrosoftOpenTelemetry should set the distro Statsbeat routing AppContext switch.");
+        }
+    }
+}

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/ResourceProviderHelperTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/ResourceProviderHelperTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.OpenTelemetry.AzureMonitor.Internals;
+using Xunit;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
+{
+    [Collection(nameof(ResourceProviderHelperCollection))]
+    public class ResourceProviderHelperTests : IDisposable
+    {
+        // Snapshot existing env vars so we can restore them after the test.
+        private readonly string? _functionsRuntime;
+        private readonly string? _websiteSiteName;
+        private readonly string? _aksArmNamespaceId;
+
+        public ResourceProviderHelperTests()
+        {
+            _functionsRuntime = Environment.GetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME");
+            _websiteSiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            _aksArmNamespaceId = Environment.GetEnvironmentVariable("AKS_ARM_NAMESPACE_ID");
+
+            Environment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", null);
+            Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", null);
+            Environment.SetEnvironmentVariable("AKS_ARM_NAMESPACE_ID", null);
+            ResourceProviderHelper.ResetForTesting();
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", _functionsRuntime);
+            Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", _websiteSiteName);
+            Environment.SetEnvironmentVariable("AKS_ARM_NAMESPACE_ID", _aksArmNamespaceId);
+            ResourceProviderHelper.ResetForTesting();
+        }
+
+        [Fact]
+        public void GetResourceProvider_DetectsFunctions()
+        {
+            Environment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "dotnet-isolated");
+
+            Assert.Equal("functions", ResourceProviderHelper.GetResourceProvider());
+        }
+
+        [Fact]
+        public void GetResourceProvider_DetectsAppService()
+        {
+            Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "my-app");
+
+            Assert.Equal("appsvc", ResourceProviderHelper.GetResourceProvider());
+        }
+
+        [Fact]
+        public void GetResourceProvider_DetectsAks()
+        {
+            Environment.SetEnvironmentVariable("AKS_ARM_NAMESPACE_ID", "ns");
+
+            Assert.Equal("aks", ResourceProviderHelper.GetResourceProvider());
+        }
+
+        [Fact]
+        public void GetResourceProvider_FunctionsTakesPrecedenceOverAppService()
+        {
+            Environment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "dotnet-isolated");
+            Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "my-app");
+
+            Assert.Equal("functions", ResourceProviderHelper.GetResourceProvider());
+        }
+
+        [Fact]
+        public void GetOperatingSystem_ReturnsKnownPlatform()
+        {
+            // Just sanity-check that we get a non-empty platform string. The actual value
+            // depends on the host running the test.
+            var os = ResourceProviderHelper.GetOperatingSystem();
+            Assert.False(string.IsNullOrEmpty(os));
+            Assert.Contains(os, new[] { "windows", "linux", "osx", "unknown" });
+        }
+
+        [Fact]
+        public void GetAttachMode_ReturnsManual()
+        {
+            Assert.Equal("Manual", ResourceProviderHelper.GetAttachMode());
+        }
+    }
+
+    [CollectionDefinition(nameof(ResourceProviderHelperCollection), DisableParallelization = true)]
+    public class ResourceProviderHelperCollection
+    {
+        // Resource provider detection caches results process-wide; serialize tests.
+    }
+}


### PR DESCRIPTION
Publishes a `Feature` observable gauge on a new distro-owned meter `MicrosoftOpenTelemetryFeatureSdkStatsMeter`. The Azure Monitor exporter's Statsbeat MeterProvider subscribes to this meter and ships the metric on the existing 24-hour Statsbeat cadence to the Microsoft SDKStats Application Insights resource.

Reported regardless of which exporter the customer selected:

- Azure Monitor selected: the customer's own `AzureMonitorMetricExporter` already triggers Statsbeat for the process; the distro just publishes the gauge with the customer iKey as `cikey`.
- OTLP / Console / Agent365 only: the distro holds an inert `AzureMonitorMetricExporter` (with a placeholder `InstrumentationKey=N/A;IngestionEndpoint=https://westus-0...` connection string and `DisableOfflineStorage=true`) as a singleton pin to trigger the Statsbeat MeterProvider via the exporter's ctor-time side effect. `cikey` is reported as the literal `"N/A"` per the SDKStats spec convention.

Initial bit map (type=0 features, 14 bits):

- DISTRO, AAD_HANDLING, LIVE_METRICS, STANDARD_METRICS, PERF_COUNTERS,
- DISK_RETRY, CUSTOMER_SDKSTATS, TRACE_BASED_LOGS_SAMPLER,
- EXPORTER_AZUREMONITOR, EXPORTER_OTLP, EXPORTER_AGENT365,
- EXPORTER_CONSOLE, AGENT_FRAMEWORK, A365_ONLY_MODE

Bits 14-63 reserved.

Honors `APPLICATIONINSIGHTS_STATSBEAT_DISABLED=true` (same kill switch the exporter uses). All errors in the registration and gauge callback paths are swallowed and logged via `AzureMonitorAspNetCoreEventSource` so stats can never break customer instrumentation.

Includes unit tests for the snapshot bit map, the cikey="N/A" fallback, the empty-features short-circuit, the inert-exporter pin disposal lifecycle, and resource-provider env-var precedence.

Requires the companion change in Azure.Monitor.OpenTelemetry.Exporter that subscribes the Statsbeat MeterProvider to
`MicrosoftOpenTelemetryFeatureSdkStatsMeter`.