### PR TITLE
Make invoke_agent span OTel GenAI v1.42 compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.6 - 2026-06-16
+
+- Make the `invoke_agent` span compliant with OpenTelemetry GenAI semantic conventions v1.42: add request/response GenAI attributes (`gen_ai.request.*`, `gen_ai.data_source.id`, `gen_ai.output.type`, `gen_ai.system_instructions`, `gen_ai.response.finish_reasons`, `gen_ai.usage.*`) via reusable `GenAiRequestParameters`/`GenAiResponseParameters`, and emit `gen_ai.provider.name` on all GenAI spans. Token usage is now emitted as integers and `gen_ai.response.finish_reasons` as a string array across all spans ([#120](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/120))
+
 ## 1.0.5 - 2026-06-12
 
 - Bootstrap SDK Stats eagerly in `UseMicrosoftOpenTelemetry` so Attach + Feature SDK Stats are reported when the Azure Monitor exporter is not selected (OTLP-only, Console-only, Agent365-only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Make the `invoke_agent` span compliant with OpenTelemetry GenAI semantic conventions v1.42: add request/response GenAI attributes (`gen_ai.request.*`, `gen_ai.data_source.id`, `gen_ai.output.type`, `gen_ai.system_instructions`, `gen_ai.response.finish_reasons`, `gen_ai.usage.*`) via reusable `GenAiRequestParameters`/`GenAiResponseParameters`, and emit `gen_ai.provider.name` on all GenAI spans. Token usage is now emitted as integers and `gen_ai.response.finish_reasons` as a string array across all spans ([#120](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/120))
+- Make the `invoke_agent` span compliant with OpenTelemetry GenAI semantic conventions v1.42: add request/response GenAI attributes (`gen_ai.request.*`, `gen_ai.data_source.id`, `gen_ai.output.type`, `gen_ai.system_instructions`, `gen_ai.response.finish_reasons`, `gen_ai.usage.*`) via reusable `GenAiRequestParameters`/`GenAiResponseParameters`, and emit `gen_ai.provider.name` on spans that carry agent details (e.g. `invoke_agent`, inference). Token usage is now emitted as integers and `gen_ai.response.finish_reasons` as a string array across all spans ([#120](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/120))
 
 ## 1.0.5 - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.6 - 2026-06-16
+## Unreleased
 
 - Make the `invoke_agent` span compliant with OpenTelemetry GenAI semantic conventions v1.42: add request/response GenAI attributes (`gen_ai.request.*`, `gen_ai.data_source.id`, `gen_ai.output.type`, `gen_ai.system_instructions`, `gen_ai.response.finish_reasons`, `gen_ai.usage.*`) via reusable `GenAiRequestParameters`/`GenAiResponseParameters`, and emit `gen_ai.provider.name` on all GenAI spans. Token usage is now emitted as integers and `gen_ai.response.finish_reasons` as a string array across all spans ([#120](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/120))
 

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -145,6 +145,7 @@ Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParam
 override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.Equals(object? obj) -> bool
 override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.GetHashCode() -> int
 *REMOVED*Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.InvokeAgentScopeDetails(System.Uri? endpoint = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.InvokeAgentScopeDetails(System.Uri? endpoint) -> void
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.InvokeAgentScopeDetails(System.Uri? endpoint = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters? requestParameters = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters? responseParameters = null) -> void
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.RequestParameters.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters?
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.ResponseParameters.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters?

--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -115,3 +115,37 @@ Microsoft.Agents.A365.Observability.Runtime.Etw.IA365EtwLogger<T>.LogApplyGuardr
 Microsoft.Agents.A365.Observability.Runtime.Etw.A365EtwLogger<T>.LogApplyGuardrail(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GuardrailDetails! guardrailDetails, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.AgentDetails! agentDetails, string! conversationId, string! parentSpanId, System.DateTimeOffset? startTime = null, System.DateTimeOffset? endTime = null, string? spanId = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.Channel? channel = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.CallerDetails? callerDetails = null, string? traceId = null) -> void
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.OpenTelemetryScope.AddEvent(System.Diagnostics.ActivityEvent activityEvent) -> void
 static Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders.BaseDataBuilder<T>.AddSdkAttributes(System.Collections.Generic.IDictionary<string!, object?>! attributes) -> void
+static Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders.BaseDataBuilder<T>.AddRequestParameters(System.Collections.Generic.IDictionary<string!, object?>! attributes, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters? requestParameters) -> void
+static Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders.BaseDataBuilder<T>.AddResponseParameters(System.Collections.Generic.IDictionary<string!, object?>! attributes, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters? responseParameters) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.GenAiRequestParameters(string? model = null, int? seed = null, int? choiceCount = null, double? frequencyPenalty = null, int? maxTokens = null, double? presencePenalty = null, string![]? stopSequences = null, double? temperature = null, double? topP = null, string? dataSourceId = null, string? outputType = null, string? systemInstructions = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.Model.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.Seed.get -> int?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.ChoiceCount.get -> int?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.FrequencyPenalty.get -> double?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.MaxTokens.get -> int?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.PresencePenalty.get -> double?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.StopSequences.get -> string![]?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.Temperature.get -> double?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.TopP.get -> double?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.DataSourceId.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.OutputType.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.SystemInstructions.get -> string?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.Equals(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters? other) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.Equals(object? obj) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters.GetHashCode() -> int
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.GenAiResponseParameters(string![]? finishReasons = null, int? inputTokens = null, int? outputTokens = null, int? cacheCreationInputTokens = null, int? cacheReadInputTokens = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.FinishReasons.get -> string![]?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.InputTokens.get -> int?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.OutputTokens.get -> int?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.CacheCreationInputTokens.get -> int?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.CacheReadInputTokens.get -> int?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.Equals(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters? other) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.Equals(object? obj) -> bool
+override Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters.GetHashCode() -> int
+*REMOVED*Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.InvokeAgentScopeDetails(System.Uri? endpoint = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.InvokeAgentScopeDetails(System.Uri? endpoint = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters? requestParameters = null, Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters? responseParameters = null) -> void
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.RequestParameters.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.ResponseParameters.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters?
+Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.InvokeAgentScope.RecordResponseParameters(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters! responseParameters) -> void

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/BaseDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/BaseDataBuilder.cs
@@ -163,9 +163,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
             AddIfNotNull(
                 attributes,
                 OpenTelemetryConstants.GenAiResponseFinishReasonsKey,
-                responseParameters.FinishReasons != null ? string.Join(",", responseParameters.FinishReasons) : null);
-            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageInputTokensKey, responseParameters.InputTokens?.ToString());
-            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageOutputTokensKey, responseParameters.OutputTokens?.ToString());
+                responseParameters.FinishReasons);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageInputTokensKey, responseParameters.InputTokens);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageOutputTokensKey, responseParameters.OutputTokens);
             AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageCacheCreationInputTokensKey, responseParameters.CacheCreationInputTokens);
             AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageCacheReadInputTokensKey, responseParameters.CacheReadInputTokens);
         }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/BaseDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/BaseDataBuilder.cs
@@ -57,7 +57,20 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
             OpenTelemetryConstants.GenAiUsageInputTokensKey,
             OpenTelemetryConstants.GenAiUsageOutputTokensKey,
             OpenTelemetryConstants.GenAiResponseFinishReasonsKey,
-            OpenTelemetryConstants.GenAiAgentThoughtProcessKey
+            OpenTelemetryConstants.GenAiAgentThoughtProcessKey,
+            OpenTelemetryConstants.GenAiDataSourceIdKey,
+            OpenTelemetryConstants.GenAiOutputTypeKey,
+            OpenTelemetryConstants.GenAiRequestChoiceCountKey,
+            OpenTelemetryConstants.GenAiRequestSeedKey,
+            OpenTelemetryConstants.GenAiRequestFrequencyPenaltyKey,
+            OpenTelemetryConstants.GenAiRequestMaxTokensKey,
+            OpenTelemetryConstants.GenAiRequestPresencePenaltyKey,
+            OpenTelemetryConstants.GenAiRequestStopSequencesKey,
+            OpenTelemetryConstants.GenAiRequestTemperatureKey,
+            OpenTelemetryConstants.GenAiRequestTopPKey,
+            OpenTelemetryConstants.GenAiSystemInstructionsKey,
+            OpenTelemetryConstants.GenAiUsageCacheCreationInputTokensKey,
+            OpenTelemetryConstants.GenAiUsageCacheReadInputTokensKey
         };
 
         /// <summary>
@@ -117,6 +130,44 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
             {
                 AddIfNotNull(attributes, OpenTelemetryConstants.ServerPortKey, endpoint.Port.ToString());
             }
+        }
+
+        /// <summary>
+        /// Adds request-side GenAI parameters to the attributes dictionary.
+        /// </summary>
+        protected static void AddRequestParameters(IDictionary<string, object?> attributes, GenAiRequestParameters? requestParameters)
+        {
+            if (requestParameters == null) return;
+
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiRequestModelKey, requestParameters.Model);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiRequestSeedKey, requestParameters.Seed);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiRequestChoiceCountKey, requestParameters.ChoiceCount);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiRequestFrequencyPenaltyKey, requestParameters.FrequencyPenalty);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiRequestMaxTokensKey, requestParameters.MaxTokens);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiRequestPresencePenaltyKey, requestParameters.PresencePenalty);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiRequestStopSequencesKey, requestParameters.StopSequences);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiRequestTemperatureKey, requestParameters.Temperature);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiRequestTopPKey, requestParameters.TopP);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiDataSourceIdKey, requestParameters.DataSourceId);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiOutputTypeKey, requestParameters.OutputType);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiSystemInstructionsKey, requestParameters.SystemInstructions);
+        }
+
+        /// <summary>
+        /// Adds response-side GenAI parameters (finish reasons and token usage) to the attributes dictionary.
+        /// </summary>
+        protected static void AddResponseParameters(IDictionary<string, object?> attributes, GenAiResponseParameters? responseParameters)
+        {
+            if (responseParameters == null) return;
+
+            AddIfNotNull(
+                attributes,
+                OpenTelemetryConstants.GenAiResponseFinishReasonsKey,
+                responseParameters.FinishReasons != null ? string.Join(",", responseParameters.FinishReasons) : null);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageInputTokensKey, responseParameters.InputTokens?.ToString());
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageOutputTokensKey, responseParameters.OutputTokens?.ToString());
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageCacheCreationInputTokensKey, responseParameters.CacheCreationInputTokens);
+            AddIfNotNull(attributes, OpenTelemetryConstants.GenAiUsageCacheReadInputTokensKey, responseParameters.CacheReadInputTokens);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ExecuteInferenceDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/ExecuteInferenceDataBuilder.cs
@@ -112,9 +112,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
             AddIfNotNull(attributes, GenAiOperationNameKey, inferenceCallDetails.OperationName.ToString().ToLowerInvariant());
             AddIfNotNull(attributes, GenAiRequestModelKey, inferenceCallDetails.Model);
             AddIfNotNull(attributes, GenAiProviderNameKey, inferenceCallDetails.ProviderName);
-            AddIfNotNull(attributes, GenAiUsageInputTokensKey, inferenceCallDetails.InputTokens?.ToString());
-            AddIfNotNull(attributes, GenAiUsageOutputTokensKey, inferenceCallDetails.OutputTokens?.ToString());
-            AddIfNotNull(attributes, GenAiResponseFinishReasonsKey, inferenceCallDetails.FinishReasons != null ? string.Join(",", inferenceCallDetails.FinishReasons) : null);
+            AddIfNotNull(attributes, GenAiUsageInputTokensKey, inferenceCallDetails.InputTokens);
+            AddIfNotNull(attributes, GenAiUsageOutputTokensKey, inferenceCallDetails.OutputTokens);
+            AddIfNotNull(attributes, GenAiResponseFinishReasonsKey, inferenceCallDetails.FinishReasons);
         }
     }
 }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/InvokeAgentDataBuilder.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/DTOs/Builders/InvokeAgentDataBuilder.cs
@@ -104,6 +104,10 @@ namespace Microsoft.Agents.A365.Observability.Runtime.DTOs.Builders
             // Add endpoint details
             AddEndpointDetails(attributes, invokeAgentScopeDetails.Endpoint);
 
+            // Add request/response GenAI parameters (model, sampling, usage, finish reasons)
+            AddRequestParameters(attributes, invokeAgentScopeDetails.RequestParameters);
+            AddResponseParameters(attributes, invokeAgentScopeDetails.ResponseParameters);
+
             // Add request details
             AddRequestDetails(attributes, request);
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GenAiRequestParameters.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GenAiRequestParameters.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma warning disable CS8604
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
+{
+    /// <summary>
+    /// Reusable container for request-side GenAI parameters defined by the
+    /// OpenTelemetry GenAI semantic conventions. Can be supplied to any GenAI
+    /// span (e.g. invoke_agent, chat) that accepts request parameters.
+    /// </summary>
+    public sealed class GenAiRequestParameters : IEquatable<GenAiRequestParameters>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenAiRequestParameters"/> class.
+        /// </summary>
+        /// <param name="model">The name of the GenAI model the request is being made to (e.g. "gpt-4").</param>
+        /// <param name="seed">Requests with the same seed value are more likely to return the same result.</param>
+        /// <param name="choiceCount">The target number of candidate completions to return.</param>
+        /// <param name="frequencyPenalty">The frequency penalty setting for the request.</param>
+        /// <param name="maxTokens">The maximum number of tokens the model generates for the request.</param>
+        /// <param name="presencePenalty">The presence penalty setting for the request.</param>
+        /// <param name="stopSequences">List of sequences that the model will use to stop generating further tokens.</param>
+        /// <param name="temperature">The temperature setting for the request.</param>
+        /// <param name="topP">The top_p sampling setting for the request.</param>
+        /// <param name="dataSourceId">The data source identifier used for grounding/retrieval (e.g. a knowledge base or index id).</param>
+        /// <param name="outputType">The content type requested by the client (e.g. "text", "json", "image").</param>
+        /// <param name="systemInstructions">The system/developer instructions provided to the model.</param>
+        public GenAiRequestParameters(
+            string? model = null,
+            int? seed = null,
+            int? choiceCount = null,
+            double? frequencyPenalty = null,
+            int? maxTokens = null,
+            double? presencePenalty = null,
+            string[]? stopSequences = null,
+            double? temperature = null,
+            double? topP = null,
+            string? dataSourceId = null,
+            string? outputType = null,
+            string? systemInstructions = null)
+        {
+            Model = model;
+            Seed = seed;
+            ChoiceCount = choiceCount;
+            FrequencyPenalty = frequencyPenalty;
+            MaxTokens = maxTokens;
+            PresencePenalty = presencePenalty;
+            StopSequences = stopSequences;
+            Temperature = temperature;
+            TopP = topP;
+            DataSourceId = dataSourceId;
+            OutputType = outputType;
+            SystemInstructions = systemInstructions;
+        }
+
+        /// <summary>
+        /// Gets the name of the GenAI model the request is being made to.
+        /// </summary>
+        public string? Model { get; }
+
+        /// <summary>
+        /// Gets the request seed used to improve result reproducibility.
+        /// </summary>
+        public int? Seed { get; }
+
+        /// <summary>
+        /// Gets the target number of candidate completions to return.
+        /// </summary>
+        public int? ChoiceCount { get; }
+
+        /// <summary>
+        /// Gets the frequency penalty setting for the request.
+        /// </summary>
+        public double? FrequencyPenalty { get; }
+
+        /// <summary>
+        /// Gets the maximum number of tokens the model generates for the request.
+        /// </summary>
+        public int? MaxTokens { get; }
+
+        /// <summary>
+        /// Gets the presence penalty setting for the request.
+        /// </summary>
+        public double? PresencePenalty { get; }
+
+        /// <summary>
+        /// Gets the list of sequences that the model will use to stop generating further tokens.
+        /// </summary>
+        public string[]? StopSequences { get; }
+
+        /// <summary>
+        /// Gets the temperature setting for the request.
+        /// </summary>
+        public double? Temperature { get; }
+
+        /// <summary>
+        /// Gets the top_p sampling setting for the request.
+        /// </summary>
+        public double? TopP { get; }
+
+        /// <summary>
+        /// Gets the data source identifier used for grounding/retrieval.
+        /// </summary>
+        public string? DataSourceId { get; }
+
+        /// <summary>
+        /// Gets the content type requested by the client.
+        /// </summary>
+        public string? OutputType { get; }
+
+        /// <summary>
+        /// Gets the system/developer instructions provided to the model.
+        /// </summary>
+        public string? SystemInstructions { get; }
+
+        /// <inheritdoc/>
+        public bool Equals(GenAiRequestParameters? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return string.Equals(Model, other.Model, StringComparison.Ordinal) &&
+                   Seed == other.Seed &&
+                   ChoiceCount == other.ChoiceCount &&
+                   Nullable.Equals(FrequencyPenalty, other.FrequencyPenalty) &&
+                   MaxTokens == other.MaxTokens &&
+                   Nullable.Equals(PresencePenalty, other.PresencePenalty) &&
+                   EqualityComparer<string[]?>.Default.Equals(StopSequences, other.StopSequences) &&
+                   Nullable.Equals(Temperature, other.Temperature) &&
+                   Nullable.Equals(TopP, other.TopP) &&
+                   string.Equals(DataSourceId, other.DataSourceId, StringComparison.Ordinal) &&
+                   string.Equals(OutputType, other.OutputType, StringComparison.Ordinal) &&
+                   string.Equals(SystemInstructions, other.SystemInstructions, StringComparison.Ordinal);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as GenAiRequestParameters);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 31) + (Model != null ? StringComparer.Ordinal.GetHashCode(Model) : 0);
+                hash = (hash * 31) + (Seed?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (ChoiceCount?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (FrequencyPenalty?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (MaxTokens?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (PresencePenalty?.GetHashCode() ?? 0);
+                hash = (hash * 31) + EqualityComparer<string[]?>.Default.GetHashCode(StopSequences);
+                hash = (hash * 31) + (Temperature?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (TopP?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (DataSourceId != null ? StringComparer.Ordinal.GetHashCode(DataSourceId) : 0);
+                hash = (hash * 31) + (OutputType != null ? StringComparer.Ordinal.GetHashCode(OutputType) : 0);
+                hash = (hash * 31) + (SystemInstructions != null ? StringComparer.Ordinal.GetHashCode(SystemInstructions) : 0);
+                return hash;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GenAiResponseParameters.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/GenAiResponseParameters.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma warning disable CS8604
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
+{
+    /// <summary>
+    /// Reusable container for response-side GenAI parameters defined by the
+    /// OpenTelemetry GenAI semantic conventions (finish reasons and token usage).
+    /// Can be supplied to any GenAI span (e.g. invoke_agent, chat) that records a response.
+    /// </summary>
+    public sealed class GenAiResponseParameters : IEquatable<GenAiResponseParameters>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenAiResponseParameters"/> class.
+        /// </summary>
+        /// <param name="finishReasons">Array of reasons the model stopped generating tokens.</param>
+        /// <param name="inputTokens">The number of tokens used in the GenAI input (prompt).</param>
+        /// <param name="outputTokens">The number of tokens used in the GenAI response (completion).</param>
+        /// <param name="cacheCreationInputTokens">The number of input tokens written to a provider-managed cache.</param>
+        /// <param name="cacheReadInputTokens">The number of input tokens served from a provider-managed cache.</param>
+        public GenAiResponseParameters(
+            string[]? finishReasons = null,
+            int? inputTokens = null,
+            int? outputTokens = null,
+            int? cacheCreationInputTokens = null,
+            int? cacheReadInputTokens = null)
+        {
+            FinishReasons = finishReasons;
+            InputTokens = inputTokens;
+            OutputTokens = outputTokens;
+            CacheCreationInputTokens = cacheCreationInputTokens;
+            CacheReadInputTokens = cacheReadInputTokens;
+        }
+
+        /// <summary>
+        /// Gets the array of reasons the model stopped generating tokens.
+        /// </summary>
+        public string[]? FinishReasons { get; }
+
+        /// <summary>
+        /// Gets the number of tokens used in the GenAI input (prompt).
+        /// </summary>
+        public int? InputTokens { get; }
+
+        /// <summary>
+        /// Gets the number of tokens used in the GenAI response (completion).
+        /// </summary>
+        public int? OutputTokens { get; }
+
+        /// <summary>
+        /// Gets the number of input tokens written to a provider-managed cache.
+        /// </summary>
+        public int? CacheCreationInputTokens { get; }
+
+        /// <summary>
+        /// Gets the number of input tokens served from a provider-managed cache.
+        /// </summary>
+        public int? CacheReadInputTokens { get; }
+
+        /// <inheritdoc/>
+        public bool Equals(GenAiResponseParameters? other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            return EqualityComparer<string[]?>.Default.Equals(FinishReasons, other.FinishReasons) &&
+                   InputTokens == other.InputTokens &&
+                   OutputTokens == other.OutputTokens &&
+                   CacheCreationInputTokens == other.CacheCreationInputTokens &&
+                   CacheReadInputTokens == other.CacheReadInputTokens;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as GenAiResponseParameters);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 31) + EqualityComparer<string[]?>.Default.GetHashCode(FinishReasons);
+                hash = (hash * 31) + (InputTokens?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (OutputTokens?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (CacheCreationInputTokens?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (CacheReadInputTokens?.GetHashCode() ?? 0);
+                return hash;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/InvokeAgentDetails.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/InvokeAgentDetails.cs
@@ -13,6 +13,17 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
     public sealed class InvokeAgentScopeDetails : IEquatable<InvokeAgentScopeDetails>
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="InvokeAgentScopeDetails"/> class
+        /// with only an endpoint. Preserved for binary compatibility with consumers
+        /// compiled against the original single-parameter constructor.
+        /// </summary>
+        /// <param name="endpoint">Optional endpoint URI of the agent to invoke.</param>
+        public InvokeAgentScopeDetails(Uri? endpoint)
+            : this(endpoint, null, null)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="InvokeAgentScopeDetails"/> class.
         /// </summary>
         /// <param name="endpoint">Optional endpoint URI of the agent to invoke.</param>

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/InvokeAgentDetails.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Contracts/InvokeAgentDetails.cs
@@ -16,15 +16,32 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
         /// Initializes a new instance of the <see cref="InvokeAgentScopeDetails"/> class.
         /// </summary>
         /// <param name="endpoint">Optional endpoint URI of the agent to invoke.</param>
-        public InvokeAgentScopeDetails(Uri? endpoint = null)
+        /// <param name="requestParameters">Optional request-side GenAI parameters (model, sampling settings, data source, etc.).</param>
+        /// <param name="responseParameters">Optional response-side GenAI parameters (finish reasons, token usage).</param>
+        public InvokeAgentScopeDetails(
+            Uri? endpoint = null,
+            GenAiRequestParameters? requestParameters = null,
+            GenAiResponseParameters? responseParameters = null)
         {
             Endpoint = endpoint;
+            RequestParameters = requestParameters;
+            ResponseParameters = responseParameters;
         }
 
         /// <summary>
         /// The endpoint URI for the AI agent.
         /// </summary>
         public Uri? Endpoint { get; }
+
+        /// <summary>
+        /// Optional request-side GenAI parameters (model, sampling settings, data source, output type, system instructions).
+        /// </summary>
+        public GenAiRequestParameters? RequestParameters { get; }
+
+        /// <summary>
+        /// Optional response-side GenAI parameters (finish reasons and token usage).
+        /// </summary>
+        public GenAiResponseParameters? ResponseParameters { get; }
 
         /// <inheritdoc/>
         public bool Equals(InvokeAgentScopeDetails? other)
@@ -34,7 +51,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
                 return false;
             }
 
-            return EqualityComparer<Uri?>.Default.Equals(Endpoint, other.Endpoint);
+            return EqualityComparer<Uri?>.Default.Equals(Endpoint, other.Endpoint) &&
+                   EqualityComparer<GenAiRequestParameters?>.Default.Equals(RequestParameters, other.RequestParameters) &&
+                   EqualityComparer<GenAiResponseParameters?>.Default.Equals(ResponseParameters, other.ResponseParameters);
         }
 
         /// <inheritdoc/>
@@ -46,7 +65,14 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return EqualityComparer<Uri?>.Default.GetHashCode(Endpoint);
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 31) + EqualityComparer<Uri?>.Default.GetHashCode(Endpoint);
+                hash = (hash * 31) + (RequestParameters != null ? RequestParameters.GetHashCode() : 0);
+                hash = (hash * 31) + (ResponseParameters != null ? ResponseParameters.GetHashCode() : 0);
+                return hash;
+            }
         }
     }
 }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/InferenceScope.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/InferenceScope.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
             SetTagMaybe(GenAiOperationNameKey, details.OperationName.ToString());
             SetTagMaybe(GenAiRequestModelKey, details.Model);
             SetTagMaybe(GenAiProviderNameKey, details.ProviderName);
-            SetTagMaybe(GenAiUsageInputTokensKey, details.InputTokens?.ToString());
-            SetTagMaybe(GenAiUsageOutputTokensKey, details.OutputTokens?.ToString());
-            SetTagMaybe(GenAiResponseFinishReasonsKey, details.FinishReasons != null ? string.Join(",", details.FinishReasons) : null);
+            SetTagMaybe(GenAiUsageInputTokensKey, details.InputTokens);
+            SetTagMaybe(GenAiUsageOutputTokensKey, details.OutputTokens);
+            SetTagMaybe(GenAiResponseFinishReasonsKey, details.FinishReasons);
             SetTagMaybe(GenAiConversationIdKey, request?.ConversationId);
 
             if (request?.InputContent != null)
@@ -117,7 +117,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// </summary>
         public void RecordInputTokens(int inputTokens)
         {
-            SetTagMaybe(GenAiUsageInputTokensKey, inputTokens.ToString());
+            SetTagMaybe(GenAiUsageInputTokensKey, inputTokens);
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         /// </summary>
         public void RecordOutputTokens(int outputTokens)
         {
-            SetTagMaybe(GenAiUsageOutputTokensKey, outputTokens.ToString());
+            SetTagMaybe(GenAiUsageOutputTokensKey, outputTokens);
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         {
             if (finishReasons != null)
             {
-                SetTagMaybe(GenAiResponseFinishReasonsKey, string.Join(",", finishReasons));
+                SetTagMaybe(GenAiResponseFinishReasonsKey, finishReasons);
             }
         }
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/InvokeAgentScope.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/InvokeAgentScope.cs
@@ -168,9 +168,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
 
             SetTagMaybe(
                 OpenTelemetryConstants.GenAiResponseFinishReasonsKey,
-                responseParameters.FinishReasons != null ? string.Join(",", responseParameters.FinishReasons) : null);
-            SetTagMaybe(OpenTelemetryConstants.GenAiUsageInputTokensKey, responseParameters.InputTokens?.ToString());
-            SetTagMaybe(OpenTelemetryConstants.GenAiUsageOutputTokensKey, responseParameters.OutputTokens?.ToString());
+                responseParameters.FinishReasons);
+            SetTagMaybe(OpenTelemetryConstants.GenAiUsageInputTokensKey, responseParameters.InputTokens);
+            SetTagMaybe(OpenTelemetryConstants.GenAiUsageOutputTokensKey, responseParameters.OutputTokens);
             SetTagMaybe(OpenTelemetryConstants.GenAiUsageCacheCreationInputTokensKey, responseParameters.CacheCreationInputTokens);
             SetTagMaybe(OpenTelemetryConstants.GenAiUsageCacheReadInputTokensKey, responseParameters.CacheReadInputTokens);
         }

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/InvokeAgentScope.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/InvokeAgentScope.cs
@@ -85,6 +85,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
                 }
             }
 
+            SetRequestParameters(scopeDetails?.RequestParameters);
+            SetResponseParameters(scopeDetails?.ResponseParameters);
+
             // Set request metadata
             if (request?.Channel != null)
             {
@@ -124,6 +127,52 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         public void RecordResponse(string response)
         {
             this.RecordOutputMessages(messages: new string[] { response });
+        }
+
+        /// <summary>
+        /// Records response-side GenAI parameters (finish reasons and token usage) for telemetry tracking.
+        /// </summary>
+        /// <param name="responseParameters">The response parameters to record.</param>
+        public void RecordResponseParameters(GenAiResponseParameters responseParameters)
+        {
+            SetResponseParameters(responseParameters);
+        }
+
+        private void SetRequestParameters(GenAiRequestParameters? requestParameters)
+        {
+            if (requestParameters == null)
+            {
+                return;
+            }
+
+            SetTagMaybe(OpenTelemetryConstants.GenAiRequestModelKey, requestParameters.Model);
+            SetTagMaybe(OpenTelemetryConstants.GenAiRequestSeedKey, requestParameters.Seed);
+            SetTagMaybe(OpenTelemetryConstants.GenAiRequestChoiceCountKey, requestParameters.ChoiceCount);
+            SetTagMaybe(OpenTelemetryConstants.GenAiRequestFrequencyPenaltyKey, requestParameters.FrequencyPenalty);
+            SetTagMaybe(OpenTelemetryConstants.GenAiRequestMaxTokensKey, requestParameters.MaxTokens);
+            SetTagMaybe(OpenTelemetryConstants.GenAiRequestPresencePenaltyKey, requestParameters.PresencePenalty);
+            SetTagMaybe(OpenTelemetryConstants.GenAiRequestStopSequencesKey, requestParameters.StopSequences);
+            SetTagMaybe(OpenTelemetryConstants.GenAiRequestTemperatureKey, requestParameters.Temperature);
+            SetTagMaybe(OpenTelemetryConstants.GenAiRequestTopPKey, requestParameters.TopP);
+            SetTagMaybe(OpenTelemetryConstants.GenAiDataSourceIdKey, requestParameters.DataSourceId);
+            SetTagMaybe(OpenTelemetryConstants.GenAiOutputTypeKey, requestParameters.OutputType);
+            SetTagMaybe(OpenTelemetryConstants.GenAiSystemInstructionsKey, requestParameters.SystemInstructions);
+        }
+
+        private void SetResponseParameters(GenAiResponseParameters? responseParameters)
+        {
+            if (responseParameters == null)
+            {
+                return;
+            }
+
+            SetTagMaybe(
+                OpenTelemetryConstants.GenAiResponseFinishReasonsKey,
+                responseParameters.FinishReasons != null ? string.Join(",", responseParameters.FinishReasons) : null);
+            SetTagMaybe(OpenTelemetryConstants.GenAiUsageInputTokensKey, responseParameters.InputTokens?.ToString());
+            SetTagMaybe(OpenTelemetryConstants.GenAiUsageOutputTokensKey, responseParameters.OutputTokens?.ToString());
+            SetTagMaybe(OpenTelemetryConstants.GenAiUsageCacheCreationInputTokensKey, responseParameters.CacheCreationInputTokens);
+            SetTagMaybe(OpenTelemetryConstants.GenAiUsageCacheReadInputTokensKey, responseParameters.CacheReadInputTokens);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryConstants.cs
@@ -24,6 +24,23 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
         public const string GenAiRequestModelKey = "gen_ai.request.model";
         public const string GenAiResponseFinishReasonsKey = "gen_ai.response.finish_reasons";
 
+        // Request parameters (GenAI semantic conventions)
+        public const string GenAiDataSourceIdKey = "gen_ai.data_source.id";
+        public const string GenAiOutputTypeKey = "gen_ai.output.type";
+        public const string GenAiRequestChoiceCountKey = "gen_ai.request.choice.count";
+        public const string GenAiRequestSeedKey = "gen_ai.request.seed";
+        public const string GenAiRequestFrequencyPenaltyKey = "gen_ai.request.frequency_penalty";
+        public const string GenAiRequestMaxTokensKey = "gen_ai.request.max_tokens";
+        public const string GenAiRequestPresencePenaltyKey = "gen_ai.request.presence_penalty";
+        public const string GenAiRequestStopSequencesKey = "gen_ai.request.stop_sequences";
+        public const string GenAiRequestTemperatureKey = "gen_ai.request.temperature";
+        public const string GenAiRequestTopPKey = "gen_ai.request.top_p";
+        public const string GenAiSystemInstructionsKey = "gen_ai.system_instructions";
+
+        // Usage / response parameters (GenAI semantic conventions)
+        public const string GenAiUsageCacheCreationInputTokensKey = "gen_ai.usage.cache_creation.input_tokens";
+        public const string GenAiUsageCacheReadInputTokensKey = "gen_ai.usage.cache_read.input_tokens";
+
         public const string GenAiConversationIdKey = "gen_ai.conversation.id";
         public const string GenAiConversationItemLinkKey = "microsoft.conversation.item.link";
         public const string GenAiUsageInputTokensKey = "gen_ai.usage.input_tokens";

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Scopes/OpenTelemetryScope.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes
                 SetTagMaybe(GenAiAgentNameKey, agentDetails.AgentName);
                 SetTagMaybe(GenAiAgentDescriptionKey, agentDetails.AgentDescription);
                 SetTagMaybe(GenAiAgentVersionKey, agentDetails.AgentVersion);
+                SetTagMaybe(GenAiProviderNameKey, agentDetails.ProviderName);
                 SetTagMaybe(AgentAUIDKey, agentDetails.AgenticUserId);
                 SetTagMaybe(AgentEmailKey, agentDetails.AgenticUserEmail);
                 SetTagMaybe(AgentBlueprintIdKey, agentDetails.AgentBlueprintId);

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Agent365ExporterAsyncE2ETests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Agent365ExporterAsyncE2ETests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.Net;
 using System.Text.Json;
+using System.Linq;
 
 namespace Microsoft.Agents.A365.Observability.Runtime.Tests.IntegrationTests
 {
@@ -246,7 +247,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.IntegrationTests
             this.GetAttribute(attributes, "gen_ai.provider.name").Should().Be(inferenceDetails.ProviderName);
             this.GetAttribute(attributes, "gen_ai.usage.input_tokens").Should().Be("42");
             this.GetAttribute(attributes, "gen_ai.usage.output_tokens").Should().Be("84");
-            this.GetAttribute(attributes, "gen_ai.response.finish_reasons").Should().Be("stop,length");
+            attributes.GetProperty("gen_ai.response.finish_reasons").EnumerateArray()
+                .Select(e => e.GetString()).Should().BeEquivalentTo(new[] { "stop", "length" });
             var inputMessages = this.GetAttribute(attributes, "gen_ai.input.messages");
             inputMessages.Should().StartWith("[");
             inputMessages.Should().Contain("Hello").And.Contain("World");

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Agent365ExporterE2ETests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Integration/Agent365ExporterE2ETests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.Net;
 using System.Text.Json;
+using System.Linq;
 
 namespace Microsoft.Agents.A365.Observability.Runtime.Tests.IntegrationTests
 {
@@ -292,7 +293,8 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.IntegrationTests
             this.GetAttribute(attributes, "gen_ai.provider.name").Should().Be(inferenceDetails.ProviderName);
             this.GetAttribute(attributes, "gen_ai.usage.input_tokens").Should().Be("42");
             this.GetAttribute(attributes, "gen_ai.usage.output_tokens").Should().Be("84");
-            this.GetAttribute(attributes, "gen_ai.response.finish_reasons").Should().Be("stop,length");
+            attributes.GetProperty("gen_ai.response.finish_reasons").EnumerateArray()
+                .Select(e => e.GetString()).Should().BeEquivalentTo(new[] { "stop", "length" });
             var inputMessages = this.GetAttribute(attributes, "gen_ai.input.messages");
             inputMessages.Should().StartWith("[");
             inputMessages.Should().Contain("Hello").And.Contain("World");

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/DTOs/Builders/ExecuteInferenceDataBuilderTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/DTOs/Builders/ExecuteInferenceDataBuilderTests.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.DTOs.Builders
             var data = ExecuteInferenceDataBuilder.Build(details, agent, conversationId);
 
             // Assert
-            data.Attributes.Should().ContainKey(OpenTelemetryConstants.GenAiUsageInputTokensKey).WhoseValue.Should().Be("10");
-            data.Attributes.Should().ContainKey(OpenTelemetryConstants.GenAiUsageOutputTokensKey).WhoseValue.Should().Be("20");
-            data.Attributes.Should().ContainKey(OpenTelemetryConstants.GenAiResponseFinishReasonsKey).WhoseValue.Should().Be("stop");
+            data.Attributes.Should().ContainKey(OpenTelemetryConstants.GenAiUsageInputTokensKey).WhoseValue.Should().Be(10);
+            data.Attributes.Should().ContainKey(OpenTelemetryConstants.GenAiUsageOutputTokensKey).WhoseValue.Should().Be(20);
+            data.Attributes.Should().ContainKey(OpenTelemetryConstants.GenAiResponseFinishReasonsKey).WhoseValue.Should().BeEquivalentTo(new[] { "stop" });
             data.Attributes.Should().ContainKey(OpenTelemetryConstants.GenAiConversationIdKey).WhoseValue.Should().Be(conversationId);
         }
 

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/DTOs/Builders/InvokeAgentDataBuilderTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/DTOs/Builders/InvokeAgentDataBuilderTests.cs
@@ -588,9 +588,9 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.DTOs.Builders
             var telemetry = InvokeAgentDataBuilder.Build(scopeDetails, agentDetails, "conv-resp");
 
             // Assert
-            telemetry.Attributes[OpenTelemetryConstants.GenAiResponseFinishReasonsKey].Should().Be("stop,length");
-            telemetry.Attributes[OpenTelemetryConstants.GenAiUsageInputTokensKey].Should().Be("100");
-            telemetry.Attributes[OpenTelemetryConstants.GenAiUsageOutputTokensKey].Should().Be("180");
+            telemetry.Attributes[OpenTelemetryConstants.GenAiResponseFinishReasonsKey].Should().BeEquivalentTo(new[] { "stop", "length" });
+            telemetry.Attributes[OpenTelemetryConstants.GenAiUsageInputTokensKey].Should().Be(100);
+            telemetry.Attributes[OpenTelemetryConstants.GenAiUsageOutputTokensKey].Should().Be(180);
             telemetry.Attributes[OpenTelemetryConstants.GenAiUsageCacheCreationInputTokensKey].Should().Be(25);
             telemetry.Attributes[OpenTelemetryConstants.GenAiUsageCacheReadInputTokensKey].Should().Be(50);
         }

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/DTOs/Builders/InvokeAgentDataBuilderTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/DTOs/Builders/InvokeAgentDataBuilderTests.cs
@@ -528,5 +528,102 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tests.DTOs.Builders
             // Assert
             data.SpanKind.Should().Be(SpanKindConstants.Server);
         }
+
+        [TestMethod]
+        public void Build_IncludesRequestParameters_WhenProvided()
+        {
+            // Arrange
+            var requestParameters = new GenAiRequestParameters(
+                model: "gpt-4",
+                seed: 42,
+                choiceCount: 3,
+                frequencyPenalty: 0.5,
+                maxTokens: 256,
+                presencePenalty: 0.25,
+                stopSequences: new[] { "STOP", "END" },
+                temperature: 0.7,
+                topP: 0.9,
+                dataSourceId: "ds-001",
+                outputType: "json",
+                systemInstructions: "Be concise.");
+            var scopeDetails = new InvokeAgentScopeDetails(
+                endpoint: new Uri("https://example.com"),
+                requestParameters: requestParameters);
+            var agentDetails = new AgentDetails("agent-123", "TestAgent");
+
+            // Act
+            var telemetry = InvokeAgentDataBuilder.Build(scopeDetails, agentDetails, "conv-req");
+
+            // Assert
+            telemetry.Attributes[OpenTelemetryConstants.GenAiRequestModelKey].Should().Be("gpt-4");
+            telemetry.Attributes[OpenTelemetryConstants.GenAiRequestSeedKey].Should().Be(42);
+            telemetry.Attributes[OpenTelemetryConstants.GenAiRequestChoiceCountKey].Should().Be(3);
+            telemetry.Attributes[OpenTelemetryConstants.GenAiRequestFrequencyPenaltyKey].Should().Be(0.5);
+            telemetry.Attributes[OpenTelemetryConstants.GenAiRequestMaxTokensKey].Should().Be(256);
+            telemetry.Attributes[OpenTelemetryConstants.GenAiRequestPresencePenaltyKey].Should().Be(0.25);
+            telemetry.Attributes[OpenTelemetryConstants.GenAiRequestStopSequencesKey].Should().BeEquivalentTo(new[] { "STOP", "END" });
+            telemetry.Attributes[OpenTelemetryConstants.GenAiRequestTemperatureKey].Should().Be(0.7);
+            telemetry.Attributes[OpenTelemetryConstants.GenAiRequestTopPKey].Should().Be(0.9);
+            telemetry.Attributes[OpenTelemetryConstants.GenAiDataSourceIdKey].Should().Be("ds-001");
+            telemetry.Attributes[OpenTelemetryConstants.GenAiOutputTypeKey].Should().Be("json");
+            telemetry.Attributes[OpenTelemetryConstants.GenAiSystemInstructionsKey].Should().Be("Be concise.");
+        }
+
+        [TestMethod]
+        public void Build_IncludesResponseParameters_WhenProvided()
+        {
+            // Arrange
+            var responseParameters = new GenAiResponseParameters(
+                finishReasons: new[] { "stop", "length" },
+                inputTokens: 100,
+                outputTokens: 180,
+                cacheCreationInputTokens: 25,
+                cacheReadInputTokens: 50);
+            var scopeDetails = new InvokeAgentScopeDetails(
+                endpoint: new Uri("https://example.com"),
+                responseParameters: responseParameters);
+            var agentDetails = new AgentDetails("agent-123", "TestAgent");
+
+            // Act
+            var telemetry = InvokeAgentDataBuilder.Build(scopeDetails, agentDetails, "conv-resp");
+
+            // Assert
+            telemetry.Attributes[OpenTelemetryConstants.GenAiResponseFinishReasonsKey].Should().Be("stop,length");
+            telemetry.Attributes[OpenTelemetryConstants.GenAiUsageInputTokensKey].Should().Be("100");
+            telemetry.Attributes[OpenTelemetryConstants.GenAiUsageOutputTokensKey].Should().Be("180");
+            telemetry.Attributes[OpenTelemetryConstants.GenAiUsageCacheCreationInputTokensKey].Should().Be(25);
+            telemetry.Attributes[OpenTelemetryConstants.GenAiUsageCacheReadInputTokensKey].Should().Be(50);
+        }
+
+        [TestMethod]
+        public void Build_IncludesProviderName_WhenAgentProviderSet()
+        {
+            // Arrange
+            var agentDetails = new AgentDetails(agentId: "agent-123", providerName: "openai");
+            var scopeDetails = new InvokeAgentScopeDetails(endpoint: new Uri("https://example.com"));
+
+            // Act
+            var telemetry = InvokeAgentDataBuilder.Build(scopeDetails, agentDetails, "conv-prov");
+
+            // Assert
+            telemetry.Attributes[OpenTelemetryConstants.GenAiProviderNameKey].Should().Be("openai");
+        }
+
+        [TestMethod]
+        public void Build_OmitsRequestAndResponseParameters_WhenAbsent()
+        {
+            // Arrange
+            var scopeDetails = new InvokeAgentScopeDetails(endpoint: new Uri("https://example.com"));
+            var agentDetails = new AgentDetails("agent-123", "TestAgent");
+
+            // Act
+            var telemetry = InvokeAgentDataBuilder.Build(scopeDetails, agentDetails, "conv-none");
+
+            // Assert
+            telemetry.Attributes.Should().NotContainKey(OpenTelemetryConstants.GenAiRequestModelKey);
+            telemetry.Attributes.Should().NotContainKey(OpenTelemetryConstants.GenAiRequestTemperatureKey);
+            telemetry.Attributes.Should().NotContainKey(OpenTelemetryConstants.GenAiResponseFinishReasonsKey);
+            telemetry.Attributes.Should().NotContainKey(OpenTelemetryConstants.GenAiUsageInputTokensKey);
+        }
     }
 }

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/InferenceScopeTest.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/InferenceScopeTest.cs
@@ -32,9 +32,9 @@ public sealed class InferenceScopeTest : ActivityTest
         activity.ShouldHaveTag(OpenTelemetryConstants.GenAiOperationNameKey, details.OperationName.ToString());
         activity.ShouldHaveTag(OpenTelemetryConstants.GenAiRequestModelKey, details.Model);
         activity.ShouldHaveTag(OpenTelemetryConstants.GenAiProviderNameKey, details.ProviderName);
-        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiUsageInputTokensKey, details.InputTokens!.Value.ToString());
-        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiUsageOutputTokensKey, details.OutputTokens!.Value.ToString());
-        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiResponseFinishReasonsKey, string.Join(",", details.FinishReasons!));
+        activity.GetTagItem(OpenTelemetryConstants.GenAiUsageInputTokensKey).Should().Be(details.InputTokens!.Value);
+        activity.GetTagItem(OpenTelemetryConstants.GenAiUsageOutputTokensKey).Should().Be(details.OutputTokens!.Value);
+        activity.GetTagItem(OpenTelemetryConstants.GenAiResponseFinishReasonsKey).Should().BeEquivalentTo(details.FinishReasons!);
     }
 
     [TestMethod]
@@ -50,7 +50,7 @@ public sealed class InferenceScopeTest : ActivityTest
             using var scope = InferenceScope.Start(Util.GetDefaultRequest(), details, Util.GetAgentDetails())!;
             scope.RecordInputTokens(inputTokens);
         });
-        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiUsageInputTokensKey, inputTokens.ToString());
+        activity.GetTagItem(OpenTelemetryConstants.GenAiUsageInputTokensKey).Should().Be(inputTokens);
     }
 
     [TestMethod]
@@ -66,7 +66,7 @@ public sealed class InferenceScopeTest : ActivityTest
             using var scope = InferenceScope.Start(Util.GetDefaultRequest(), details, Util.GetAgentDetails())!;
             scope.RecordOutputTokens(outputTokens);
         });
-        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiUsageOutputTokensKey, outputTokens.ToString());
+        activity.GetTagItem(OpenTelemetryConstants.GenAiUsageOutputTokensKey).Should().Be(outputTokens);
     }
 
     [TestMethod]
@@ -83,7 +83,7 @@ public sealed class InferenceScopeTest : ActivityTest
             using var scope = InferenceScope.Start(Util.GetDefaultRequest(), details, Util.GetAgentDetails())!;
             scope.RecordFinishReasons(finishReasons);
         });
-        activity.ShouldHaveTag(OpenTelemetryConstants.GenAiResponseFinishReasonsKey, string.Join(",", finishReasons));
+        activity.GetTagItem(OpenTelemetryConstants.GenAiResponseFinishReasonsKey).Should().BeEquivalentTo(finishReasons);
     }
 
     [TestMethod]

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/InvokeAgentScopeTest.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/InvokeAgentScopeTest.cs
@@ -379,4 +379,128 @@ public sealed class InvokeAgentScopeTest : ActivityTest
             activity.ShouldHaveTag(ServerPortKey, serverPort);
         }
     }
+
+    [TestMethod]
+    public void ProviderName_IsSetOnInvokeAgentSpan_WhenProvided()
+    {
+        // Arrange
+        var agentDetails = new AgentDetails(agentId: "agent-provider", providerName: "openai");
+
+        // Act
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = InvokeAgentScope.Start(Util.GetDefaultRequest(), ScopeDetails, agentDetails);
+        });
+
+        // Assert
+        activity.ShouldHaveTag(GenAiProviderNameKey, "openai");
+    }
+
+    [TestMethod]
+    public void RequestParameters_AreSetOnSpan_WhenProvided()
+    {
+        // Arrange
+        var requestParameters = new GenAiRequestParameters(
+            model: "gpt-4",
+            seed: 42,
+            choiceCount: 3,
+            frequencyPenalty: 0.5,
+            maxTokens: 256,
+            presencePenalty: 0.25,
+            stopSequences: new[] { "STOP", "END" },
+            temperature: 0.7,
+            topP: 0.9,
+            dataSourceId: "ds-001",
+            outputType: "json",
+            systemInstructions: "Be concise.");
+        var scopeDetails = new InvokeAgentScopeDetails(
+            endpoint: new Uri("https://example.com"),
+            requestParameters: requestParameters);
+
+        // Act
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = InvokeAgentScope.Start(Util.GetDefaultRequest(), scopeDetails, TestAgentDetails);
+        });
+
+        // Assert
+        activity.GetTagItem(GenAiRequestModelKey).Should().Be("gpt-4");
+        activity.GetTagItem(GenAiRequestSeedKey).Should().Be(42);
+        activity.GetTagItem(GenAiRequestChoiceCountKey).Should().Be(3);
+        activity.GetTagItem(GenAiRequestFrequencyPenaltyKey).Should().Be(0.5);
+        activity.GetTagItem(GenAiRequestMaxTokensKey).Should().Be(256);
+        activity.GetTagItem(GenAiRequestPresencePenaltyKey).Should().Be(0.25);
+        activity.GetTagItem(GenAiRequestStopSequencesKey).Should().BeEquivalentTo(new[] { "STOP", "END" });
+        activity.GetTagItem(GenAiRequestTemperatureKey).Should().Be(0.7);
+        activity.GetTagItem(GenAiRequestTopPKey).Should().Be(0.9);
+        activity.GetTagItem(GenAiDataSourceIdKey).Should().Be("ds-001");
+        activity.GetTagItem(GenAiOutputTypeKey).Should().Be("json");
+        activity.GetTagItem(GenAiSystemInstructionsKey).Should().Be("Be concise.");
+    }
+
+    [TestMethod]
+    public void ResponseParameters_AreSetOnSpan_WhenProvided()
+    {
+        // Arrange
+        var responseParameters = new GenAiResponseParameters(
+            finishReasons: new[] { "stop", "length" },
+            inputTokens: 100,
+            outputTokens: 180,
+            cacheCreationInputTokens: 25,
+            cacheReadInputTokens: 50);
+        var scopeDetails = new InvokeAgentScopeDetails(
+            endpoint: new Uri("https://example.com"),
+            responseParameters: responseParameters);
+
+        // Act
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = InvokeAgentScope.Start(Util.GetDefaultRequest(), scopeDetails, TestAgentDetails);
+        });
+
+        // Assert
+        activity.ShouldHaveTag(GenAiResponseFinishReasonsKey, "stop,length");
+        activity.ShouldHaveTag(GenAiUsageInputTokensKey, "100");
+        activity.ShouldHaveTag(GenAiUsageOutputTokensKey, "180");
+        activity.GetTagItem(GenAiUsageCacheCreationInputTokensKey).Should().Be(25);
+        activity.GetTagItem(GenAiUsageCacheReadInputTokensKey).Should().Be(50);
+    }
+
+    [TestMethod]
+    public void RecordResponseParameters_SetsTagsCorrectly()
+    {
+        // Arrange
+        var responseParameters = new GenAiResponseParameters(
+            finishReasons: new[] { "stop" },
+            inputTokens: 10,
+            outputTokens: 20);
+
+        // Act
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = InvokeAgentScope.Start(Util.GetDefaultRequest(), ScopeDetails, TestAgentDetails);
+            scope.RecordResponseParameters(responseParameters);
+        });
+
+        // Assert
+        activity.ShouldHaveTag(GenAiResponseFinishReasonsKey, "stop");
+        activity.ShouldHaveTag(GenAiUsageInputTokensKey, "10");
+        activity.ShouldHaveTag(GenAiUsageOutputTokensKey, "20");
+    }
+
+    [TestMethod]
+    public void RequestAndResponseParameters_AreNotSet_WhenAbsent()
+    {
+        // Act
+        var activity = ListenForActivity(() =>
+        {
+            using var scope = InvokeAgentScope.Start(Util.GetDefaultRequest(), ScopeDetails, TestAgentDetails);
+        });
+
+        // Assert
+        activity.GetTagItem(GenAiRequestModelKey).Should().BeNull();
+        activity.GetTagItem(GenAiRequestTemperatureKey).Should().BeNull();
+        activity.GetTagItem(GenAiResponseFinishReasonsKey).Should().BeNull();
+        activity.GetTagItem(GenAiUsageInputTokensKey).Should().BeNull();
+    }
 }

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/InvokeAgentScopeTest.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Scopes/InvokeAgentScopeTest.cs
@@ -459,9 +459,9 @@ public sealed class InvokeAgentScopeTest : ActivityTest
         });
 
         // Assert
-        activity.ShouldHaveTag(GenAiResponseFinishReasonsKey, "stop,length");
-        activity.ShouldHaveTag(GenAiUsageInputTokensKey, "100");
-        activity.ShouldHaveTag(GenAiUsageOutputTokensKey, "180");
+        activity.GetTagItem(GenAiResponseFinishReasonsKey).Should().BeEquivalentTo(new[] { "stop", "length" });
+        activity.GetTagItem(GenAiUsageInputTokensKey).Should().Be(100);
+        activity.GetTagItem(GenAiUsageOutputTokensKey).Should().Be(180);
         activity.GetTagItem(GenAiUsageCacheCreationInputTokensKey).Should().Be(25);
         activity.GetTagItem(GenAiUsageCacheReadInputTokensKey).Should().Be(50);
     }
@@ -483,9 +483,9 @@ public sealed class InvokeAgentScopeTest : ActivityTest
         });
 
         // Assert
-        activity.ShouldHaveTag(GenAiResponseFinishReasonsKey, "stop");
-        activity.ShouldHaveTag(GenAiUsageInputTokensKey, "10");
-        activity.ShouldHaveTag(GenAiUsageOutputTokensKey, "20");
+        activity.GetTagItem(GenAiResponseFinishReasonsKey).Should().BeEquivalentTo(new[] { "stop" });
+        activity.GetTagItem(GenAiUsageInputTokensKey).Should().Be(10);
+        activity.GetTagItem(GenAiUsageOutputTokensKey).Should().Be(20);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
Makes the `invoke_agent` span compliant with the [OpenTelemetry GenAI semantic conventions v1.42](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md). Adds the missing Required / Conditionally-Required, Recommended, and Opt-In attributes **without changing any public `Start`/`Build` signatures**.

## Approach
New request/response data is carried via `InvokeAgentScopeDetails` using two new reusable contracts so the public live-span API stays stable:
- `GenAiRequestParameters` — model, seed, choice.count, frequency/presence penalty, max_tokens, stop_sequences, temperature, top_p, data_source.id, output.type, system_instructions.
- `GenAiResponseParameters` — finish_reasons, input/output tokens, cache creation/read input tokens.

## Changes
- **Constants**: 13 new GenAI semantic-convention keys.
- **provider.name fix**: `gen_ai.provider.name` is now emitted on all scopes (previously only on the DTO/export path, missing on the live span).
- **Both emission paths wired**: live-span (`InvokeAgentScope` / `OpenTelemetryScope`) and DTO/export (`InvokeAgentDataBuilder` / `BaseDataBuilder`).
- **Public API** recorded in `PublicAPI.Unshipped.txt`.

## Out of scope
- `microsoft.session.id -> session.id` rename (intentionally deferred).

## Testing
- Added 5 scope tests + 4 DTO-builder tests.
- Full suite green: **445 passed, 3 skipped, 0 failed** on net8.0 and net10.0.