### PR TITLE
Add actionable error message for HTTP 403 insufficient_scope

### DIFF
--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -11,9 +11,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
@@ -239,9 +241,7 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                         this._logger?.LogDebug("Agent365ExporterCore: HTTP {StatusCode} exporting spans. '{HeaderKey}': '{CorrelationId}'.", (int)resp.StatusCode, CorrelationIdHeaderKey, correlationId);
                         if (!resp.IsSuccessStatusCode)
                         {
-                            this._logger?.LogWarning(
-                                "Agent365ExporterCore: Chunk {ChunkIndex} of {ChunkCount} failed; aborting batch.",
-                                i + 1, chunks.Count);
+                            LogNonSuccessResponse(resp, correlationId, token!, i + 1, chunks.Count);
                             return ExportResult.Failure;
                         }
                     }
@@ -294,6 +294,83 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
             var skippedCount = nonGenAICount + missingIdentityCount;
             if (skippedCount > 0)
                 _logger?.LogDebug("[Agent365Exporter] Partitioned into {GroupCount} identity groups ({SkippedCount} spans skipped)", groupCount, skippedCount);
+        }
+
+        private void LogNonSuccessResponse(HttpResponseMessage resp, string? correlationId, string token, int chunkIndex, int chunkCount)
+        {
+            var wwwAuth = resp.Headers.WwwAuthenticate.ToString();
+
+            if (resp.StatusCode == HttpStatusCode.Forbidden && wwwAuth.Contains("insufficient_scope", StringComparison.OrdinalIgnoreCase))
+            {
+                var spStr = ExtractTokenIdentity(token);
+                var identityDescription = !string.IsNullOrEmpty(spStr)
+                    ? $" service principal ({spStr})"
+                    : " your application's service principal";
+
+                _logger?.LogError(
+                    "HTTP 403 authorization error: the token is missing the required " +
+                    "'Agent365.Observability.OtelWrite' app role. " +
+                    "Grant the 'Agent365.Observability.OtelWrite' role to{Identity} " +
+                    "and ensure admin consent has been granted. " +
+                    "| Setup instructions: https://learn.microsoft.com/microsoft-agent-365/developer/observability?tabs=dotnet#http-403-forbidden " +
+                    "| For Foundry: https://learn.microsoft.com/azure/foundry/agents/how-to/grant-agent-365-permissions " +
+                    "| Correlation ID: {CorrelationId}.",
+                    identityDescription,
+                    correlationId ?? "N/A");
+            }
+            else
+            {
+                _logger?.LogError(
+                    "Agent365ExporterCore: HTTP {StatusCode} non-retryable error. " +
+                    "Chunk {ChunkIndex} of {ChunkCount} failed; aborting batch. " +
+                    "WWW-Authenticate: {WwwAuthenticate}. Correlation ID: {CorrelationId}.",
+                    (int)resp.StatusCode,
+                    chunkIndex,
+                    chunkCount,
+                    string.IsNullOrEmpty(wwwAuth) ? "N/A" : wwwAuth,
+                    correlationId ?? "N/A");
+            }
+        }
+
+        /// <summary>
+        /// Decodes the JWT payload to extract service principal identity claims.
+        /// Returns a descriptive string like "app ID: xxx, object ID: yyy" or empty if not decodable.
+        /// </summary>
+        internal static string ExtractTokenIdentity(string token)
+        {
+            try
+            {
+                var parts = token.Split('.');
+                if (parts.Length != 3)
+                    return string.Empty;
+
+                var payloadBase64 = parts[1];
+                // Pad to valid base64
+                switch (payloadBase64.Length % 4)
+                {
+                    case 2: payloadBase64 += "=="; break;
+                    case 3: payloadBase64 += "="; break;
+                }
+
+                var payloadBytes = Convert.FromBase64String(payloadBase64.Replace('-', '+').Replace('_', '/'));
+                using var doc = JsonDocument.Parse(payloadBytes);
+                var root = doc.RootElement;
+
+                var spParts = new List<string>();
+                if (root.TryGetProperty("appid", out var appId) && appId.ValueKind == JsonValueKind.String)
+                    spParts.Add($"app ID: {appId.GetString()}");
+                else if (root.TryGetProperty("azp", out var azp) && azp.ValueKind == JsonValueKind.String)
+                    spParts.Add($"app ID: {azp.GetString()}");
+
+                if (root.TryGetProperty("oid", out var oid) && oid.ValueKind == JsonValueKind.String)
+                    spParts.Add($"object ID: {oid.GetString()}");
+
+                return string.Join(", ", spParts);
+            }
+            catch
+            {
+                return string.Empty;
+            }
         }
     }
 }

--- a/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/Agent365ExporterTests.cs
+++ b/test/Microsoft.OpenTelemetry.Agent365.Tests/Runtime/Tracing/Exporters/Agent365ExporterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Agents.A365.Observability.Runtime.Common;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters;
@@ -11,6 +12,7 @@ using OpenTelemetry.Resources;
 using System.Diagnostics;
 using System.Reflection;
 using System.Net;
+using System.Text;
 
 namespace Microsoft.Agents.A365.Observability.Tests.Tracing.Exporters;
 
@@ -1343,6 +1345,87 @@ public sealed class Agent365ExporterTests
 
     #endregion
 
+    #region HTTP 403 Actionable Error Message Tests
+
+    [TestMethod]
+    public void Export_Http403_InsufficientScope_LogsActionableErrorMessage()
+    {
+        // Arrange
+        var handler = new TestHttpMessageHandler(req =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Forbidden);
+            response.Headers.Add("x-ms-correlation-id", "test-correlation-id");
+            response.Headers.WwwAuthenticate.ParseAdd(
+                "Bearer error=\"insufficient_scope\", " +
+                "error_description=\"Required app role: Agent365.Observability.OtelWrite\", " +
+                "scope=\"Agent365.Observability.OtelWrite\"");
+            return response;
+        });
+        var httpClient = new HttpClient(handler);
+
+        var options = new Agent365ExporterOptions
+        {
+            TokenResolver = (_, _) => Task.FromResult<string?>("test-token"),
+            UseS2SEndpoint = false,
+            DomainResolver = _ => "test.example.com"
+        };
+
+        var resource = ResourceBuilder.CreateEmpty()
+            .AddService("unit-test-service", serviceVersion: "1.0.0")
+            .Build();
+
+        var inMemoryLogger = new InMemoryLogger();
+
+        var core = new Agent365ExporterCore(new ExportFormatter(NullLogger<ExportFormatter>.Instance), inMemoryLogger);
+
+        var exporter = new Agent365Exporter(
+            core,
+            NullLogger<Agent365Exporter>.Instance,
+            options,
+            resource,
+            httpClient);
+
+        using var activity = CreateActivity(tenantId: "tenant-403", agentId: "agent-403");
+        var batch = CreateBatch(activity);
+
+        // Act
+        var result = exporter.Export(in batch);
+
+        // Assert
+        result.Should().Be(ExportResult.Failure);
+        var errorLogs = inMemoryLogger.LogMessages.Where(m => m.Contains("Agent365.Observability.OtelWrite")).ToList();
+        errorLogs.Should().NotBeEmpty("a 403 with insufficient_scope should log an actionable error message");
+        var msg = errorLogs.First();
+        msg.Should().Contain("Agent365.Observability.OtelWrite");
+        msg.Should().Contain("https://learn.microsoft.com/microsoft-agent-365/developer/observability");
+        msg.Should().Contain("https://learn.microsoft.com/azure/foundry/agents/how-to/grant-agent-365-permissions");
+        msg.Should().Contain("Foundry");
+    }
+
+    [TestMethod]
+    public void ExtractTokenIdentity_ValidJwt_ReturnsAppIdAndObjectId()
+    {
+        // Create a minimal JWT with appid and oid claims
+        var header = Convert.ToBase64String(Encoding.UTF8.GetBytes("{\"alg\":\"RS256\",\"typ\":\"JWT\"}")).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        var payload = Convert.ToBase64String(Encoding.UTF8.GetBytes("{\"appid\":\"test-app-id\",\"oid\":\"test-object-id\"}")).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        var signature = "fake-signature";
+        var token = $"{header}.{payload}.{signature}";
+
+        var result = Agent365ExporterCore.ExtractTokenIdentity(token);
+
+        result.Should().Contain("app ID: test-app-id");
+        result.Should().Contain("object ID: test-object-id");
+    }
+
+    [TestMethod]
+    public void ExtractTokenIdentity_InvalidToken_ReturnsEmpty()
+    {
+        var result = Agent365ExporterCore.ExtractTokenIdentity("not-a-jwt");
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
     private class TestHttpMessageHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
@@ -1354,6 +1437,25 @@ public sealed class Agent365ExporterTests
         {
             return Task.FromResult(_handler(request));
         }
+    }
+
+    private class InMemoryLogger : ILogger<Agent365ExporterCore>
+    {
+        public List<string> LogMessages { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            LogMessages.Add(formatter(state, exception));
+        }
+    }
+
+    private class InMemoryLoggerProvider : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new InMemoryLogger();
+        public void Dispose() { }
     }
 
 }


### PR DESCRIPTION
## Summary

Adding actionable error message with links to docs to resolve 403 error when exporting traces to A365. This brings the .NET distro to parity with the Python distro (see microsoft/opentelemetry-distro-python#213).

## Problem

When the identity used to send traces to A365 does not have the required permissions, the .NET distro silently fails without any useful log message, making it very difficult for customers to diagnose permission issues.

## Changes

- **\Agent365ExporterCore.cs\**: Added \LogNonSuccessResponse()\ that detects HTTP 403 + \insufficient_scope\ and logs an actionable error with:
  - The specific missing role name (\Agent365.Observability.OtelWrite\)
  - The service principal identity (app ID and object ID) decoded from the JWT
  - Links to setup documentation for both A365 and Foundry
  - Correlation ID for support escalation
- **\Agent365ExporterCore.cs\**: Added \ExtractTokenIdentity()\ helper to decode JWT payload and extract \ppid\/\zp\/\oid\ claims
- For non-403 errors, enhanced logging now includes HTTP status code, WWW-Authenticate header, and correlation ID

## Tests

Added 3 new tests:
- \Export_Http403_InsufficientScope_LogsActionableErrorMessage\
- \ExtractTokenIdentity_ValidJwt_ReturnsAppIdAndObjectId\
- \ExtractTokenIdentity_InvalidToken_ReturnsEmpty\

All 50 exporter tests pass on .NET 8 and .NET 10.

Fixes #122