### PR TITLE
Throttle distro Feature SDK Stats to 24-hour emission cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Throttle distro Feature SDK Stats to a 24-hour emission cadence. The exporter now collects Feature SDK Stats on the shared 15-minute Network SDK Stats reader, so the observable gauge applies an emission-ticks throttle (mirroring the Attach gauge) to avoid emitting every 15 minutes.
+
 ## 1.0.5 - 2026-06-12
 
 - Bootstrap SDK Stats eagerly in `UseMicrosoftOpenTelemetry` so Attach + Feature SDK Stats are reported when the Azure Monitor exporter is not selected (OTLP-only, Console-only, Agent365-only).

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSdkStats.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSdkStats.cs
@@ -13,8 +13,9 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
     /// Owns the distro's Feature SDKStats meter and observable gauge. The Azure Monitor
     /// exporter's Statsbeat <c>MeterProvider</c> subscribes to the meter name advertised by
     /// this class (see <c>StatsbeatConstants.DistroFeatureSdkStatsMeterName</c> in the
-    /// exporter), so measurements are exported on the existing 24-hour Statsbeat cadence
-    /// without any further wiring on the distro side.
+    /// exporter). That provider collects on the shared 15-minute reader, so this gauge
+    /// throttles to one emission per <see cref="EmissionInterval"/> (24 hr) instead of
+    /// shipping every 15 min.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -46,6 +47,13 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
         /// <summary>Meter version reported alongside <see cref="MeterName"/>.</summary>
         internal const string MeterVersion = "1.0";
 
+        /// <summary>
+        /// Minimum time between Feature SDKStats emissions. Feature stats share the exporter's
+        /// 15-minute reader but must ship on the 24 hr cadence, so <see cref="Observe"/>
+        /// throttles to one emission per interval (matches the exporter's Attach gauge).
+        /// </summary>
+        internal static readonly TimeSpan EmissionInterval = TimeSpan.FromHours(24);
+
         private static DistroFeatureSdkStats? s_instance;
         private static readonly object s_lock = new();
 
@@ -53,6 +61,10 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
 
         private readonly Meter _meter;
         private DistroFeatureSnapshot _snapshot;
+
+        // Throttle so the Feature gauge emits at most once per EmissionInterval even though
+        // the shared reader collects every 15 min.
+        private long _lastEmissionTicks;
 
         private DistroFeatureSdkStats(DistroFeatureSnapshot snapshot)
         {
@@ -150,6 +162,21 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
                 return EmptyMeasurements;
             }
 
+            // Throttle to the 24 hr cadence: skip collections inside the window. Delta
+            // temporality means a skipped collection exports nothing.
+            long previousTicks = Volatile.Read(ref _lastEmissionTicks);
+            long nowTicks = DateTime.UtcNow.Ticks;
+            if (previousTicks != 0 && nowTicks - previousTicks < EmissionInterval.Ticks)
+            {
+                return EmptyMeasurements;
+            }
+
+            // CAS so a racing collection can't double-emit.
+            if (Interlocked.CompareExchange(ref _lastEmissionTicks, nowTicks, previousTicks) != previousTicks)
+            {
+                return EmptyMeasurements;
+            }
+
             try
             {
                 var measurement = new Measurement<long>(
@@ -168,6 +195,8 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
             catch (Exception ex)
             {
                 AzureMonitorAspNetCoreEventSource.Log.DistroFeatureSdkStatsCallbackFailed(ex);
+                // Rewind so we retry on the next collection.
+                Volatile.Write(ref _lastEmissionTicks, previousTicks);
                 return EmptyMeasurements;
             }
         }

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSdkStats.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroFeatureSdkStats.cs
@@ -163,10 +163,13 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
             }
 
             // Throttle to the 24 hr cadence: skip collections inside the window. Delta
-            // temporality means a skipped collection exports nothing.
+            // temporality means a skipped collection exports nothing. A negative elapsed value
+            // means the wall clock jumped backwards (e.g. NTP/VM sync); treat that as eligible
+            // so a backwards jump re-anchors the window instead of suppressing for up to 24 hr.
             long previousTicks = Volatile.Read(ref _lastEmissionTicks);
             long nowTicks = DateTime.UtcNow.Ticks;
-            if (previousTicks != 0 && nowTicks - previousTicks < EmissionInterval.Ticks)
+            long elapsedTicks = nowTicks - previousTicks;
+            if (previousTicks != 0 && elapsedTicks >= 0 && elapsedTicks < EmissionInterval.Ticks)
             {
                 return EmptyMeasurements;
             }

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSdkStatsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSdkStatsTests.cs
@@ -101,6 +101,51 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
             Assert.Equal((long)snapshot.Features, match.value);
         }
 
+        [Fact]
+        public void Observe_ThrottlesToSingleEmission_AcrossRapidCollections()
+        {
+            // The exporter collects this gauge on the shared 15-minute reader. Verify the
+            // throttle holds it to one emission per 24 hr window so Feature stats don't ship
+            // every 15 min.
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.AzureMonitor.ConnectionString = ValidConnectionString;
+
+            var snapshot = DistroFeatureSnapshot.Build(
+                options,
+                ValidConnectionString,
+                ExportTarget.AzureMonitor,
+                customerSdkStatsEnabled: false,
+                a365OnlyMode: false,
+                distroVersion: "9.9.9-throttle")!;
+
+            DistroFeatureSdkStats.Initialize(snapshot);
+
+            const int simulatedCollections = 5;
+            int emissions = 0;
+            using var listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == DistroFeatureSdkStats.MeterName
+                        && instrument.Name == DistroFeatureSdkStats.MetricName)
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+            listener.SetMeasurementEventCallback<long>((_, _, _, _) => emissions++);
+            listener.Start();
+
+            for (int i = 0; i < simulatedCollections; i++)
+            {
+                listener.RecordObservableInstruments();
+            }
+
+            // 5 collections at the 15-min cadence, but the throttle allows only one until the
+            // 24 hr window elapses.
+            Assert.Equal(1, emissions);
+        }
+
         private static List<(long value, Dictionary<string, object?> tags)> CollectObservableMeasurements()
         {
             var results = new List<(long value, Dictionary<string, object?> tags)>();

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSdkStatsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroFeatureSdkStatsTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using System.Reflection;
 using Microsoft.OpenTelemetry.AzureMonitor.SdkStats;
 using Xunit;
 
@@ -144,6 +146,36 @@ namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
             // 5 collections at the 15-min cadence, but the throttle allows only one until the
             // 24 hr window elapses.
             Assert.Equal(1, emissions);
+        }
+
+        [Fact]
+        public void Observe_EmitsAgain_WhenClockJumpsBackwards()
+        {
+            // Simulate the last emission being recorded ~48 hr in the future, i.e. the wall
+            // clock has since jumped backwards (NTP/VM sync). The backwards-jump guard must
+            // allow an emission now instead of suppressing until wall-clock time catches up.
+            var options = new MicrosoftOpenTelemetryOptions();
+            options.AzureMonitor.ConnectionString = ValidConnectionString;
+
+            var snapshot = DistroFeatureSnapshot.Build(
+                options,
+                ValidConnectionString,
+                ExportTarget.AzureMonitor,
+                customerSdkStatsEnabled: false,
+                a365OnlyMode: false,
+                distroVersion: "9.9.9-clockback")!;
+
+            DistroFeatureSdkStats.Initialize(snapshot);
+
+            var instance = DistroFeatureSdkStats.Instance!;
+            long futureTicks = DateTime.UtcNow.Ticks + TimeSpan.FromHours(48).Ticks;
+            typeof(DistroFeatureSdkStats)
+                .GetField("_lastEmissionTicks", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(instance, futureTicks);
+
+            var measurements = CollectObservableMeasurements();
+
+            Assert.Single(measurements);
         }
 
         private static List<(long value, Dictionary<string, object?> tags)> CollectObservableMeasurements()


### PR DESCRIPTION
## Summary

Distro Feature SDK Stats were emitting on **every** collection of the exporter's shared 15-minute Network SDK Stats reader, so they would ship every 15 min instead of the intended 24-hour cadence. This was flagged by @harsimar on [Azure/azure-sdk-for-net#59909](https://github.com/Azure/azure-sdk-for-net/pull/59909): *"I suspect it might start emitting every 15 min with current code."*

The Azure Monitor exporter only throttles its **Attach** gauge, so the distro's Feature gauge needs the same treatment.

## Changes

- `DistroFeatureSdkStats.Observe()` now applies an emission-ticks throttle (24 hr `EmissionInterval`), mirroring the exporter's Attach gauge: window check → CAS to claim the slot → rewind on build failure. The throttle sits after the `DistroFeature.None` short-circuit so empty collections don't consume the window.
- Corrected the class doc comment, which previously claimed Feature stats already exported on a 24-hour cadence.
- Added `Observe_ThrottlesToSingleEmission_AcrossRapidCollections` proving 5 rapid collections yield exactly one emission.
- Added a CHANGELOG entry.

## Verification

- `Microsoft.OpenTelemetry` builds clean across net8.0 / net10.0 / netstandard2.0.
- Distro tests pass 4/4 on net10.0, including the new throttle test.