### PR TITLE
feat: support custom A365 exporter via DI marker detection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,0 @@
-- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
-- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
-- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
+- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
+- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.

--- a/.gitignore
+++ b/.gitignore
@@ -424,3 +424,4 @@ api/
 
 # Language server cache
 *.lscache
+.github/copilot-instructions.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Support custom A365 exporter via DI marker detection and add `GenAiActivityFilterProcessor` to pre-filter non-GenAI spans ([#110](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/110))
+
 ## 1.0.3 - 2026-05-22
 
 - Fix `gen_ai.tool.arguments` attribute name to `gen_ai.tool.call.arguments` ([#88](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/88))

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -2,6 +2,9 @@ Microsoft.OpenTelemetry.Agent365Options.ClusterCategory.get -> string!
 Microsoft.OpenTelemetry.Agent365Options.ClusterCategory.set -> void
 Microsoft.OpenTelemetry.CustomAgent365ExporterMarker
 static readonly Microsoft.OpenTelemetry.CustomAgent365ExporterMarker.Instance -> Microsoft.OpenTelemetry.CustomAgent365ExporterMarker!
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors.GenAiActivityFilterProcessor
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors.GenAiActivityFilterProcessor.GenAiActivityFilterProcessor(OpenTelemetry.BaseProcessor<System.Diagnostics.Activity!>! inner) -> void
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors.GenAiActivityFilterProcessor.OnEnd(System.Diagnostics.Activity! data) -> void
 Microsoft.OpenTelemetry.Agent365Options.DomainResolver.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TenantDomainResolver!
 Microsoft.OpenTelemetry.Agent365Options.DomainResolver.set -> void
 Microsoft.OpenTelemetry.Agent365Options.ExporterTimeoutMilliseconds.get -> int

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 Microsoft.OpenTelemetry.Agent365Options.ClusterCategory.get -> string!
 Microsoft.OpenTelemetry.Agent365Options.ClusterCategory.set -> void
+Microsoft.OpenTelemetry.CustomAgent365ExporterMarker
+static readonly Microsoft.OpenTelemetry.CustomAgent365ExporterMarker.Instance -> Microsoft.OpenTelemetry.CustomAgent365ExporterMarker!
 Microsoft.OpenTelemetry.Agent365Options.DomainResolver.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.TenantDomainResolver!
 Microsoft.OpenTelemetry.Agent365Options.DomainResolver.set -> void
 Microsoft.OpenTelemetry.Agent365Options.ExporterTimeoutMilliseconds.get -> int

--- a/src/Microsoft.OpenTelemetry/Agent365/CustomAgent365ExporterMarker.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/CustomAgent365ExporterMarker.cs
@@ -4,11 +4,26 @@
 namespace Microsoft.OpenTelemetry;
 
 /// <summary>
-/// Marker class registered as a singleton to indicate that a custom (shim) Agent365 exporter
-/// has been registered. When detected, the built-in Agent365 exporter is skipped.
+/// Marker class registered as a singleton to indicate that a custom Agent365 exporter
+/// has been registered. When detected, the built-in Agent365 exporter is skipped,
+/// but all A365 instrumentation (sampler, activity sources, processors) and
+/// <see cref="Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions"/>
+/// remain available in DI.
 /// </summary>
-internal sealed class CustomAgent365ExporterMarker
+/// <remarks>
+/// <para>
+/// Register <see cref="Instance"/> as a singleton in the DI container before building the host
+/// to signal that a custom exporter will handle A365 span export:
+/// </para>
+/// <code>
+/// services.AddSingleton(CustomAgent365ExporterMarker.Instance);
+/// </code>
+/// </remarks>
+public sealed class CustomAgent365ExporterMarker
 {
+    /// <summary>
+    /// The singleton instance to register in DI.
+    /// </summary>
     public static readonly CustomAgent365ExporterMarker Instance = new();
 
     private CustomAgent365ExporterMarker()

--- a/src/Microsoft.OpenTelemetry/Agent365/CustomAgent365ExporterMarker.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/CustomAgent365ExporterMarker.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.OpenTelemetry;
+
+/// <summary>
+/// Marker class registered as a singleton to indicate that a custom (shim) Agent365 exporter
+/// has been registered. When detected, the built-in Agent365 exporter is skipped.
+/// </summary>
+internal sealed class CustomAgent365ExporterMarker
+{
+    public static readonly CustomAgent365ExporterMarker Instance = new();
+
+    private CustomAgent365ExporterMarker()
+    {
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
@@ -92,14 +92,6 @@ internal static class Agent365OpenTelemetryBuilderExtensions
                     localParentNotSampled: new global::OpenTelemetry.Trace.AlwaysOnSampler(),
                     remoteParentNotSampled: new global::OpenTelemetry.Trace.AlwaysOnSampler()));
 
-            // Agent365 scopes + baggage processor
-            if (instrumentationOptions.EnableAgent365Instrumentation)
-            {
-                tracing
-                    .AddSource(OpenTelemetryConstants.SourceName)
-                    .AddProcessor<ActivityProcessor>();
-            }
-
             // Semantic Kernel
             if (instrumentationOptions.EnableSemanticKernelInstrumentation)
             {
@@ -117,20 +109,46 @@ internal static class Agent365OpenTelemetryBuilderExtensions
                     .AddSource("Experimental.Microsoft.Extensions.AI");
             }
 
+            // Agent365 scopes + baggage processor — registered last because processors
+            // are called in order of addition; this ensures OnStart runs after SK and
+            // other instrumentation processors.
+            if (instrumentationOptions.EnableAgent365Instrumentation)
+            {
+                tracing
+                    .AddSource(OpenTelemetryConstants.SourceName)
+                    .AddProcessor<ActivityProcessor>();
+            }
+
             // Agent365 Exporter options (available via DI for built-in or custom shim exporter)
             if (!options.SkipExporter)
             {
                 builder.Services.AddSingleton(options.ExporterOptions);
 
-                // Skip built-in exporter if a custom shim exporter has been registered
-                var shimRegistered = builder.Services.Any(s =>
-                    s.ImplementationInstance is CustomAgent365ExporterMarker ||
-                    s.ServiceType == typeof(CustomAgent365ExporterMarker) ||
-                    s.ImplementationType == typeof(CustomAgent365ExporterMarker));
-
-                if (!shimRegistered)
+                // Defer the marker check to provider build time so that
+                // AddCustomAgent365Exporter can be called AFTER UseMicrosoftOpenTelemetry.
+                if (tracing is IDeferredTracerProviderBuilder deferredTracing)
                 {
-                    tracing.AddAgent365Exporter();
+                    deferredTracing.Configure((sp, tracerBuilder) =>
+                    {
+                        var shimRegistered = sp.GetService<CustomAgent365ExporterMarker>() != null;
+                        if (!shimRegistered)
+                        {
+                            tracerBuilder.AddAgent365Exporter();
+                        }
+                    });
+                }
+                else
+                {
+                    // Fallback: check services at call time (legacy behavior)
+                    var shimRegistered = builder.Services.Any(s =>
+                        s.ImplementationInstance is CustomAgent365ExporterMarker ||
+                        s.ServiceType == typeof(CustomAgent365ExporterMarker) ||
+                        s.ImplementationType == typeof(CustomAgent365ExporterMarker));
+
+                    if (!shimRegistered)
+                    {
+                        tracing.AddAgent365Exporter();
+                    }
                 }
             }
             });

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Linq;
 using Microsoft.Agents.A365.Observability.Runtime;
 using Microsoft.Agents.A365.Observability.Runtime.Common;
 using Microsoft.Agents.A365.Observability.Extensions.SemanticKernel;
@@ -116,11 +117,19 @@ internal static class Agent365OpenTelemetryBuilderExtensions
                     .AddSource("Experimental.Microsoft.Extensions.AI");
             }
 
-            // Agent365 Exporter (enabled when not skipped)
+            // Agent365 Exporter options (available via DI for built-in or custom shim exporter)
             if (!options.SkipExporter)
             {
                 builder.Services.AddSingleton(options.ExporterOptions);
-                tracing.AddAgent365Exporter();
+
+                // Skip built-in exporter if a custom shim exporter has been registered
+                var shimRegistered = builder.Services.Any(
+                    s => s.ImplementationInstance is CustomAgent365ExporterMarker);
+
+                if (!shimRegistered)
+                {
+                    tracing.AddAgent365Exporter();
+                }
             }
             });
         }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Agent365OpenTelemetryBuilderExtensions.cs
@@ -123,8 +123,10 @@ internal static class Agent365OpenTelemetryBuilderExtensions
                 builder.Services.AddSingleton(options.ExporterOptions);
 
                 // Skip built-in exporter if a custom shim exporter has been registered
-                var shimRegistered = builder.Services.Any(
-                    s => s.ImplementationInstance is CustomAgent365ExporterMarker);
+                var shimRegistered = builder.Services.Any(s =>
+                    s.ImplementationInstance is CustomAgent365ExporterMarker ||
+                    s.ServiceType == typeof(CustomAgent365ExporterMarker) ||
+                    s.ImplementationType == typeof(CustomAgent365ExporterMarker));
 
                 if (!shimRegistered)
                 {

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ExecuteToolDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ExecuteToolDataBuilder.cs
@@ -15,8 +15,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
     /// </summary>
     public class ExecuteToolDataBuilder : BaseDataBuilder<ExecuteToolData>
     {
-        private const string ExecuteToolOperationName = "execute_tool";
-
         /// <summary>
         /// Builds complete data for an execute_tool operation.
         /// </summary>
@@ -69,7 +67,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
             AddSdkAttributes(attributes);
 
             // Operation name
-            AddIfNotNull(attributes, GenAiOperationNameKey, ExecuteToolDataBuilder.ExecuteToolOperationName);
+            AddIfNotNull(attributes, GenAiOperationNameKey, OpenTelemetryConstants.ExecuteToolOperationName);
 
             AddAgentDetails(attributes, agentDetails);
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/InvokeAgentDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/InvokeAgentDataBuilder.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
     /// </summary>
     public class InvokeAgentDataBuilder : BaseDataBuilder<InvokeAgentData>
     {
-        private const string InvokeAgentOperationName = "invoke_agent";
-
         /// <summary>
         /// Builds complete data for an invoke_agent operation.
         /// </summary>
@@ -98,7 +96,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
             AddSdkAttributes(attributes);
 
             // Operation name
-            AddIfNotNull(attributes, GenAiOperationNameKey, InvokeAgentDataBuilder.InvokeAgentOperationName);
+            AddIfNotNull(attributes, GenAiOperationNameKey, OpenTelemetryConstants.InvokeAgentOperationName);
 
             // Add agent details (includes tenant ID)
             AddAgentDetails(attributes, agentDetails);

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/OutputDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/OutputDataBuilder.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
     /// </summary>
     public class OutputDataBuilder : BaseDataBuilder<OutputData>
     {
-        private const string OutputMessagesOperationName = "output_messages";
-
         /// <summary>
         /// Builds complete data for an output_messages operation.
         /// </summary>
@@ -63,7 +61,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
             AddSdkAttributes(attributes);
 
             // Operation name
-            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiOperationNameKey, OutputMessagesOperationName);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiOperationNameKey, OpenTelemetryConstants.OutputMessagesOperationName);
             
             AddAgentDetails(attributes, agentDetails);
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -32,15 +32,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         // gen_ai.operation.name through unchanged. Both the lowercase canonical value and the
         // InferenceOperationType.Chat enum name are accepted in this set so that activities
         // tagged with either form are not filtered out by PartitionByIdentity.
-        private static readonly HashSet<string> GenAiOperationNames = new HashSet<string>(StringComparer.Ordinal)
-        {
-            InvokeAgentScope.OperationName,
-            ExecuteToolScope.OperationName,
-            OutputScope.OperationName,
-            OpenTelemetryConstants.ApplyGuardrailOperationName,
-            "chat",
-            nameof(InferenceOperationType.Chat),
-        };
+        private static readonly HashSet<string> GenAiOperationNames = OpenTelemetryConstants.GenAiOperationNames;
 
         private enum AddResult { Added, NonGenAI, MissingIdentity, Null }
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
         // gen_ai.operation.name through unchanged. Both the lowercase canonical value and the
         // InferenceOperationType.Chat enum name are accepted in this set so that activities
         // tagged with either form are not filtered out by PartitionByIdentity.
-        private static readonly HashSet<string> GenAiOperationNames = OpenTelemetryConstants.GenAiOperationNames;
-
         private enum AddResult { Added, NonGenAI, MissingIdentity, Null }
 
         /// <summary>
@@ -267,7 +265,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             if (activity is null) return AddResult.Null;
 
             var operationName = activity.GetAttributeOrBaggage(OpenTelemetryConstants.GenAiOperationNameKey);
-            if (string.IsNullOrEmpty(operationName) || !GenAiOperationNames.Contains(operationName!))
+            if (string.IsNullOrEmpty(operationName) || !OpenTelemetryConstants.GenAiOperationNames.Contains(operationName!))
                 return AddResult.NonGenAI;
 
             var tenant = activity.GetAttributeOrBaggage(OpenTelemetryConstants.TenantIdKey);

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/ObservabilityTracerProviderBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/ObservabilityTracerProviderBuilderExtensions.cs
@@ -82,20 +82,22 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             switch (exporterType)
             {
                 case Agent365ExporterType.Agent365ExporterAsync:
-                    builder.AddProcessor(new BatchActivityExportProcessorAsync(
+                    var asyncBatchProcessor = new BatchActivityExportProcessorAsync(
                         new Agent365ExporterAsync(core: exporterCore, logger: logger, options: exporterOptions, resource: null, httpClient: httpClient),
                         maxQueueSize: exporterOptions.MaxQueueSize,
                         scheduledDelayMilliseconds: exporterOptions.ScheduledDelayMilliseconds,
-                        maxExportBatchSize: exporterOptions.MaxExportBatchSize));
+                        maxExportBatchSize: exporterOptions.MaxExportBatchSize);
+                    builder.AddProcessor(new GenAiActivityFilterProcessor(asyncBatchProcessor));
                     break;
 
                 case Agent365ExporterType.Agent365Exporter:
-                    builder.AddProcessor(new BatchActivityExportProcessor(
+                    var batchProcessor = new BatchActivityExportProcessor(
                         new Agent365Exporter(core: exporterCore, logger: logger, options: exporterOptions, resource: null, httpClient: httpClient),
                         maxQueueSize: exporterOptions.MaxQueueSize,
                         scheduledDelayMilliseconds: exporterOptions.ScheduledDelayMilliseconds,
                         exporterTimeoutMilliseconds: exporterOptions.ExporterTimeoutMilliseconds,
-                        maxExportBatchSize: exporterOptions.MaxExportBatchSize));
+                        maxExportBatchSize: exporterOptions.MaxExportBatchSize);
+                    builder.AddProcessor(new GenAiActivityFilterProcessor(batchProcessor));
                     break;
 
                 default:

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Processors/ActivityProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Processors/ActivityProcessor.cs
@@ -52,15 +52,15 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors
 
         /// <summary>
         /// Called when an activity starts, adds tags for attributes listed in AttributeKeys.
-        /// Only GenAI spans originating from the Agent365 SDK source are processed (those that
-        /// have a <c>gen_ai.operation.name</c> tag, i.e. invoke_agent, execute_tool, inference,
-        /// and output_messages spans); all other activities pass through unmodified.
+        /// Any span with an allowlisted <c>gen_ai.operation.name</c> tag is processed;
+        /// all other activities pass through unmodified.
         /// </summary>
         /// <param name="activity">The activity that is starting.</param>
         public override void OnStart(Activity activity)
         {
-            if (activity.Source.Name != OpenTelemetryConstants.SourceName ||
-                activity.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) == null)
+            var operationName = activity.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) as string;
+            if (string.IsNullOrEmpty(operationName) ||
+                !OpenTelemetryConstants.GenAiOperationNames.Contains(operationName!))
             {
                 base.OnStart(activity);
                 return;

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Processors/ActivityProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Processors/ActivityProcessor.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors
                 activity.CoalesceTag(key, Baggage.Current.GetBaggage(key));
             }
 
-            if (activity.OperationName == InvokeAgentScope.OperationName ||
-                (activity.DisplayName != null && activity.DisplayName.StartsWith(InvokeAgentScope.OperationName)))
+            if (activity.OperationName == OpenTelemetryConstants.InvokeAgentOperationName ||
+                (activity.DisplayName != null && activity.DisplayName.StartsWith(OpenTelemetryConstants.InvokeAgentOperationName)))
             {
                 foreach (var key in InvokeAgentAttributeKeys)
                 {

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Processors/GenAiActivityFilterProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Processors/GenAiActivityFilterProcessor.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors
+{
+    using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts;
+    using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
+    using global::OpenTelemetry;
+    using System;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// A composite processor that filters activities, forwarding only genAI spans
+    /// (those with a recognized <c>gen_ai.operation.name</c>) to the wrapped inner processor.
+    /// Non-genAI activities are silently dropped before reaching the inner processor.
+    /// </summary>
+    /// <remarks>
+    /// This processor is designed to wrap a <see cref="BatchActivityExportProcessor"/> or
+    /// <see cref="BatchActivityExportProcessorAsync"/> so that the exporter only receives
+    /// genAI spans without needing its own filtering logic.
+    /// </remarks>
+    public sealed class GenAiActivityFilterProcessor : BaseProcessor<Activity>
+    {
+        private static readonly HashSet<string> GenAiOperationNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            InvokeAgentScope.OperationName,
+            ExecuteToolScope.OperationName,
+            OutputScope.OperationName,
+            OpenTelemetryConstants.ApplyGuardrailOperationName,
+            "chat",
+            nameof(InferenceOperationType.Chat),
+        };
+
+        private readonly BaseProcessor<Activity> _inner;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenAiActivityFilterProcessor"/> class.
+        /// </summary>
+        /// <param name="inner">The inner processor that receives only genAI activities.</param>
+        public GenAiActivityFilterProcessor(BaseProcessor<Activity> inner)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        }
+
+        /// <inheritdoc/>
+        public override void OnEnd(Activity data)
+        {
+            if (IsGenAiActivity(data))
+            {
+                _inner.OnEnd(data);
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override bool OnForceFlush(int timeoutMilliseconds)
+        {
+            return _inner.ForceFlush(timeoutMilliseconds);
+        }
+
+        /// <inheritdoc/>
+        protected override bool OnShutdown(int timeoutMilliseconds)
+        {
+            return _inner.Shutdown(timeoutMilliseconds);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private static bool IsGenAiActivity(Activity activity)
+        {
+            var operationName = activity.GetTagItem(OpenTelemetryConstants.GenAiOperationNameKey) as string;
+            if (string.IsNullOrEmpty(operationName))
+            {
+                // Fall back to baggage
+                operationName = activity.GetBaggageItem(OpenTelemetryConstants.GenAiOperationNameKey);
+            }
+
+            return !string.IsNullOrEmpty(operationName) && GenAiOperationNames.Contains(operationName!);
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Processors/GenAiActivityFilterProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Processors/GenAiActivityFilterProcessor.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors
 {
-    using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts;
     using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
     using global::OpenTelemetry;
     using System;
@@ -21,16 +20,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors
     /// </remarks>
     public sealed class GenAiActivityFilterProcessor : BaseProcessor<Activity>
     {
-        private static readonly HashSet<string> GenAiOperationNames = new HashSet<string>(StringComparer.Ordinal)
-        {
-            InvokeAgentScope.OperationName,
-            ExecuteToolScope.OperationName,
-            OutputScope.OperationName,
-            OpenTelemetryConstants.ApplyGuardrailOperationName,
-            "chat",
-            nameof(InferenceOperationType.Chat),
-        };
-
         private readonly BaseProcessor<Activity> _inner;
 
         /// <summary>
@@ -83,7 +72,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Processors
                 operationName = activity.GetBaggageItem(OpenTelemetryConstants.GenAiOperationNameKey);
             }
 
-            return !string.IsNullOrEmpty(operationName) && GenAiOperationNames.Contains(operationName!);
+            return !string.IsNullOrEmpty(operationName) && OpenTelemetryConstants.GenAiOperationNames.Contains(operationName!);
         }
     }
 }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/ExecuteToolScope.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/ExecuteToolScope.cs
@@ -19,11 +19,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
     public sealed class ExecuteToolScope : OpenTelemetryScope
     {
         /// <summary>
-        /// The operation name for tool execution tracing.
-        /// </summary>
-        internal const string OperationName = "execute_tool";
-
-        /// <summary>
         /// Creates and starts a new scope for tool execution tracing.
         /// </summary>
         /// <param name="request">Request details for the tool execution.</param>
@@ -49,8 +44,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
 
         private ExecuteToolScope(Request request, ToolCallDetails details, AgentDetails agentDetails, UserDetails? userDetails, SpanDetails? spanDetails, ThreatDiagnosticsSummary? threatDiagnosticsSummary)
             : base(
-                operationName: OperationName,
-                activityName: $"{OperationName} {details.ToolName}",
+                operationName: OpenTelemetryConstants.ExecuteToolOperationName,
+                activityName: $"{OpenTelemetryConstants.ExecuteToolOperationName} {details.ToolName}",
                 agentDetails: agentDetails,
                 spanDetails: new SpanDetails(spanDetails?.SpanKind ?? ActivityKind.Internal, spanDetails?.ParentContext, spanDetails?.StartTime, spanDetails?.EndTime, spanDetails?.SpanLinks),
                 userDetails: userDetails)

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/InvokeAgentScope.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/InvokeAgentScope.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// <see href="https://learn.microsoft.com/microsoft-agent-365/developer/observability?tabs=dotnet#agent-invocation">Learn more about Agent Invocation</see>
         /// </para>
         /// </remarks>
-        internal const string OperationName = "invoke_agent";
 
         /// <summary>
         /// Creates and starts a new scope for agent invocation tracing.
@@ -64,9 +63,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
             SpanDetails? spanDetails,
             ThreatDiagnosticsSummary? threatDiagnosticsSummary)
             : base(
-                operationName: OperationName,
+                operationName: OpenTelemetryConstants.InvokeAgentOperationName,
                 activityName: string.IsNullOrWhiteSpace(agentDetails?.AgentName)
-                    ? OperationName
+                    ? OpenTelemetryConstants.InvokeAgentOperationName
                     : $"invoke_agent {agentDetails!.AgentName}",
                 agentDetails: agentDetails!,
                 spanDetails: new SpanDetails(spanDetails?.SpanKind ?? ActivityKind.Client, spanDetails?.ParentContext, spanDetails?.StartTime, spanDetails?.EndTime, spanDetails?.SpanLinks),

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
@@ -39,19 +39,19 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         [DataContract]
         public enum OperationNames
         {
-            [EnumMember(Value = "InvokeAgent")]
+            [EnumMember(Value = InvokeAgentOperationName)]
             InvokeAgent,
 
-            [EnumMember(Value = "ExecuteInference")]
+            [EnumMember(Value = ChatOperationName)]
             ExecuteInference,
 
-            [EnumMember(Value = "ExecuteTool")]
+            [EnumMember(Value = ExecuteToolOperationName)]
             ExecuteTool,
 
-            [EnumMember(Value = "OutputMessages")]
+            [EnumMember(Value = OutputMessagesOperationName)]
             OutputMessages,
 
-            [EnumMember(Value = "ApplyGuardrail")]
+            [EnumMember(Value = ApplyGuardrailOperationName)]
             ApplyGuardrail
         }
 
@@ -59,6 +59,26 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// The operation name value for apply_guardrail spans.
         /// </summary>
         public const string ApplyGuardrailOperationName = "apply_guardrail";
+
+        /// <summary>
+        /// The operation name value for invoke_agent spans.
+        /// </summary>
+        public const string InvokeAgentOperationName = "invoke_agent";
+
+        /// <summary>
+        /// The operation name value for execute_tool spans.
+        /// </summary>
+        public const string ExecuteToolOperationName = "execute_tool";
+
+        /// <summary>
+        /// The operation name value for output_messages spans.
+        /// </summary>
+        public const string OutputMessagesOperationName = "output_messages";
+
+        /// <summary>
+        /// The operation name value for chat/inference spans.
+        /// </summary>
+        public const string ChatOperationName = "chat";
 
         // Channel dimensions (renamed from gen_ai.channel.* to microsoft.channel.*)
         public const string ChannelNameKey = "microsoft.channel.name";
@@ -110,7 +130,20 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         ///  The GenAI operation name key.
         /// </summary>
         public const string GenAiOperationNameKey = "gen_ai.operation.name";
-        
+
+        /// <summary>
+        /// The set of recognized genAI operation names used to identify A365-exportable spans.
+        /// Comparison is case-insensitive.
+        /// </summary>
+        internal static readonly HashSet<string> GenAiOperationNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            InvokeAgentOperationName,
+            ExecuteToolOperationName,
+            OutputMessagesOperationName,
+            ApplyGuardrailOperationName,
+            ChatOperationName,
+        };
+
         /// <summary>
         /// The error message key.
         /// </summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
@@ -39,19 +39,19 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         [DataContract]
         public enum OperationNames
         {
-            [EnumMember(Value = InvokeAgentOperationName)]
+            [EnumMember(Value = "InvokeAgent")]
             InvokeAgent,
 
-            [EnumMember(Value = ChatOperationName)]
+            [EnumMember(Value = "ExecuteInference")]
             ExecuteInference,
 
-            [EnumMember(Value = ExecuteToolOperationName)]
+            [EnumMember(Value = "ExecuteTool")]
             ExecuteTool,
 
-            [EnumMember(Value = OutputMessagesOperationName)]
+            [EnumMember(Value = "OutputMessages")]
             OutputMessages,
 
-            [EnumMember(Value = ApplyGuardrailOperationName)]
+            [EnumMember(Value = "ApplyGuardrail")]
             ApplyGuardrail
         }
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OutputScope.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OutputScope.cs
@@ -22,11 +22,6 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
     public sealed class OutputScope : OpenTelemetryScope
     {
         /// <summary>
-        /// The operation name for output tracing.
-        /// </summary>
-        internal const string OperationName = "output_messages";
-
-        /// <summary>
         /// Creates and starts a new scope for output tracing.
         /// </summary>
         /// <param name="request">Request details for the output operation.</param>
@@ -40,8 +35,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
 
         private OutputScope(Request request, Response response, AgentDetails agentDetails, UserDetails? userDetails, SpanDetails? spanDetails)
             : base(
-                operationName: OperationName,
-                activityName: $"{OperationName} {agentDetails.AgentId}",
+                operationName: OpenTelemetryConstants.OutputMessagesOperationName,
+                activityName: $"{OpenTelemetryConstants.OutputMessagesOperationName} {agentDetails.AgentId}",
                 agentDetails: agentDetails,
                 spanDetails: spanDetails ?? new SpanDetails(ActivityKind.Client),
                 userDetails: userDetails)

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/OutputScopeTest.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/OutputScopeTest.cs
@@ -29,8 +29,8 @@ public sealed class OutputScopeTest : ActivityTest
         });
 
         // Assert - operation name and activity name
-        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiOperationNameKey, OutputScope.OperationName);
-        activity.DisplayName.Should().Be($"{OutputScope.OperationName} {agentDetails.AgentId}");
+        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiOperationNameKey, OpenTelemetryConstants.OutputMessagesOperationName);
+        activity.DisplayName.Should().Be($"{OpenTelemetryConstants.OutputMessagesOperationName} {agentDetails.AgentId}");
 
         // Assert - agent details
         activity.ShouldHaveTag(OpenTelemetryConstants.GenAiAgentIdKey, agentDetails.AgentId!);
@@ -95,7 +95,7 @@ public sealed class OutputScopeTest : ActivityTest
 
         // Assert - child activity should have the parent set
         childActivity.ParentSpanId.ToString().Should().NotBeNullOrEmpty();
-        childActivity.ShouldHaveTag(OpenTelemetryConstants.GenAiOperationNameKey, OutputScope.OperationName);
+        childActivity.ShouldHaveTag(OpenTelemetryConstants.GenAiOperationNameKey, OpenTelemetryConstants.OutputMessagesOperationName);
         childActivity.ShouldHaveTagContaining(OpenTelemetryConstants.GenAiOutputMessagesKey, "Test message");
     }
 

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/ScopeTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/ScopeTests.cs
@@ -35,7 +35,7 @@ public sealed class ScopeTests : ActivityTest
         activity.Should().NotBeNull();
         activity.Kind.Should().Be(ActivityKind.Internal);
         activity.TagObjects.Should().ContainKey(GenAiOperationNameKey)
-            .WhoseValue.Should().Be(ExecuteToolScope.OperationName);
+            .WhoseValue.Should().Be(OpenTelemetryConstants.ExecuteToolOperationName);
         activity.TagObjects.Should().ContainKey(GenAiAgentIdKey)
             .WhoseValue.Should().BeOfType<string>()
             .Which.Should().Be(AgentId);

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
@@ -551,5 +551,140 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
             Assert.True(captured.EnableAzureSdkInstrumentation);
         }
     }
+
+    [Collection("EnvironmentVariableTests")]
+    public class UseCustomExporterTests
+    {
+        [Fact]
+        public void CustomExporterMarker_SkipsBuiltInExporter_RegistersOptionsInDI()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(Microsoft.OpenTelemetry.CustomAgent365ExporterMarker.Instance);
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.ContextualTokenResolver = _ =>
+                        System.Threading.Tasks.Task.FromResult<string?>("token");
+                });
+
+            // Agent365ExporterOptions IS registered in DI (shim can resolve it)
+            Assert.Contains(services, s => s.ServiceType.Name == "Agent365ExporterOptions");
+
+            // Tracing configuration is still registered (instrumentation active)
+            Assert.Contains(services, s =>
+                s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
+                s.ServiceType.Name.Contains("TracerProviderBuilder"));
+        }
+
+        [Fact]
+        public void CustomExporterMarker_ExporterOptionsResolvable_WithTokenResolver()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton(Microsoft.OpenTelemetry.CustomAgent365ExporterMarker.Instance);
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.TokenResolver = (agentId, tenantId) =>
+                        System.Threading.Tasks.Task.FromResult<string?>("resolved-token");
+                });
+
+            var sp = services.BuildServiceProvider();
+            var options = sp.GetService<Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions>();
+
+            Assert.NotNull(options);
+            Assert.NotNull(options!.TokenResolver);
+        }
+
+        [Fact]
+        public void CustomExporterMarker_ExporterOptionsResolvable_WithContextualTokenResolver()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton(Microsoft.OpenTelemetry.CustomAgent365ExporterMarker.Instance);
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.ContextualTokenResolver = ctx =>
+                        System.Threading.Tasks.Task.FromResult<string?>("contextual-token");
+                });
+
+            var sp = services.BuildServiceProvider();
+            var options = sp.GetService<Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions>();
+
+            Assert.NotNull(options);
+            Assert.NotNull(options!.ContextualTokenResolver);
+        }
+
+        [Fact]
+        public void NoMarker_RegistersBuiltInExporter()
+        {
+            var services = new ServiceCollection();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.TokenResolver = (a, t) =>
+                        System.Threading.Tasks.Task.FromResult<string?>("token");
+                });
+
+            // Built-in exporter is registered (no marker present)
+            Assert.Contains(services, s => s.ServiceType.Name == "Agent365ExporterOptions");
+        }
+
+        [Fact]
+        public void CustomExporterMarker_WithSkipExporter_NoOptionsInDI()
+        {
+            const string envVar = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+            var original = Environment.GetEnvironmentVariable(envVar);
+            try
+            {
+                Environment.SetEnvironmentVariable(envVar, null);
+
+                var services = new ServiceCollection();
+                services.AddSingleton(Microsoft.OpenTelemetry.CustomAgent365ExporterMarker.Instance);
+                services.AddOpenTelemetry()
+                    .UseMicrosoftOpenTelemetry(o =>
+                    {
+                        o.Exporters = ExportTarget.Console; // Agent365 NOT in target
+                        o.Agent365.TokenResolver = (a, t) =>
+                            System.Threading.Tasks.Task.FromResult<string?>("token");
+                    });
+
+                // Agent365ExporterOptions NOT registered (SkipExporter takes precedence)
+                Assert.DoesNotContain(services, s => s.ServiceType.Name == "Agent365ExporterOptions");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVar, original);
+            }
+        }
+
+        [Fact]
+        public void CustomExporterMarker_A365OnlyMode_InfraStillSuppressed()
+        {
+            var services = new ServiceCollection();
+            InstrumentationOptions? captured = null;
+
+            services.AddSingleton(Microsoft.OpenTelemetry.CustomAgent365ExporterMarker.Instance);
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.ContextualTokenResolver = _ =>
+                        System.Threading.Tasks.Task.FromResult<string?>("token");
+                    captured = o.Instrumentation;
+                });
+
+            Assert.NotNull(captured);
+            Assert.False(captured!.EnableAspNetCoreInstrumentation);
+            Assert.False(captured.EnableHttpClientInstrumentation);
+            Assert.False(captured.EnableSqlClientInstrumentation);
+            Assert.False(captured.EnableAzureSdkInstrumentation);
+        }
+    }
 }
 #endif

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/UseMicrosoftOpenTelemetryTests.cs
@@ -559,6 +559,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
         public void CustomExporterMarker_SkipsBuiltInExporter_RegistersOptionsInDI()
         {
             var services = new ServiceCollection();
+            services.AddLogging();
             services.AddSingleton(Microsoft.OpenTelemetry.CustomAgent365ExporterMarker.Instance);
             services.AddOpenTelemetry()
                 .UseMicrosoftOpenTelemetry(o =>
@@ -568,14 +569,74 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                         System.Threading.Tasks.Task.FromResult<string?>("token");
                 });
 
-            // Agent365ExporterOptions IS registered in DI (shim can resolve it)
-            Assert.Contains(services, s => s.ServiceType.Name == "Agent365ExporterOptions");
+            using var sp = services.BuildServiceProvider();
 
-            // Tracing configuration is still registered (instrumentation active)
-            Assert.Contains(services, s =>
-                s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder") ||
-                s.ServiceType.Name.Contains("TracerProviderBuilder"));
+            // Agent365ExporterOptions IS registered in DI (shim can resolve it)
+            var options = sp.GetService<Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions>();
+            Assert.NotNull(options);
+
+            // The built-in exporter registers via IDeferredTracerProviderBuilder.Configure which
+            // adds IConfigureTracerProviderBuilder registrations. With the marker, there should be
+            // fewer such registrations than without the marker.
+            var configureCount = services.Count(s =>
+                s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder"));
+
+            // Compare with no-marker baseline to verify the exporter configure callback was skipped
+            var servicesNoMarker = new ServiceCollection();
+            servicesNoMarker.AddLogging();
+            servicesNoMarker.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.ContextualTokenResolver = _ =>
+                        System.Threading.Tasks.Task.FromResult<string?>("token");
+                });
+
+            var configureCountNoMarker = servicesNoMarker.Count(s =>
+                s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder"));
+
+            Assert.True(configureCountNoMarker > configureCount,
+                $"Without marker: {configureCountNoMarker} configure callbacks, with marker: {configureCount}. " +
+                "The built-in exporter should add at least one extra configure callback when no marker is present.");
         }
+
+        [Fact]
+        public void NoMarker_RegistersBuiltInExporter_InProcessorChain()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.TokenResolver = (a, t) =>
+                        System.Threading.Tasks.Task.FromResult<string?>("token");
+                });
+
+            // Without a marker, AddAgent365Exporter() is called which registers a deferred
+            // configure callback. Verify it's present (more callbacks than with marker).
+            var configureCount = services.Count(s =>
+                s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder"));
+
+            var servicesWithMarker = new ServiceCollection();
+            servicesWithMarker.AddLogging();
+            servicesWithMarker.AddSingleton(Microsoft.OpenTelemetry.CustomAgent365ExporterMarker.Instance);
+            servicesWithMarker.AddOpenTelemetry()
+                .UseMicrosoftOpenTelemetry(o =>
+                {
+                    o.Exporters = ExportTarget.Agent365;
+                    o.Agent365.TokenResolver = (a, t) =>
+                        System.Threading.Tasks.Task.FromResult<string?>("token");
+                });
+
+            var configureCountWithMarker = servicesWithMarker.Count(s =>
+                s.ServiceType.Name.Contains("IConfigureTracerProviderBuilder"));
+
+            Assert.True(configureCount > configureCountWithMarker,
+                $"Without marker: {configureCount} configure callbacks, with marker: {configureCountWithMarker}. " +
+                "The built-in exporter should register an additional configure callback.");
+        }
+
 
         [Fact]
         public void CustomExporterMarker_ExporterOptionsResolvable_WithTokenResolver()
@@ -591,7 +652,7 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                         System.Threading.Tasks.Task.FromResult<string?>("resolved-token");
                 });
 
-            var sp = services.BuildServiceProvider();
+            using var sp = services.BuildServiceProvider();
             var options = sp.GetService<Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions>();
 
             Assert.NotNull(options);
@@ -612,27 +673,11 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests
                         System.Threading.Tasks.Task.FromResult<string?>("contextual-token");
                 });
 
-            var sp = services.BuildServiceProvider();
+            using var sp = services.BuildServiceProvider();
             var options = sp.GetService<Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters.Agent365ExporterOptions>();
 
             Assert.NotNull(options);
             Assert.NotNull(options!.ContextualTokenResolver);
-        }
-
-        [Fact]
-        public void NoMarker_RegistersBuiltInExporter()
-        {
-            var services = new ServiceCollection();
-            services.AddOpenTelemetry()
-                .UseMicrosoftOpenTelemetry(o =>
-                {
-                    o.Exporters = ExportTarget.Agent365;
-                    o.Agent365.TokenResolver = (a, t) =>
-                        System.Threading.Tasks.Task.FromResult<string?>("token");
-                });
-
-            // Built-in exporter is registered (no marker present)
-            Assert.Contains(services, s => s.ServiceType.Name == "Agent365ExporterOptions");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Adds support for 1P shim SDKs to replace the built-in Agent365 exporter while preserving all instrumentation (scopes, baggage, processors) and sharing token resolvers via DI.

## Motivation

Internal/1P teams need to route A365 spans through a custom exporter (shim SDK) while still leveraging the distro's instrumentation pipeline and token resolver configuration.

## Design

Uses a **DI marker pattern** (same as existing \UseMicrosoftOpenTelemetryRegistration\):

1. Shim SDK registers \CustomAgent365ExporterMarker.Instance\ in DI
2. Distro detects the marker and skips the built-in \Agent365Exporter\
3. \Agent365ExporterOptions\ (with token resolvers) is still registered in DI for the shim to consume

### Usage (1P app):
\\\csharp
// Shim SDK call
builder.Services.AddCustomAgent365Exporter();

// Distro call (unchanged)
builder.UseMicrosoftOpenTelemetry(o =>
{
    o.Exporters = ExportTarget.Agent365;
    o.Agent365.ContextualTokenResolver = myResolver;
});
\\\

## Changes

- \CustomAgent365ExporterMarker.cs\ — new sentinel class (\internal\)
- \Agent365OpenTelemetryBuilderExtensions.cs\ — detect marker, skip built-in exporter when present
- 6 new tests in \UseMicrosoftOpenTelemetryTests.cs\

## Testing

All 226 existing tests pass + 6 new tests covering:
- Marker skips built-in exporter but registers options in DI
- Token resolvers resolvable from DI (both delegates)
- No marker = default behavior unchanged
- SkipExporter takes precedence over marker
- A365-only mode infra suppression still works with marker
