### PR TITLE
feat(agentframework): add Microsoft.Extensions.AI source for inference spans

### DIFF
--- a/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Program.cs
+++ b/examples/Microsoft.OpenTelemetry.AgentFramework.Demo/Program.cs
@@ -35,14 +35,20 @@ var apiKey = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY")
 static string GetWeather([Description("The location to get the weather for.")] string location)
     => $"The weather in {location} is cloudy with a high of 15°C.";
 
+// Instrument the underlying chat client with the standard Microsoft.Extensions.AI
+// `.UseOpenTelemetry()` (emits the `chat` inference span), then instrument the agent layer
+// (emits `invoke_agent` + `execute_tool`). The distro's UseAgentFramework() collects all three.
 AIAgent agent = new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey))
     .GetChatClient(deploymentName)
     .AsIChatClient()
+    .AsBuilder()
+    .UseOpenTelemetry(configure: cfg => cfg.EnableSensitiveData = true)
+    .Build()
     .AsAIAgent(
         instructions: "You are a helpful assistant that provides concise responses.",
         tools: [AIFunctionFactory.Create(GetWeather)])
     .AsBuilder()
-    .UseOpenTelemetry()
+    .UseOpenTelemetry(configure: cfg => cfg.EnableSensitiveData = true)
     .Build();
 
 // --- Endpoints ---------------------------------------------------------------

--- a/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkConstants.cs
+++ b/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkConstants.cs
@@ -23,4 +23,12 @@ internal static class AgentFrameworkConstants
     /// Activity source for chat client operations.
     /// </summary>
     internal const string ChatClientSource = "Experimental.Microsoft.Agents.AI.ChatClient";
+
+    /// <summary>
+    /// Default activity source/meter name emitted by <c>Microsoft.Extensions.AI</c> when
+    /// <c>.UseOpenTelemetry()</c> is called on an <c>IChatClient</c>
+    /// without a custom <c>sourceName</c>. Agent Framework delegates LLM calls to the underlying
+    /// chat client, so the <c>chat</c> (inference) span is emitted on this source.
+    /// </summary>
+    internal const string MicrosoftExtensionsAISource = "Experimental.Microsoft.Extensions.AI";
 }

--- a/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkOpenTelemetryBuilderExtensions.cs
@@ -53,12 +53,15 @@ internal static class AgentFrameworkOpenTelemetryBuilderExtensions
         {
             builder.WithTracing(tracing =>
             {
-                // Default Microsoft Agent Framework activity sources
+                // Default Microsoft Agent Framework activity sources, plus the
+                // Microsoft.Extensions.AI source the agent's underlying IChatClient emits the
+                // `chat` (inference) span on when instrumented with the default `.UseOpenTelemetry()`.
                 tracing
                     .AddSource(AgentFrameworkConstants.DefaultSource)
                     .AddSource(AgentFrameworkConstants.AgentSource)
                     .AddSource(AgentFrameworkConstants.ChatClientSource)
-                    .AddProcessor(new AgentFrameworkSpanProcessor());
+                    .AddSource(AgentFrameworkConstants.MicrosoftExtensionsAISource)
+                    .AddProcessor(new AgentFrameworkSpanProcessor(AgentFrameworkConstants.MicrosoftExtensionsAISource));
             });
         }
 
@@ -70,7 +73,8 @@ internal static class AgentFrameworkOpenTelemetryBuilderExtensions
                 metrics
                     .AddMeter(AgentFrameworkConstants.DefaultSource)
                     .AddMeter(AgentFrameworkConstants.AgentSource)
-                    .AddMeter(AgentFrameworkConstants.ChatClientSource);
+                    .AddMeter(AgentFrameworkConstants.ChatClientSource)
+                    .AddMeter(AgentFrameworkConstants.MicrosoftExtensionsAISource);
             });
         }
 

--- a/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/AgentFramework/AgentFrameworkOpenTelemetryBuilderExtensions.cs
@@ -55,7 +55,7 @@ internal static class AgentFrameworkOpenTelemetryBuilderExtensions
             {
                 // Default Microsoft Agent Framework activity sources, plus the
                 // Microsoft.Extensions.AI source the agent's underlying IChatClient emits the
-                // `chat` (inference) span on when instrumented with the default `.UseOpenTelemetry()`.
+                // `chat` (inference) span when instrumented with the default `.UseOpenTelemetry()`.
                 tracing
                     .AddSource(AgentFrameworkConstants.DefaultSource)
                     .AddSource(AgentFrameworkConstants.AgentSource)

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Extensions/SemanticKernelAutoInstrumentationTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Extensions/SemanticKernelAutoInstrumentationTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,13 +35,13 @@ public class SemanticKernelAutoInstrumentationTests
         !string.IsNullOrEmpty(ApiKey) &&
         !string.IsNullOrEmpty(Deployment);
 
-    private List<Activity> _exportedActivities = new();
+    private ConcurrentQueue<Activity> _exportedActivities = new();
     private ServiceProvider? _serviceProvider;
 
     [TestInitialize]
     public void Setup()
     {
-        _exportedActivities = new List<Activity>();
+        _exportedActivities = new ConcurrentQueue<Activity>();
 
         var services = new ServiceCollection();
         services.AddLogging();
@@ -51,7 +52,7 @@ public class SemanticKernelAutoInstrumentationTests
         services.AddOpenTelemetry()
             .UseMicrosoftOpenTelemetry(o => o.Exporters = ExportTarget.Console)
             .WithTracing(tracing => tracing
-                .AddProcessor(new SimpleActivityExportProcessor(new ActivityCapturingExporter(_exportedActivities))));
+                .AddProcessor(new SimpleActivityExportProcessor(new ConcurrentQueueActivityExporter(_exportedActivities))));
 
         _serviceProvider = services.BuildServiceProvider();
         _serviceProvider.GetService<TracerProvider>();
@@ -227,6 +228,28 @@ public class SemanticKernelAutoInstrumentationTests
         {
             Assert.Inconclusive(
                 "Skipped: set AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT env vars to run.");
+        }
+    }
+
+    /// <summary>
+    /// Exporter that enqueues activities into a thread-safe <see cref="ConcurrentQueue{T}"/> at
+    /// export time. Span export/end callbacks can occur on different threads, so a thread-safe
+    /// collection avoids races (and enumeration faults while <c>DumpAllActivities</c> iterates).
+    /// </summary>
+    private sealed class ConcurrentQueueActivityExporter : BaseExporter<Activity>
+    {
+        private readonly ConcurrentQueue<Activity> _activities;
+
+        public ConcurrentQueueActivityExporter(ConcurrentQueue<Activity> activities) => _activities = activities;
+
+        public override ExportResult Export(in Batch<Activity> batch)
+        {
+            foreach (var activity in batch)
+            {
+                _activities.Enqueue(activity);
+            }
+
+            return ExportResult.Success;
         }
     }
 

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Extensions/SemanticKernelAutoInstrumentationTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Extensions/SemanticKernelAutoInstrumentationTests.cs
@@ -1,0 +1,234 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Agents;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
+
+namespace Microsoft.OpenTelemetry.Agent365.Tests.Integration.Extensions;
+
+/// <summary>
+/// Integration tests verifying Semantic Kernel auto-instrumentation, via the distro's
+/// public <c>UseMicrosoftOpenTelemetry()</c> entry point, emits all 3 span types:
+/// invoke_agent, execute_tool, and chat (inference).
+/// SK self-instruments every layer on the <c>Microsoft.SemanticKernel*</c> source, which the distro
+/// collects and the <c>SemanticKernelSpanProcessor</c> enriches (mapping messages, normalizing the
+/// chat operation name).
+/// Makes real API calls against Azure OpenAI.
+/// Requires: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT env vars.
+/// </summary>
+[TestClass]
+public class SemanticKernelAutoInstrumentationTests
+{
+    private static string? Endpoint => Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+    private static string? ApiKey => Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY");
+    private static string? Deployment => Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT");
+
+    private static bool HasCredentials =>
+        !string.IsNullOrEmpty(Endpoint) &&
+        !string.IsNullOrEmpty(ApiKey) &&
+        !string.IsNullOrEmpty(Deployment);
+
+    private List<Activity> _exportedActivities = new();
+    private ServiceProvider? _serviceProvider;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _exportedActivities = new List<Activity>();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Use the distro's public entry point exactly as a consumer would.
+        // ExportTarget.Console enables tracing + source registration without requiring an
+        // Agent365 token resolver or network export; we capture the enriched spans ourselves.
+        services.AddOpenTelemetry()
+            .UseMicrosoftOpenTelemetry(o => o.Exporters = ExportTarget.Console)
+            .WithTracing(tracing => tracing
+                .AddProcessor(new SimpleActivityExportProcessor(new ActivityCapturingExporter(_exportedActivities))));
+
+        _serviceProvider = services.BuildServiceProvider();
+        _serviceProvider.GetService<TracerProvider>();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _serviceProvider?.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies that invoking a SK ChatCompletionAgent with a tool emits all 3 span types:
+    /// invoke_agent, execute_tool, and chat (inference) — all in the same trace.
+    /// </summary>
+    [TestMethod]
+    public async Task AgentWithTool_EmitsAllThreeSpanTypes_InvokeAgent_ExecuteTool_Inference()
+    {
+        SkipIfNoCredentials();
+
+        var agent = CreateAgentWithWeatherTool();
+
+        await foreach (var _ in agent.InvokeAsync("What is the weather in Seattle right now?"))
+        {
+        }
+
+        ForceFlush();
+        DumpAllActivities("SK AgentWithTool_AllThreeSpans");
+
+        var invokeAgentSpans = SpansWithOperation("invoke_agent");
+        invokeAgentSpans.Should().NotBeEmpty("SK ChatCompletionAgent should emit an invoke_agent span");
+
+        var executeToolSpans = SpansWithOperation("execute_tool");
+        executeToolSpans.Should().NotBeEmpty("SK should emit execute_tool span(s) when a kernel function is auto-invoked");
+
+        var chatSpans = ChatSpans();
+        chatSpans.Should().NotBeEmpty("SK should emit chat (inference) span(s) for LLM calls");
+
+        // Parent-child: execute_tool and chat should share the trace with invoke_agent.
+        var traceId = invokeAgentSpans.First().TraceId;
+
+        executeToolSpans.Should().AllSatisfy(span =>
+            span.TraceId.Should().Be(traceId, "execute_tool spans should share trace with invoke_agent"));
+
+        chatSpans.Should().AllSatisfy(span =>
+            span.TraceId.Should().Be(traceId, "chat spans should share trace with invoke_agent"));
+    }
+
+    /// <summary>
+    /// Verifies a SK agent invocation without tools emits invoke_agent and chat but no execute_tool.
+    /// </summary>
+    [TestMethod]
+    public async Task AgentWithoutTools_EmitsInvokeAgentAndInference_NoExecuteTool()
+    {
+        SkipIfNoCredentials();
+
+        var agent = CreateAgentWithoutTools();
+
+        await foreach (var _ in agent.InvokeAsync("What is the capital of France?"))
+        {
+        }
+
+        ForceFlush();
+        DumpAllActivities("SK AgentWithoutTools");
+
+        SpansWithOperation("invoke_agent").Should().NotBeEmpty("agent invocation should emit invoke_agent");
+        ChatSpans().Should().NotBeEmpty("agent invocation should emit a chat (inference) span");
+        SpansWithOperation("execute_tool").Should().BeEmpty("no tool should be invoked without tools registered");
+    }
+
+    /// <summary>
+    /// Verifies the chat (inference) span carries OTel GenAI structured input/output messages
+    /// after the distro's SemanticKernelSpanProcessor maps them.
+    /// </summary>
+    [TestMethod]
+    public async Task InferenceSpan_HasStructuredMessages()
+    {
+        SkipIfNoCredentials();
+
+        var agent = CreateAgentWithoutTools();
+
+        await foreach (var _ in agent.InvokeAsync("Say hello in one short sentence."))
+        {
+        }
+
+        ForceFlush();
+
+        var chatSpan = ChatSpans().FirstOrDefault();
+        chatSpan.Should().NotBeNull("a chat inference span should be emitted");
+
+        var input = chatSpan!.GetTagItem("gen_ai.input.messages") as string;
+        var output = chatSpan.GetTagItem("gen_ai.output.messages") as string;
+
+        input.Should().NotBeNullOrEmpty("chat span should record input messages");
+        input!.TrimStart().Should().StartWith("[", "input messages should be a JSON array per OTel spec");
+        output.Should().NotBeNullOrEmpty("chat span should record output messages");
+        output!.TrimStart().Should().StartWith("[", "output messages should be a JSON array per OTel spec");
+    }
+
+    #region Helpers
+
+    private sealed class WeatherPlugin
+    {
+        [KernelFunction]
+        [Description("Get the current weather for a given location.")]
+        public string GetWeather([Description("The city name to check weather for.")] string location)
+            => $"The weather in {location} is sunny with a high of 22C.";
+    }
+
+    private static ChatCompletionAgent CreateAgentWithWeatherTool()
+    {
+        var kernelBuilder = Kernel.CreateBuilder();
+        kernelBuilder.AddAzureOpenAIChatCompletion(Deployment!, Endpoint!, ApiKey!);
+        kernelBuilder.Plugins.AddFromObject(new WeatherPlugin(), "Weather");
+        var kernel = kernelBuilder.Build();
+
+        return new ChatCompletionAgent
+        {
+            Name = "WeatherAgent",
+            Instructions = "You are a helpful weather assistant. Always use the GetWeather function when asked about weather.",
+            Kernel = kernel,
+            Arguments = new KernelArguments(new PromptExecutionSettings
+            {
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+            }),
+        };
+    }
+
+    private static ChatCompletionAgent CreateAgentWithoutTools()
+    {
+        var kernelBuilder = Kernel.CreateBuilder();
+        kernelBuilder.AddAzureOpenAIChatCompletion(Deployment!, Endpoint!, ApiKey!);
+        var kernel = kernelBuilder.Build();
+
+        return new ChatCompletionAgent
+        {
+            Name = "Assistant",
+            Instructions = "You are a helpful assistant. Reply in one sentence.",
+            Kernel = kernel,
+        };
+    }
+
+    private List<Activity> SpansWithOperation(string operation) =>
+        _exportedActivities
+            .Where(a => string.Equals(a.GetTagItem("gen_ai.operation.name") as string, operation, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+    // The SemanticKernelSpanProcessor normalizes the SK "chat.completions"/"chat" operation to
+    // InferenceOperationType.Chat.ToString() ("Chat"), so match case-insensitively.
+    private List<Activity> ChatSpans() => SpansWithOperation("chat");
+
+    private void ForceFlush()
+    {
+        var tracerProvider = _serviceProvider?.GetService<TracerProvider>();
+        tracerProvider?.ForceFlush();
+    }
+
+    private void DumpAllActivities(string label)
+    {
+        Console.WriteLine($"\n=== {label}: All captured activities ({_exportedActivities.Count}) ===");
+        foreach (var act in _exportedActivities)
+        {
+            var op = act.GetTagItem("gen_ai.operation.name");
+            var parent = act.ParentId ?? "(root)";
+            Console.WriteLine($"  [{act.Source.Name}] {act.DisplayName} | op={op} | parent={parent}");
+        }
+        Console.WriteLine("===\n");
+    }
+
+    private static void SkipIfNoCredentials()
+    {
+        if (!HasCredentials)
+        {
+            Assert.Inconclusive(
+                "Skipped: set AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, AZURE_OPENAI_DEPLOYMENT env vars to run.");
+        }
+    }
+
+    #endregion
+}

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Extensions/SemanticKernelAutoInstrumentationTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Extensions/SemanticKernelAutoInstrumentationTests.cs
@@ -175,7 +175,7 @@ public class SemanticKernelAutoInstrumentationTests
             Kernel = kernel,
             Arguments = new KernelArguments(new PromptExecutionSettings
             {
-                FunctionChoiceBehavior = FunctionChoiceBehavior.Auto(),
+                FunctionChoiceBehavior = FunctionChoiceBehavior.Required(),
             }),
         };
     }

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Microsoft.OpenTelemetry.Agent365.Tests.csproj
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Microsoft.OpenTelemetry.Agent365.Tests.csproj
@@ -38,6 +38,9 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.Agents.Builder" />
     <PackageReference Include="Azure.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Agents.AI" />
+    <PackageReference Include="Microsoft.SemanticKernel" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" />
     <PackageReference Include="Microsoft.Extensions.AI" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
     <PackageReference Include="Microsoft.Extensions.Logging" />


### PR DESCRIPTION
## Summary
Agent Framework delegates LLM calls to the underlying `IChatClient`, which emits the `chat` (inference) span on the default **`Experimental.Microsoft.Extensions.AI`** source when instrumented with `.UseOpenTelemetry()`. Previously the distro did not subscribe to this source, so only `invoke_agent` + `execute_tool` were collected and the inference span was dropped.

This PR registers the `Experimental.Microsoft.Extensions.AI` source (and meter) in `UseAgentFramework()` so all three Agent 365 spans are captured.

## Changes
- `AgentFrameworkConstants`: add `MicrosoftExtensionsAISource` constant.
- `AgentFrameworkOpenTelemetryBuilderExtensions`: add the source to tracing (wired into `AgentFrameworkSpanProcessor`) and the meter to metrics.
- Demo `Program.cs`: instrument the underlying chat client so the example emits all three spans.
- Tests: add **Semantic Kernel auto-instrumentation integration tests** validating all three spans are captured via the public `UseMicrosoftOpenTelemetry` path; add required SK/Agents test packages.

## Testing
- Full suite: 435 passed, 6 skipped (integration tests skip without Azure OpenAI creds).
- SK integration tests run live: 3/3 passed, all three span types captured.