### PR TITLE
Add ApplyGuardrailScope for security guardrail evaluation tracing

### DIFF
--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -29,3 +29,84 @@ Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverConte
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TokenResolverContext.TenantId.get -> string!
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.ContextualTokenResolver.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.AsyncContextualTokenResolver?
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions.ContextualTokenResolver.set -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType.Allow = 0 -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType.Audit = 1 -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType.Deny = 2 -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType.Modify = 3 -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType.Warn = 4 -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.GuardrailDetails(string! targetType, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType decisionType, string? guardianName = null, string? guardianId = null, string? guardianProviderName = null, string? guardianVersion = null, string? targetId = null, string? decisionReason = null, string? decisionCode = null, string? policyId = null, string? policyName = null, string? policyVersion = null, string? contentInputHash = null, bool? contentModified = null, string? externalEventId = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.TargetType.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.DecisionType.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.GuardianName.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.GuardianId.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.GuardianProviderName.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.GuardianVersion.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.TargetId.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.DecisionReason.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.DecisionCode.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.PolicyId.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.PolicyName.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.PolicyVersion.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.ContentInputHash.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.ContentModified.get -> bool?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.ExternalEventId.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.Equals(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails? other) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.Equals(object? obj) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails.GetHashCode() -> int
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.GuardrailFinding(string! riskCategory, string! riskSeverity, string? policyDecisionType = null, string? policyId = null, string? policyName = null, string? policyVersion = null, double? riskScore = null, string![]? riskMetadata = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.RiskCategory.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.RiskSeverity.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.PolicyDecisionType.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.PolicyId.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.PolicyName.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.PolicyVersion.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.RiskScore.get -> double?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.RiskMetadata.get -> string![]?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.Equals(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding? other) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.Equals(object? obj) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding.GetHashCode() -> int
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailRiskSeverity
+const Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailRiskSeverity.None = "none" -> string!
+const Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailRiskSeverity.Low = "low" -> string!
+const Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailRiskSeverity.Medium = "medium" -> string!
+const Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailRiskSeverity.High = "high" -> string!
+const Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailRiskSeverity.Critical = "critical" -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.GuardrailTargetType(string! value) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.Value.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.Equals(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType other) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.Equals(object? obj) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.GetHashCode() -> int
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.ToString() -> string!
+static Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.implicit operator Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType(string! value) -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+static Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.implicit operator string!(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType type) -> string!
+static Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.operator ==(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType left, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType right) -> bool
+static Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.operator !=(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType left, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType right) -> bool
+static readonly Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.LlmInput -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+static readonly Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.LlmOutput -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+static readonly Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.ToolCall -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+static readonly Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.ToolDefinition -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+static readonly Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.MemoryStore -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+static readonly Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.MemoryRetrieve -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+static readonly Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.KnowledgeQuery -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+static readonly Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.KnowledgeResult -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+static readonly Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.Message -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.ApplyGuardrailScope
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.ApplyGuardrailScope.RecordDecision(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDecisionType decisionType, string? reason = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.ApplyGuardrailScope.RecordContentOutput(string! outputValue) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.ApplyGuardrailScope.RecordFinding(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailFinding! finding) -> void
+static Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.ApplyGuardrailScope.Start(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails! details, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.AgentDetails! agentDetails, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.Request? request = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.UserDetails? userDetails = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.SpanDetails? spanDetails = null) -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.ApplyGuardrailScope!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailTargetType.GuardrailTargetType() -> void
+Microsoft.Agents.A365.Observability.Runtime.DTOs.ApplyGuardrailData
+Microsoft.Agents.A365.Observability.Runtime.DTOs.ApplyGuardrailData.ApplyGuardrailData(string! parentSpanId, System.Collections.Generic.IDictionary<string!, object?>? attributes = null, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, string? spanKind = null, string? traceId = null) -> void
+override Microsoft.Agents.A365.Observability.Runtime.DTOs.ApplyGuardrailData.Name.get -> string!
+Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders.ApplyGuardrailDataBuilder
+Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders.ApplyGuardrailDataBuilder.ApplyGuardrailDataBuilder() -> void
+static Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders.ApplyGuardrailDataBuilder.Build(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails! guardrailDetails, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string! parentSpanId, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.Channel? channel = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.CallerDetails? callerDetails = null, System.Collections.Generic.IDictionary<string!, object?>? extraAttributes = null, string? spanKind = null, string? traceId = null) -> Microsoft.Agents.A365.Observability.Runtime.DTOs.ApplyGuardrailData!
+Microsoft.Agents.A365.Observability.Runtime.Etw.IA365EtwLogger<T>.LogApplyGuardrail(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails! guardrailDetails, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string! parentSpanId, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.Channel? channel = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.CallerDetails? callerDetails = null, string? traceId = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Etw.A365EtwLogger<T>.LogApplyGuardrail(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails! guardrailDetails, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string! parentSpanId, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.Channel? channel = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.CallerDetails? callerDetails = null, string? traceId = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.OpenTelemetryScope.AddEvent(System.Diagnostics.ActivityEvent activityEvent) -> void
+static Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders.BaseDataBuilder<T>.AddSdkAttributes(System.Collections.Generic.IDictionary<string!, object?>! attributes) -> void

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/ApplyGuardrailData.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/ApplyGuardrailData.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.DTOs
+{
+    /// <summary>
+    /// Encapsulates all telemetry data for an apply_guardrail operation.
+    /// </summary>
+    public class ApplyGuardrailData : BaseData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplyGuardrailData"/> class.
+        /// </summary>
+        /// <param name="parentSpanId">The parent span ID for distributed tracing.</param>
+        /// <param name="attributes">The telemetry attributes (tags).</param>
+        /// <param name="startTime">Optional custom start time for the operation.</param>
+        /// <param name="endTime">Optional custom end time for the operation.</param>
+        /// <param name="spanId">Optional span ID for the operation. If not provided one will be created.</param>
+        /// <param name="spanKind">Optional span kind override. Defaults to <c>null</c> (unset). Use <see cref="SpanKindConstants.Internal"/> as appropriate.</param>
+        /// <param name="traceId">Optional trace ID for distributed tracing.</param>
+        public ApplyGuardrailData(
+            string parentSpanId,
+            IDictionary<string, object?>? attributes = null,
+            DateTimeOffset? startTime = null,
+            DateTimeOffset? endTime = null,
+            string? spanId = null,
+            string? spanKind = null,
+            string? traceId = null)
+            : base(attributes, startTime, endTime, spanId, parentSpanId, spanKind, traceId)
+        { }
+
+        /// <summary>
+        /// Gets the name of the operation.
+        /// </summary>
+        public override string Name => OpenTelemetryConstants.OperationNames.ApplyGuardrail.ToString();
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ApplyGuardrailDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ApplyGuardrailDataBuilder.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
+{
+    /// <summary>
+    /// Builds an ApplyGuardrailData instance.
+    /// </summary>
+    public class ApplyGuardrailDataBuilder : BaseDataBuilder<ApplyGuardrailData>
+    {
+        /// <summary>
+        /// Builds complete data for an apply_guardrail operation.
+        /// </summary>
+        /// <param name="guardrailDetails">The details of the guardrail evaluation.</param>
+        /// <param name="agentDetails">The details of the agent (includes tenant ID).</param>
+        /// <param name="conversationId">The conversation id.</param>
+        /// <param name="parentSpanId">The parent span ID for distributed tracing.</param>
+        /// <param name="startTime">Optional custom start time for the operation.</param>
+        /// <param name="endTime">Optional custom end time for the operation.</param>
+        /// <param name="spanId">Optional span ID for the operation.</param>
+        /// <param name="channel">Optional channel information for the operation.</param>
+        /// <param name="callerDetails">Optional details about the caller.</param>
+        /// <param name="extraAttributes">Optional dictionary of extra attributes.</param>
+        /// <param name="spanKind">Optional span kind override.</param>
+        /// <param name="traceId">Optional trace ID for distributed tracing.</param>
+        /// <returns>An ApplyGuardrailData object containing all telemetry data.</returns>
+        public static ApplyGuardrailData Build(
+            GuardrailDetails guardrailDetails,
+            AgentDetails agentDetails,
+            string conversationId,
+            string parentSpanId,
+            DateTimeOffset? startTime = null,
+            DateTimeOffset? endTime = null,
+            string? spanId = null,
+            Channel? channel = null,
+            CallerDetails? callerDetails = null,
+            IDictionary<string, object?>? extraAttributes = null,
+            string? spanKind = null,
+            string? traceId = null)
+        {
+            var attributes = BuildAttributes(guardrailDetails, agentDetails, conversationId, channel, callerDetails, extraAttributes);
+
+            return new ApplyGuardrailData(parentSpanId, attributes, startTime, endTime, spanId, spanKind, traceId);
+        }
+
+        private static Dictionary<string, object?> BuildAttributes(
+            GuardrailDetails guardrailDetails,
+            AgentDetails agentDetails,
+            string conversationId,
+            Channel? channel,
+            CallerDetails? callerDetails,
+            IDictionary<string, object?>? extraAttributes = null)
+        {
+            var attributes = new Dictionary<string, object?>();
+
+            // Operation name
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiOperationNameKey, OpenTelemetryConstants.ApplyGuardrailOperationName);
+
+            AddAgentDetails(attributes, agentDetails);
+
+            // Guardrail details
+            AddGuardrailDetails(attributes, guardrailDetails);
+
+            // Conversation
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiConversationIdKey, conversationId);
+
+            // Channel
+            AddChannelAttributes(attributes, channel);
+
+            // Caller details
+            AddCallerDetails(attributes, callerDetails);
+
+            // Extra attributes
+            AddExtraAttributes(attributes, extraAttributes);
+
+            return attributes;
+        }
+
+        private static void AddGuardrailDetails(
+            Dictionary<string, object?> attributes,
+            GuardrailDetails details)
+        {
+            // Required attributes
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityDecisionTypeKey, details.DecisionType.ToString().ToLowerInvariant());
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityTargetTypeKey, details.TargetType);
+
+            // Guardian attributes
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiGuardianIdKey, details.GuardianId);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiGuardianNameKey, details.GuardianName);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiGuardianProviderNameKey, details.GuardianProviderName);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiGuardianVersionKey, details.GuardianVersion);
+
+            // Target attributes
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityTargetIdKey, details.TargetId);
+
+            // Decision attributes
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityDecisionReasonKey, details.DecisionReason);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityDecisionCodeKey, details.DecisionCode);
+
+            // Policy attributes
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityPolicyIdKey, details.PolicyId);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityPolicyNameKey, details.PolicyName);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityPolicyVersionKey, details.PolicyVersion);
+
+            // Content attributes
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityContentInputHashKey, details.ContentInputHash);
+            if (details.ContentModified.HasValue)
+            {
+                attributes[OpenTelemetryConstants.GenAiSecurityContentModifiedKey] = details.ContentModified.Value;
+            }
+
+            // Correlation
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSecurityExternalEventIdKey, details.ExternalEventId);
+        }
+
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ApplyGuardrailDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ApplyGuardrailDataBuilder.cs
@@ -58,6 +58,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
         {
             var attributes = new Dictionary<string, object?>();
 
+            AddSdkAttributes(attributes);
+
             // Operation name
             AddIfNotNull(attributes, OpenTelemetryConstants.GenAiOperationNameKey, OpenTelemetryConstants.ApplyGuardrailOperationName);
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/BaseDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/BaseDataBuilder.cs
@@ -177,6 +177,16 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
         }
 
         /// <summary>
+        /// Adds telemetry SDK attributes (name, version, language) to the attributes dictionary.
+        /// </summary>
+        protected static void AddSdkAttributes(IDictionary<string, object?> attributes)
+        {
+            attributes[OpenTelemetryConstants.TelemetrySdkNameKey] = OpenTelemetryConstants.TelemetrySdkNameValue;
+            attributes[OpenTelemetryConstants.TelemetrySdkVersionKey] = OpenTelemetryConstants.TelemetrySdkVersionValue;
+            attributes[OpenTelemetryConstants.TelemetrySdkLanguageKey] = OpenTelemetryConstants.TelemetrySdkLanguageValue;
+        }
+
+        /// <summary>
         /// Adds a key-value pair to the dictionary if the value is not null.
         /// </summary>
         protected static void AddIfNotNull(IDictionary<string, object?> attributes, string key, object? value)

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ExecuteInferenceDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ExecuteInferenceDataBuilder.cs
@@ -74,6 +74,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
         {
             var attributes = new Dictionary<string, object?>();
 
+            // SDK attributes
+            AddSdkAttributes(attributes);
+
             // Agent details (includes tenant ID)
             AddAgentDetails(attributes, agentDetails);
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ExecuteToolDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ExecuteToolDataBuilder.cs
@@ -65,6 +65,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
         {
             var attributes = new Dictionary<string, object?>();
 
+            // SDK attributes
+            AddSdkAttributes(attributes);
+
             // Operation name
             AddIfNotNull(attributes, GenAiOperationNameKey, ExecuteToolDataBuilder.ExecuteToolOperationName);
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/InvokeAgentDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/InvokeAgentDataBuilder.cs
@@ -94,6 +94,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
         {
             var attributes = new Dictionary<string, object?>();
 
+            // SDK attributes
+            AddSdkAttributes(attributes);
+
             // Operation name
             AddIfNotNull(attributes, GenAiOperationNameKey, InvokeAgentDataBuilder.InvokeAgentOperationName);
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/OutputDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/OutputDataBuilder.cs
@@ -59,6 +59,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
         {
             var attributes = new Dictionary<string, object?>();
 
+            // SDK attributes
+            AddSdkAttributes(attributes);
+
             // Operation name
             AddIfNotNull(attributes, OpenTelemetryConstants.GenAiOperationNameKey, OutputMessagesOperationName);
             

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Etw/A365EtwLogger.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Etw/A365EtwLogger.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Etw
         private static readonly EventId ExecuteToolEventId = new EventId(1003, ExecuteToolEventName);
         private const string OutputMessagesEventName = "OutputMessages";
         private static readonly EventId OutputMessagesEventId = new EventId(1004, OutputMessagesEventName);
+        private const string ApplyGuardrailEventName = "ApplyGuardrail";
+        private static readonly EventId ApplyGuardrailEventId = new EventId(1005, ApplyGuardrailEventName);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="A365EtwLogger{T}"/> class.
@@ -173,6 +175,40 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Etw
             logger.Log(
                 LogLevel.Information,
                 OutputMessagesEventId,
+                data.ToDictionary(),
+                null,
+                LogFormatter
+            );
+        }
+
+        /// <inheritdoc/>
+        public void LogApplyGuardrail(
+            GuardrailDetails guardrailDetails,
+            AgentDetails agentDetails,
+            string conversationId,
+            string parentSpanId,
+            DateTimeOffset? startTime = null,
+            DateTimeOffset? endTime = null,
+            string? spanId = null,
+            Channel? channel = null,
+            CallerDetails? callerDetails = null,
+            string? traceId = null)
+        {
+            var data = ApplyGuardrailDataBuilder.Build(
+                guardrailDetails,
+                agentDetails,
+                conversationId,
+                parentSpanId,
+                startTime,
+                endTime,
+                spanId,
+                channel,
+                callerDetails: callerDetails,
+                traceId: traceId);
+
+            logger.Log(
+                LogLevel.Information,
+                ApplyGuardrailEventId,
                 data.ToDictionary(),
                 null,
                 LogFormatter

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Etw/IA365EtwLogger.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Etw/IA365EtwLogger.cs
@@ -120,5 +120,30 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Etw
             string? spanId = null,
             string? parentSpanId = null,
             string? traceId = null);
+
+        /// <summary>
+        /// Logs an apply_guardrail event.
+        /// </summary>
+        /// <param name="guardrailDetails">The details of the guardrail evaluation.</param>
+        /// <param name="agentDetails">The details of the agent (includes tenant ID).</param>
+        /// <param name="conversationId">The required conversation ID.</param>
+        /// <param name="parentSpanId">The required parent span ID for tracing.</param>
+        /// <param name="startTime">Optional start time of the guardrail evaluation.</param>
+        /// <param name="endTime">Optional end time of the guardrail evaluation.</param>
+        /// <param name="spanId">Optional span ID for tracing.</param>
+        /// <param name="channel">Optional channel information.</param>
+        /// <param name="callerDetails">Optional details of the caller.</param>
+        /// <param name="traceId">Optional trace ID for distributed tracing.</param>
+        public void LogApplyGuardrail(
+            GuardrailDetails guardrailDetails,
+            AgentDetails agentDetails,
+            string conversationId,
+            string parentSpanId,
+            DateTimeOffset? startTime = null,
+            DateTimeOffset? endTime = null,
+            string? spanId = null,
+            Channel? channel = null,
+            CallerDetails? callerDetails = null,
+            string? traceId = null);
     }
 }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailDecisionType.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailDecisionType.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.Serialization;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
+{
+    /// <summary>
+    /// The decision made by a security guardian during guardrail evaluation.
+    /// </summary>
+    [DataContract]
+    public enum GuardrailDecisionType
+    {
+        /// <summary>
+        /// Content or action is allowed to proceed.
+        /// </summary>
+        [EnumMember(Value = "allow")]
+        Allow,
+
+        /// <summary>
+        /// Content or action is logged for review but allowed to proceed.
+        /// </summary>
+        [EnumMember(Value = "audit")]
+        Audit,
+
+        /// <summary>
+        /// Content or action is denied/blocked.
+        /// </summary>
+        [EnumMember(Value = "deny")]
+        Deny,
+
+        /// <summary>
+        /// Content was modified (e.g., redacted, sanitized, rewritten).
+        /// </summary>
+        [EnumMember(Value = "modify")]
+        Modify,
+
+        /// <summary>
+        /// Content or action triggered a warning but is allowed to proceed.
+        /// </summary>
+        [EnumMember(Value = "warn")]
+        Warn
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailDetails.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailDetails.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
+{
+    /// <summary>
+    /// Details of a guardrail evaluation for security operations tracing.
+    /// </summary>
+    public sealed class GuardrailDetails : IEquatable<GuardrailDetails>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GuardrailDetails"/> class.
+        /// </summary>
+        /// <param name="targetType">The type of content or action the guardrail is applied to (required). See <see cref="GuardrailTargetType"/> for well-known values.</param>
+        /// <param name="decisionType">The decision made by the guardian (required).</param>
+        /// <param name="guardianName">Human-readable name of the guardian.</param>
+        /// <param name="guardianId">Unique identifier of the guardian.</param>
+        /// <param name="guardianProviderName">Provider of the guardian service (e.g., azure.ai.content_safety).</param>
+        /// <param name="guardianVersion">Version of the guardian.</param>
+        /// <param name="targetId">Identifier of the target being guarded.</param>
+        /// <param name="decisionReason">Human-readable explanation for the decision.</param>
+        /// <param name="decisionCode">Machine-readable decision code.</param>
+        /// <param name="policyId">Identifier of the policy that triggered the decision.</param>
+        /// <param name="policyName">Human-readable name of the policy.</param>
+        /// <param name="policyVersion">Version of the policy.</param>
+        /// <param name="contentInputHash">Hash of the input content for forensic correlation.</param>
+        /// <param name="contentModified">Whether content was modified by the guardrail.</param>
+        /// <param name="externalEventId">External correlation identifier for SIEM systems.</param>
+        public GuardrailDetails(
+            string targetType,
+            GuardrailDecisionType decisionType,
+            string? guardianName = null,
+            string? guardianId = null,
+            string? guardianProviderName = null,
+            string? guardianVersion = null,
+            string? targetId = null,
+            string? decisionReason = null,
+            string? decisionCode = null,
+            string? policyId = null,
+            string? policyName = null,
+            string? policyVersion = null,
+            string? contentInputHash = null,
+            bool? contentModified = null,
+            string? externalEventId = null)
+        {
+            TargetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
+            DecisionType = decisionType;
+            GuardianName = guardianName;
+            GuardianId = guardianId;
+            GuardianProviderName = guardianProviderName;
+            GuardianVersion = guardianVersion;
+            TargetId = targetId;
+            DecisionReason = decisionReason;
+            DecisionCode = decisionCode;
+            PolicyId = policyId;
+            PolicyName = policyName;
+            PolicyVersion = policyVersion;
+            ContentInputHash = contentInputHash;
+            ContentModified = contentModified;
+            ExternalEventId = externalEventId;
+        }
+
+        /// <summary>
+        /// Gets the type of content or action the guardrail is applied to.
+        /// </summary>
+        /// <seealso cref="GuardrailTargetType"/>
+        public string TargetType { get; }
+
+        /// <summary>
+        /// Gets the decision made by the security guardian.
+        /// </summary>
+        public GuardrailDecisionType DecisionType { get; }
+
+        /// <summary>
+        /// Gets the human-readable name of the guardian.
+        /// </summary>
+        public string? GuardianName { get; }
+
+        /// <summary>
+        /// Gets the unique identifier of the guardian.
+        /// </summary>
+        public string? GuardianId { get; }
+
+        /// <summary>
+        /// Gets the provider of the guardian service.
+        /// </summary>
+        public string? GuardianProviderName { get; }
+
+        /// <summary>
+        /// Gets the version of the guardian.
+        /// </summary>
+        public string? GuardianVersion { get; }
+
+        /// <summary>
+        /// Gets the identifier of the target being guarded.
+        /// </summary>
+        public string? TargetId { get; }
+
+        /// <summary>
+        /// Gets the human-readable explanation for the decision.
+        /// </summary>
+        public string? DecisionReason { get; }
+
+        /// <summary>
+        /// Gets the machine-readable decision code.
+        /// </summary>
+        public string? DecisionCode { get; }
+
+        /// <summary>
+        /// Gets the identifier of the policy that triggered the decision.
+        /// </summary>
+        public string? PolicyId { get; }
+
+        /// <summary>
+        /// Gets the human-readable name of the policy.
+        /// </summary>
+        public string? PolicyName { get; }
+
+        /// <summary>
+        /// Gets the version of the policy.
+        /// </summary>
+        public string? PolicyVersion { get; }
+
+        /// <summary>
+        /// Gets the hash of the input content for forensic correlation.
+        /// </summary>
+        public string? ContentInputHash { get; }
+
+        /// <summary>
+        /// Gets whether content was modified by the guardrail.
+        /// </summary>
+        public bool? ContentModified { get; }
+
+        /// <summary>
+        /// Gets the external correlation identifier for SIEM systems.
+        /// </summary>
+        public string? ExternalEventId { get; }
+
+        /// <inheritdoc/>
+        public bool Equals(GuardrailDetails? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return string.Equals(TargetType, other.TargetType, StringComparison.Ordinal) &&
+                   DecisionType == other.DecisionType &&
+                   string.Equals(GuardianName, other.GuardianName, StringComparison.Ordinal) &&
+                   string.Equals(GuardianId, other.GuardianId, StringComparison.Ordinal) &&
+                   string.Equals(GuardianProviderName, other.GuardianProviderName, StringComparison.Ordinal) &&
+                   string.Equals(GuardianVersion, other.GuardianVersion, StringComparison.Ordinal) &&
+                   string.Equals(TargetId, other.TargetId, StringComparison.Ordinal) &&
+                   string.Equals(DecisionReason, other.DecisionReason, StringComparison.Ordinal) &&
+                   string.Equals(DecisionCode, other.DecisionCode, StringComparison.Ordinal) &&
+                   string.Equals(PolicyId, other.PolicyId, StringComparison.Ordinal) &&
+                   string.Equals(PolicyName, other.PolicyName, StringComparison.Ordinal) &&
+                   string.Equals(PolicyVersion, other.PolicyVersion, StringComparison.Ordinal) &&
+                   string.Equals(ContentInputHash, other.ContentInputHash, StringComparison.Ordinal) &&
+                   ContentModified == other.ContentModified &&
+                   string.Equals(ExternalEventId, other.ExternalEventId, StringComparison.Ordinal);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as GuardrailDetails);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 31) + (TargetType != null ? StringComparer.Ordinal.GetHashCode(TargetType) : 0);
+                hash = (hash * 31) + DecisionType.GetHashCode();
+                hash = (hash * 31) + (GuardianName != null ? StringComparer.Ordinal.GetHashCode(GuardianName) : 0);
+                hash = (hash * 31) + (GuardianId != null ? StringComparer.Ordinal.GetHashCode(GuardianId) : 0);
+                hash = (hash * 31) + (GuardianProviderName != null ? StringComparer.Ordinal.GetHashCode(GuardianProviderName) : 0);
+                hash = (hash * 31) + (GuardianVersion != null ? StringComparer.Ordinal.GetHashCode(GuardianVersion) : 0);
+                hash = (hash * 31) + (TargetId != null ? StringComparer.Ordinal.GetHashCode(TargetId) : 0);
+                hash = (hash * 31) + (DecisionReason != null ? StringComparer.Ordinal.GetHashCode(DecisionReason) : 0);
+                hash = (hash * 31) + (DecisionCode != null ? StringComparer.Ordinal.GetHashCode(DecisionCode) : 0);
+                hash = (hash * 31) + (PolicyId != null ? StringComparer.Ordinal.GetHashCode(PolicyId) : 0);
+                hash = (hash * 31) + (PolicyName != null ? StringComparer.Ordinal.GetHashCode(PolicyName) : 0);
+                hash = (hash * 31) + (PolicyVersion != null ? StringComparer.Ordinal.GetHashCode(PolicyVersion) : 0);
+                hash = (hash * 31) + (ContentInputHash != null ? StringComparer.Ordinal.GetHashCode(ContentInputHash) : 0);
+                hash = (hash * 31) + (ContentModified?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (ExternalEventId != null ? StringComparer.Ordinal.GetHashCode(ExternalEventId) : 0);
+                return hash;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailFinding.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailFinding.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
+{
+    /// <summary>
+    /// Represents a single security finding detected during guardian evaluation.
+    /// Multiple findings may be emitted for a single guardrail span.
+    /// </summary>
+    public sealed class GuardrailFinding : IEquatable<GuardrailFinding>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GuardrailFinding"/> class.
+        /// </summary>
+        /// <param name="riskCategory">The category of security risk detected (required).</param>
+        /// <param name="riskSeverity">The severity level of the detected risk (required).</param>
+        /// <param name="policyDecisionType">The decision type for this specific policy finding.</param>
+        /// <param name="policyId">Identifier of the policy that triggered the finding.</param>
+        /// <param name="policyName">Human-readable name of the triggered policy.</param>
+        /// <param name="policyVersion">Version of the policy.</param>
+        /// <param name="riskScore">Numeric risk/confidence score (0.0 to 1.0).</param>
+        /// <param name="riskMetadata">Non-content metadata about the detected risk (MUST NOT contain PII).</param>
+        public GuardrailFinding(
+            string riskCategory,
+            string riskSeverity,
+            string? policyDecisionType = null,
+            string? policyId = null,
+            string? policyName = null,
+            string? policyVersion = null,
+            double? riskScore = null,
+            string[]? riskMetadata = null)
+        {
+            RiskCategory = riskCategory ?? throw new ArgumentNullException(nameof(riskCategory));
+            RiskSeverity = riskSeverity ?? throw new ArgumentNullException(nameof(riskSeverity));
+            PolicyDecisionType = policyDecisionType;
+            PolicyId = policyId;
+            PolicyName = policyName;
+            PolicyVersion = policyVersion;
+            RiskScore = riskScore;
+            RiskMetadata = riskMetadata;
+        }
+
+        /// <summary>
+        /// Gets the category of security risk detected.
+        /// </summary>
+        /// <remarks>
+        /// Free-form field aligned with OWASP LLM Top 10 2025.
+        /// Common values: prompt_injection, sensitive_info_disclosure, jailbreak, toxicity, pii.
+        /// </remarks>
+        public string RiskCategory { get; }
+
+        /// <summary>
+        /// Gets the severity level of the detected risk.
+        /// </summary>
+        /// <seealso cref="GuardrailRiskSeverity"/>
+        public string RiskSeverity { get; }
+
+        /// <summary>
+        /// Gets the decision type for this specific policy finding.
+        /// </summary>
+        public string? PolicyDecisionType { get; }
+
+        /// <summary>
+        /// Gets the identifier of the policy that triggered the finding.
+        /// </summary>
+        public string? PolicyId { get; }
+
+        /// <summary>
+        /// Gets the human-readable name of the triggered policy.
+        /// </summary>
+        public string? PolicyName { get; }
+
+        /// <summary>
+        /// Gets the version of the policy.
+        /// </summary>
+        public string? PolicyVersion { get; }
+
+        /// <summary>
+        /// Gets the numeric risk/confidence score (0.0 to 1.0).
+        /// </summary>
+        public double? RiskScore { get; }
+
+        /// <summary>
+        /// Gets non-content metadata about the detected risk.
+        /// </summary>
+        /// <remarks>
+        /// This MUST NOT contain sensitive user content, PII, or other high-risk data.
+        /// Example values: "field:bcc", "pattern:ssn", "count:3", "position:input[0].content".
+        /// </remarks>
+        public string[]? RiskMetadata { get; }
+
+        /// <inheritdoc/>
+        public bool Equals(GuardrailFinding? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return string.Equals(RiskCategory, other.RiskCategory, StringComparison.Ordinal) &&
+                   string.Equals(RiskSeverity, other.RiskSeverity, StringComparison.Ordinal) &&
+                   string.Equals(PolicyDecisionType, other.PolicyDecisionType, StringComparison.Ordinal) &&
+                   string.Equals(PolicyId, other.PolicyId, StringComparison.Ordinal) &&
+                   string.Equals(PolicyName, other.PolicyName, StringComparison.Ordinal) &&
+                   string.Equals(PolicyVersion, other.PolicyVersion, StringComparison.Ordinal) &&
+                   RiskScore == other.RiskScore;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as GuardrailFinding);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 31) + (RiskCategory != null ? StringComparer.Ordinal.GetHashCode(RiskCategory) : 0);
+                hash = (hash * 31) + (RiskSeverity != null ? StringComparer.Ordinal.GetHashCode(RiskSeverity) : 0);
+                hash = (hash * 31) + (PolicyDecisionType != null ? StringComparer.Ordinal.GetHashCode(PolicyDecisionType) : 0);
+                hash = (hash * 31) + (PolicyId != null ? StringComparer.Ordinal.GetHashCode(PolicyId) : 0);
+                hash = (hash * 31) + (PolicyName != null ? StringComparer.Ordinal.GetHashCode(PolicyName) : 0);
+                hash = (hash * 31) + (PolicyVersion != null ? StringComparer.Ordinal.GetHashCode(PolicyVersion) : 0);
+                hash = (hash * 31) + (RiskScore?.GetHashCode() ?? 0);
+                return hash;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailRiskSeverity.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailRiskSeverity.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
+{
+    /// <summary>
+    /// Well-known severity levels for security risks detected by guardrails.
+    /// </summary>
+    public static class GuardrailRiskSeverity
+    {
+        /// <summary>
+        /// No risk detected.
+        /// </summary>
+        public const string None = "none";
+
+        /// <summary>
+        /// Low severity risk.
+        /// </summary>
+        public const string Low = "low";
+
+        /// <summary>
+        /// Medium severity risk.
+        /// </summary>
+        public const string Medium = "medium";
+
+        /// <summary>
+        /// High severity risk.
+        /// </summary>
+        public const string High = "high";
+
+        /// <summary>
+        /// Critical severity risk requiring immediate action.
+        /// </summary>
+        public const string Critical = "critical";
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailTargetType.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GuardrailTargetType.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
+{
+    /// <summary>
+    /// Well-known values for the type of content or action a guardrail is applied to.
+    /// </summary>
+    /// <remarks>
+    /// This is a free-form field per the OpenTelemetry semantic conventions.
+    /// These static members provide discoverability for common values, but custom strings
+    /// are accepted via implicit conversion (e.g. <c>GuardrailTargetType myType = "custom_target";</c>).
+    /// </remarks>
+    public readonly struct GuardrailTargetType : IEquatable<GuardrailTargetType>
+    {
+        /// <summary>
+        /// Input to a language model.
+        /// </summary>
+        public static readonly GuardrailTargetType LlmInput = new GuardrailTargetType("llm_input");
+
+        /// <summary>
+        /// Output from a language model.
+        /// </summary>
+        public static readonly GuardrailTargetType LlmOutput = new GuardrailTargetType("llm_output");
+
+        /// <summary>
+        /// A tool call action.
+        /// </summary>
+        public static readonly GuardrailTargetType ToolCall = new GuardrailTargetType("tool_call");
+
+        /// <summary>
+        /// A tool definition.
+        /// </summary>
+        public static readonly GuardrailTargetType ToolDefinition = new GuardrailTargetType("tool_definition");
+
+        /// <summary>
+        /// A memory store operation.
+        /// </summary>
+        public static readonly GuardrailTargetType MemoryStore = new GuardrailTargetType("memory_store");
+
+        /// <summary>
+        /// A memory retrieval operation.
+        /// </summary>
+        public static readonly GuardrailTargetType MemoryRetrieve = new GuardrailTargetType("memory_retrieve");
+
+        /// <summary>
+        /// A knowledge query.
+        /// </summary>
+        public static readonly GuardrailTargetType KnowledgeQuery = new GuardrailTargetType("knowledge_query");
+
+        /// <summary>
+        /// A knowledge retrieval result.
+        /// </summary>
+        public static readonly GuardrailTargetType KnowledgeResult = new GuardrailTargetType("knowledge_result");
+
+        /// <summary>
+        /// A message.
+        /// </summary>
+        public static readonly GuardrailTargetType Message = new GuardrailTargetType("message");
+
+        /// <summary>
+        /// Gets the string value of this target type.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GuardrailTargetType"/> struct.
+        /// </summary>
+        /// <param name="value">The target type string value.</param>
+        public GuardrailTargetType(string value)
+        {
+            Value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Implicitly converts a string to a <see cref="GuardrailTargetType"/>.
+        /// </summary>
+        public static implicit operator GuardrailTargetType(string value) => new GuardrailTargetType(value);
+
+        /// <summary>
+        /// Implicitly converts a <see cref="GuardrailTargetType"/> to its string value.
+        /// </summary>
+        public static implicit operator string(GuardrailTargetType type) => type.Value;
+
+        /// <inheritdoc/>
+        public bool Equals(GuardrailTargetType other) => string.Equals(Value, other.Value, StringComparison.Ordinal);
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) => obj is GuardrailTargetType other && Equals(other);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => Value != null ? StringComparer.Ordinal.GetHashCode(Value) : 0;
+
+        /// <inheritdoc/>
+        public override string ToString() => Value;
+
+        /// <summary>
+        /// Equality operator.
+        /// </summary>
+        public static bool operator ==(GuardrailTargetType left, GuardrailTargetType right) => left.Equals(right);
+
+        /// <summary>
+        /// Inequality operator.
+        /// </summary>
+        public static bool operator !=(GuardrailTargetType left, GuardrailTargetType right) => !left.Equals(right);
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             InvokeAgentScope.OperationName,
             ExecuteToolScope.OperationName,
             OutputScope.OperationName,
+            OpenTelemetryConstants.ApplyGuardrailOperationName,
             "chat",
             nameof(InferenceOperationType.Chat),
         };

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/ApplyGuardrailScope.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/ApplyGuardrailScope.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
+{
+    /// <summary>
+    /// Provides OpenTelemetry tracing scope for security guardrail evaluation operations.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Describes a security guardian evaluation. Multiple guardian spans MAY exist under a single
+    /// operation span if multiple guardians are chained.
+    /// </para>
+    /// <para>
+    /// Guardian spans SHOULD be children of the operation span they are protecting
+    /// (e.g., inference or execute_tool spans).
+    /// </para>
+    /// </remarks>
+    public sealed class ApplyGuardrailScope : OpenTelemetryScope
+    {
+
+        /// <summary>
+        /// Creates and starts a new scope for guardrail evaluation tracing.
+        /// </summary>
+        /// <param name="details">Details of the guardrail evaluation (target, decision, guardian info, policy).</param>
+        /// <param name="agentDetails">Information about the agent being guarded.</param>
+        /// <param name="request">Optional request details for conversation context.</param>
+        /// <param name="userDetails">Optional human user details.</param>
+        /// <param name="spanDetails">Optional span configuration (parent context, timing, kind, span links).</param>
+        /// <returns>A new ApplyGuardrailScope instance.</returns>
+        /// <remarks>
+        /// <para>
+        /// <b>Certification Requirements:</b> The following parameters must be set for the agent to pass certification requirements:
+        /// <list type="bullet">
+        ///   <item><paramref name="details"/></item>
+        ///   <item><paramref name="agentDetails"/></item>
+        /// </list>
+        /// </para>
+        /// </remarks>
+        public static ApplyGuardrailScope Start(
+            GuardrailDetails details,
+            AgentDetails agentDetails,
+            Request? request = null,
+            UserDetails? userDetails = null,
+            SpanDetails? spanDetails = null) => new ApplyGuardrailScope(details, agentDetails, request, userDetails, spanDetails);
+
+        private ApplyGuardrailScope(
+            GuardrailDetails details,
+            AgentDetails agentDetails,
+            Request? request,
+            UserDetails? userDetails,
+            SpanDetails? spanDetails)
+            : base(
+                operationName: OpenTelemetryConstants.ApplyGuardrailOperationName,
+                activityName: BuildActivityName(details),
+                agentDetails: agentDetails,
+                spanDetails: new SpanDetails(spanDetails?.SpanKind ?? ActivityKind.Internal, spanDetails?.ParentContext, spanDetails?.StartTime, spanDetails?.EndTime, spanDetails?.SpanLinks),
+                userDetails: userDetails)
+        {
+            // Required attributes
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityDecisionTypeKey, details.DecisionType.ToString().ToLowerInvariant());
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityTargetTypeKey, details.TargetType);
+
+            // Guardian attributes
+            SetTagMaybe(OpenTelemetryConstants.GenAiGuardianIdKey, details.GuardianId);
+            SetTagMaybe(OpenTelemetryConstants.GenAiGuardianNameKey, details.GuardianName);
+            SetTagMaybe(OpenTelemetryConstants.GenAiGuardianProviderNameKey, details.GuardianProviderName);
+            SetTagMaybe(OpenTelemetryConstants.GenAiGuardianVersionKey, details.GuardianVersion);
+
+            // Target attributes
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityTargetIdKey, details.TargetId);
+
+            // Decision attributes
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityDecisionReasonKey, details.DecisionReason);
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityDecisionCodeKey, details.DecisionCode);
+
+            // Policy attributes
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityPolicyIdKey, details.PolicyId);
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityPolicyNameKey, details.PolicyName);
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityPolicyVersionKey, details.PolicyVersion);
+
+            // Content attributes
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityContentInputHashKey, details.ContentInputHash);
+            if (details.ContentModified.HasValue)
+            {
+                SetTagMaybe(OpenTelemetryConstants.GenAiSecurityContentModifiedKey, details.ContentModified.Value);
+            }
+
+            // Correlation attributes
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityExternalEventIdKey, details.ExternalEventId);
+
+            // Request context
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityContentInputValueKey, request?.Content);
+            SetTagMaybe(OpenTelemetryConstants.GenAiConversationIdKey, request?.ConversationId);
+            if (request?.Channel != null)
+            {
+                SetTagMaybe(OpenTelemetryConstants.ChannelNameKey, request.Channel.Name);
+                SetTagMaybe(OpenTelemetryConstants.ChannelLinkKey, request.Channel.Link);
+            }
+        }
+
+        /// <summary>
+        /// Records an updated decision on the guardrail span.
+        /// Use this when the guardrail decision is determined after span creation.
+        /// </summary>
+        /// <param name="decisionType">The decision type made by the guardian.</param>
+        /// <param name="reason">Optional human-readable explanation for the decision.</param>
+        public void RecordDecision(GuardrailDecisionType decisionType, string? reason = null)
+        {
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityDecisionTypeKey, decisionType.ToString().ToLowerInvariant());
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityDecisionReasonKey, reason);
+        }
+
+        /// <summary>
+        /// Records the output content value for the guardrail evaluation (opt-in).
+        /// </summary>
+        /// <param name="outputValue">The output content after guardrail processing.</param>
+        public void RecordContentOutput(string outputValue)
+        {
+            SetTagMaybe(OpenTelemetryConstants.GenAiSecurityContentOutputValueKey, outputValue);
+        }
+
+        /// <summary>
+        /// Records a security finding event on the current span.
+        /// Multiple findings may be recorded per guardrail evaluation.
+        /// </summary>
+        /// <param name="finding">The security finding to record.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="finding"/> is null.</exception>
+        public void RecordFinding(GuardrailFinding finding)
+        {
+            if (finding == null)
+            {
+                throw new ArgumentNullException(nameof(finding));
+            }
+
+            var tags = new ActivityTagsCollection
+            {
+                { OpenTelemetryConstants.GenAiSecurityRiskCategoryKey, finding.RiskCategory },
+                { OpenTelemetryConstants.GenAiSecurityRiskSeverityKey, finding.RiskSeverity }
+            };
+
+            if (finding.PolicyDecisionType != null)
+            {
+                tags.Add(OpenTelemetryConstants.GenAiSecurityPolicyDecisionTypeKey, finding.PolicyDecisionType);
+            }
+
+            if (finding.PolicyId != null)
+            {
+                tags.Add(OpenTelemetryConstants.GenAiSecurityPolicyIdKey, finding.PolicyId);
+            }
+
+            if (finding.PolicyName != null)
+            {
+                tags.Add(OpenTelemetryConstants.GenAiSecurityPolicyNameKey, finding.PolicyName);
+            }
+
+            if (finding.PolicyVersion != null)
+            {
+                tags.Add(OpenTelemetryConstants.GenAiSecurityPolicyVersionKey, finding.PolicyVersion);
+            }
+
+            if (finding.RiskScore.HasValue)
+            {
+                tags.Add(OpenTelemetryConstants.GenAiSecurityRiskScoreKey, finding.RiskScore.Value);
+            }
+
+            if (finding.RiskMetadata != null)
+            {
+                tags.Add(OpenTelemetryConstants.GenAiSecurityRiskMetadataKey, finding.RiskMetadata);
+            }
+
+            var activityEvent = new ActivityEvent(OpenTelemetryConstants.GenAiSecurityFindingEventName, tags: tags);
+            AddEvent(activityEvent);
+        }
+
+        private static string BuildActivityName(GuardrailDetails details)
+        {
+            if (!string.IsNullOrWhiteSpace(details.GuardianName))
+            {
+                return $"{OpenTelemetryConstants.ApplyGuardrailOperationName} {details.GuardianName} {details.TargetType}";
+            }
+
+            return $"{OpenTelemetryConstants.ApplyGuardrailOperationName} {details.TargetType}";
+        }
+
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
@@ -49,8 +49,16 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
             ExecuteTool,
 
             [EnumMember(Value = "OutputMessages")]
-            OutputMessages
+            OutputMessages,
+
+            [EnumMember(Value = "ApplyGuardrail")]
+            ApplyGuardrail
         }
+
+        /// <summary>
+        /// The operation name value for apply_guardrail spans.
+        /// </summary>
+        public const string ApplyGuardrailOperationName = "apply_guardrail";
 
         // Channel dimensions (renamed from gen_ai.channel.* to microsoft.channel.*)
         public const string ChannelNameKey = "microsoft.channel.name";
@@ -160,6 +168,123 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// </summary>
         public const string GenAiAgentThoughtProcessKey = "microsoft.a365.agent.thought.process";
 
+        #endregion
+
+        #region guardrail keys
+        /// <summary>
+        /// The guardian identifier key.
+        /// </summary>
+        public const string GenAiGuardianIdKey = "microsoft.guardian.id";
+
+        /// <summary>
+        /// The guardian name key.
+        /// </summary>
+        public const string GenAiGuardianNameKey = "microsoft.guardian.name";
+
+        /// <summary>
+        /// The guardian provider name key.
+        /// </summary>
+        public const string GenAiGuardianProviderNameKey = "microsoft.guardian.provider.name";
+
+        /// <summary>
+        /// The guardian version key.
+        /// </summary>
+        public const string GenAiGuardianVersionKey = "microsoft.guardian.version";
+
+        /// <summary>
+        /// The security decision type key.
+        /// </summary>
+        public const string GenAiSecurityDecisionTypeKey = "microsoft.security.decision.type";
+
+        /// <summary>
+        /// The security decision reason key.
+        /// </summary>
+        public const string GenAiSecurityDecisionReasonKey = "microsoft.security.decision.reason";
+
+        /// <summary>
+        /// The security decision code key.
+        /// </summary>
+        public const string GenAiSecurityDecisionCodeKey = "microsoft.security.decision.code";
+
+        /// <summary>
+        /// The security target type key.
+        /// </summary>
+        public const string GenAiSecurityTargetTypeKey = "microsoft.security.target.type";
+
+        /// <summary>
+        /// The security target identifier key.
+        /// </summary>
+        public const string GenAiSecurityTargetIdKey = "microsoft.security.target.id";
+
+        /// <summary>
+        /// The security policy identifier key.
+        /// </summary>
+        public const string GenAiSecurityPolicyIdKey = "microsoft.security.policy.id";
+
+        /// <summary>
+        /// The security policy name key.
+        /// </summary>
+        public const string GenAiSecurityPolicyNameKey = "microsoft.security.policy.name";
+
+        /// <summary>
+        /// The security policy version key.
+        /// </summary>
+        public const string GenAiSecurityPolicyVersionKey = "microsoft.security.policy.version";
+
+        /// <summary>
+        /// The security content input hash key.
+        /// </summary>
+        public const string GenAiSecurityContentInputHashKey = "microsoft.security.content.input.hash";
+
+        /// <summary>
+        /// The security content modified key.
+        /// </summary>
+        public const string GenAiSecurityContentModifiedKey = "microsoft.security.content.modified";
+
+        /// <summary>
+        /// The security external event identifier key for SIEM correlation.
+        /// </summary>
+        public const string GenAiSecurityExternalEventIdKey = "microsoft.security.external_event_id";
+
+        /// <summary>
+        /// The security content input value key (opt-in).
+        /// </summary>
+        public const string GenAiSecurityContentInputValueKey = "microsoft.security.content.input.value";
+
+        /// <summary>
+        /// The security content output value key (opt-in).
+        /// </summary>
+        public const string GenAiSecurityContentOutputValueKey = "microsoft.security.content.output.value";
+
+        /// <summary>
+        /// The security finding event name.
+        /// </summary>
+        public const string GenAiSecurityFindingEventName = "microsoft.security.finding";
+
+        /// <summary>
+        /// The security risk category key.
+        /// </summary>
+        public const string GenAiSecurityRiskCategoryKey = "microsoft.security.risk.category";
+
+        /// <summary>
+        /// The security risk severity key.
+        /// </summary>
+        public const string GenAiSecurityRiskSeverityKey = "microsoft.security.risk.severity";
+
+        /// <summary>
+        /// The security risk score key.
+        /// </summary>
+        public const string GenAiSecurityRiskScoreKey = "microsoft.security.risk.score";
+
+        /// <summary>
+        /// The security risk metadata key.
+        /// </summary>
+        public const string GenAiSecurityRiskMetadataKey = "microsoft.security.risk.metadata";
+
+        /// <summary>
+        /// The security policy decision type key (per-finding decision).
+        /// </summary>
+        public const string GenAiSecurityPolicyDecisionTypeKey = "microsoft.security.policy.decision.type";
         #endregion
     }
     #pragma warning restore CS1591

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
@@ -238,6 +238,15 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         }
 
         /// <summary>
+        /// Adds an event to the current activity.
+        /// </summary>
+        /// <param name="activityEvent">The event to add.</param>
+        protected void AddEvent(ActivityEvent activityEvent)
+        {
+            activity?.AddEvent(activityEvent);
+        }
+
+        /// <summary>
         /// Gets the <see cref="ActivityContext"/> for this scope's span.
         /// </summary>
         /// <remarks>

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/Agent365ExporterTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/Agent365ExporterTests.cs
@@ -217,6 +217,23 @@ public sealed class Agent365ExporterTests
     }
 
     [TestMethod]
+    public void PartitionByIdentity_IncludesApplyGuardrailSpans()
+    {
+        // Arrange
+        using var guardrailSpan = CreateActivity("tenant-1", "agent-1", operationName: "apply_guardrail");
+        using var httpSpan = CreateActivity("tenant-1", "agent-1", operationName: "http_request");
+
+        var batch = CreateBatch(guardrailSpan, httpSpan);
+
+        // Act
+        var groups = Agent365ExporterTests._agent365ExporterCore.PartitionByIdentity(in batch);
+
+        // Assert
+        groups.Should().HaveCount(1);
+        groups.Should().Contain(g => g.TenantId == "tenant-1" && g.AgentId == "agent-1" && g.Activities.Count == 1);
+    }
+
+    [TestMethod]
     public void Agent365ExporterOptions_DefaultBatchingParameters_AreSet()
     {
         // Arrange & Act

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/ApplyGuardrailScopeTest.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/ApplyGuardrailScopeTest.cs
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Observability.Tests.Tracing.Scopes;
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts;
+
+[TestClass]
+public sealed class ApplyGuardrailScopeTest : ActivityTest
+{
+    [TestMethod]
+    public void Start_SetsRequiredAttributes()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmInput,
+            decisionType: GuardrailDecisionType.Deny);
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+        });
+
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiOperationNameKey, OpenTelemetryConstants.ApplyGuardrailOperationName);
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityDecisionTypeKey, "deny");
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityTargetTypeKey, GuardrailTargetType.LlmInput);
+    }
+
+    [TestMethod]
+    public void Start_SetsGuardianAttributes_WhenProvided()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmOutput,
+            decisionType: GuardrailDecisionType.Allow,
+            guardianName: "PII Filter",
+            guardianId: "guard_abc123",
+            guardianProviderName: "azure.ai.content_safety",
+            guardianVersion: "2.1.0");
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+        });
+
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiGuardianNameKey, "PII Filter");
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiGuardianIdKey, "guard_abc123");
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiGuardianProviderNameKey, "azure.ai.content_safety");
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiGuardianVersionKey, "2.1.0");
+    }
+
+    [TestMethod]
+    public void Start_SetsPolicyAttributes_WhenProvided()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.ToolCall,
+            decisionType: GuardrailDecisionType.Modify,
+            policyId: "policy_pii_v2",
+            policyName: "PII Protection Policy",
+            policyVersion: "1.0");
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+        });
+
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityPolicyIdKey, "policy_pii_v2");
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityPolicyNameKey, "PII Protection Policy");
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityPolicyVersionKey, "1.0");
+    }
+
+    [TestMethod]
+    public void Start_SetsContentAttributes_WhenProvided()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmInput,
+            decisionType: GuardrailDecisionType.Allow,
+            contentInputHash: "sha256:abc123",
+            contentModified: true,
+            externalEventId: "ext-001");
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+        });
+
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityContentInputHashKey, "sha256:abc123");
+        activity.TagObjects.First(t => t.Key == OpenTelemetryConstants.GenAiSecurityContentModifiedKey).Value.Should().Be(true);
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityExternalEventIdKey, "ext-001");
+    }
+
+    [TestMethod]
+    public void Start_BuildsActivityName_WithGuardianName()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmInput,
+            decisionType: GuardrailDecisionType.Deny,
+            guardianName: "Azure Content Safety");
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+        });
+
+        activity.DisplayName.Should().Be("apply_guardrail Azure Content Safety llm_input");
+    }
+
+    [TestMethod]
+    public void Start_BuildsActivityName_WithoutGuardianName()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.ToolCall,
+            decisionType: GuardrailDecisionType.Allow);
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+        });
+
+        activity.DisplayName.Should().Be("apply_guardrail tool_call");
+    }
+
+    [TestMethod]
+    public void RecordDecision_UpdatesDecisionType()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmInput,
+            decisionType: GuardrailDecisionType.Allow);
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+            scope.RecordDecision(GuardrailDecisionType.Deny, "Content blocked");
+        });
+
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityDecisionTypeKey, "deny");
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityDecisionReasonKey, "Content blocked");
+    }
+
+    [TestMethod]
+    public void RecordContentOutput_SetsOutputValue()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmOutput,
+            decisionType: GuardrailDecisionType.Modify);
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+            scope.RecordContentOutput("sanitized content");
+        });
+
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityContentOutputValueKey, "sanitized content");
+    }
+
+    [TestMethod]
+    public void RecordFinding_AddsEventWithAttributes()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmInput,
+            decisionType: GuardrailDecisionType.Deny);
+
+        var finding = new GuardrailFinding(
+            riskCategory: "hate_speech",
+            riskSeverity: GuardrailRiskSeverity.High,
+            policyDecisionType: "deny",
+            policyId: "policy-abc",
+            riskScore: 0.95,
+            riskMetadata: new[] { "{\"category\":\"hate\",\"confidence\":0.95}" });
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+            scope.RecordFinding(finding);
+        });
+
+        activity.Events.Should().HaveCount(1);
+        var findingEvent = activity.Events.First();
+        findingEvent.Name.Should().Be(OpenTelemetryConstants.GenAiSecurityFindingEventName);
+
+        var tags = findingEvent.Tags.ToDictionary(t => t.Key, t => t.Value);
+        tags[OpenTelemetryConstants.GenAiSecurityRiskCategoryKey].Should().Be("hate_speech");
+        tags[OpenTelemetryConstants.GenAiSecurityRiskSeverityKey].Should().Be(GuardrailRiskSeverity.High);
+        tags[OpenTelemetryConstants.GenAiSecurityPolicyDecisionTypeKey].Should().Be("deny");
+        tags[OpenTelemetryConstants.GenAiSecurityPolicyIdKey].Should().Be("policy-abc");
+        tags[OpenTelemetryConstants.GenAiSecurityRiskScoreKey].Should().Be(0.95);
+    }
+
+    [TestMethod]
+    public void RecordFinding_MultipleFindingsRecorded()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmInput,
+            decisionType: GuardrailDecisionType.Deny);
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+            scope.RecordFinding(new GuardrailFinding("hate_speech", GuardrailRiskSeverity.High));
+            scope.RecordFinding(new GuardrailFinding("pii", GuardrailRiskSeverity.Medium));
+        });
+
+        activity.Events.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public void RecordFinding_ThrowsOnNull()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmInput,
+            decisionType: GuardrailDecisionType.Allow);
+
+        Action act = () =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails());
+            scope.RecordFinding(null!);
+        };
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void Start_SetsRequestContext_WhenProvided()
+    {
+        var details = new GuardrailDetails(
+            targetType: GuardrailTargetType.LlmInput,
+            decisionType: GuardrailDecisionType.Allow);
+
+        var request = new Request(
+            content: "test input",
+            conversationId: "conv-123",
+            channel: new Channel(name: "msteams", link: "https://test.link"));
+
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = ApplyGuardrailScope.Start(details, Util.GetAgentDetails(), request: request);
+        });
+
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiSecurityContentInputValueKey, "test input");
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiConversationIdKey, "conv-123");
+        activity.ShouldHaveTag(OpenTelemetryConstants.ChannelNameKey, "msteams");
+        activity.ShouldHaveTag(OpenTelemetryConstants.ChannelLinkKey, "https://test.link");
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a new OpenTelemetry tracing scope (\ApplyGuardrailScope\) that captures security guardrail evaluations as spans. This enables observability into content safety, policy enforcement, and risk assessment decisions made during agent operations.

Port of [microsoft/Agent365-dotnet#252](https://github.com/microsoft/Agent365-dotnet/pull/252).

## Changes

### New Contracts
- **\GuardrailDetails\** — Immutable contract capturing guardian evaluation metadata: target type, decision, provider info, policy details, and content hash for forensic correlation.
- **\GuardrailFinding\** — Represents an individual risk finding with severity, category, and confidence score.
- **\GuardrailDecisionType\** — Enum for well-known guardian decisions (Allow, Audit, Deny, Modify, Warn).
- **\GuardrailRiskSeverity\** — String constants for risk severity levels (None, Low, Medium, High, Critical).
- **\GuardrailTargetType\** — Extensible type for guardrail targets (LlmInput, LlmOutput, ToolCall, etc.).

### New Tracing Scope
- **\ApplyGuardrailScope\** — Disposable OpenTelemetry scope following the same pattern as \InvokeAgentScope\, \InferenceScope\, and \ExecuteToolScope\. Supports recording findings post-creation and integrates with the existing span hierarchy.

### ETW Support
- **\ApplyGuardrailData\ / \ApplyGuardrailDataBuilder\** — DTO and builder for Event Tracing for Windows logging of guardrail events.
- Updated \IA365EtwLogger\ and \A365EtwLogger\ with \LogApplyGuardrail\ method.

### OpenTelemetry Constants
- Added \microsoft.security.*\ and \microsoft.guardian.*\ attribute keys to \OpenTelemetryConstants\.

### Base Infrastructure
- Added \AddEvent()\ helper to \OpenTelemetryScope\ for span events.
- Added \AddSdkAttributes()\ to \BaseDataBuilder\ (and called from all existing builders).

### Tests
- 12 unit tests covering scope creation, finding recording, attribute emission, and edge cases.

## Design Notes

- Guardian spans are children of the operation they protect (e.g., inference or tool execution spans).
- Multiple guardian spans may exist under a single operation when guardrails are chained.
- Follows the existing Core + Extensions pattern and disposable scope lifecycle.
- All 434 existing tests continue to pass.