### PR TITLE
Fix duplicate key exception in ExportFormatter

### DIFF
--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Common/ExportFormatter.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Common/ExportFormatter.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Common
 
             foreach (var tag in activity.TagObjects)
             {
-                dict.Add(tag.Key, tag.Value ?? "");
+                dict[tag.Key] = tag.Value ?? "";
             }
 
             return dict;
@@ -292,7 +292,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Common
                 var attrs = new Dictionary<string, object>();
                 foreach (var tag in ev.Tags)
                 {
-                    attrs.Add(tag.Key, tag.Value ?? "");
+                    attrs[tag.Key] = tag.Value ?? "";
                 }
 
                 events.Add(new OtlpEvent
@@ -316,7 +316,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Common
                 {
                     foreach (var tag in link.Tags)
                     {
-                        attrs.Add(tag.Key, tag.Value ?? "");
+                        attrs[tag.Key] = tag.Value ?? "";
                     }
                 }
 
@@ -338,7 +338,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Common
             var dict = new Dictionary<string, object>();
             foreach (var kvp in attrs)
             {
-                dict.Add(kvp.Key, kvp.Value ?? "");
+                dict[kvp.Key] = kvp.Value ?? "";
             }
 
             return dict;


### PR DESCRIPTION
## Summary

Fixes #111 — System.ArgumentException: An item with the same key has already been added. Key: gen_ai.conversation.id

## Root Cause

\MapAttributes\ used \dict.Add()\ which throws when \Activity.TagObjects\ contains duplicate keys. This can happen when external instrumentation libraries (e.g., GenAI/Semantic Kernel) call \Activity.AddTag()\ with a key that already exists on the activity.

## Fix

Replaced \dict.Add(key, value)\ with \dict[key] = value\ (indexer assignment, last-write-wins) in all four attribute-mapping methods:
- \MapAttributes\
- \MapEvents\
- \MapLinks\
- \MapResourceAttributes\

This matches \Activity.SetTag()\ semantics and the OTLP flat key→value model.

## Testing

All 18 existing ExportFormatter tests pass.