### PR TITLE
Add multi-instance support for isolated Azure Monitor pipelines

### DIFF
--- a/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenTelemetry/.publicApi/PublicAPI.Unshipped.txt
@@ -150,3 +150,13 @@ Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDe
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.RequestParameters.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiRequestParameters?
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.InvokeAgentScopeDetails.ResponseParameters.get -> Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters?
 Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes.InvokeAgentScope.RecordResponseParameters(Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts.GenAiResponseParameters! responseParameters) -> void
+Microsoft.OpenTelemetry.MultiInstance.MultiInstanceTelemetry
+Microsoft.OpenTelemetry.MultiInstance.TelemetryInstance
+Microsoft.OpenTelemetry.MultiInstance.TelemetryInstance.ActivitySource.get -> System.Diagnostics.ActivitySource!
+Microsoft.OpenTelemetry.MultiInstance.TelemetryInstance.BeginScope() -> System.IDisposable!
+Microsoft.OpenTelemetry.MultiInstance.TelemetryInstance.Dispose() -> void
+Microsoft.OpenTelemetry.MultiInstance.TelemetryInstance.ForceFlush(int timeoutMilliseconds = 10000) -> void
+Microsoft.OpenTelemetry.MultiInstance.TelemetryInstance.Logger.get -> Microsoft.Extensions.Logging.ILogger!
+Microsoft.OpenTelemetry.MultiInstance.TelemetryInstance.Meter.get -> System.Diagnostics.Metrics.Meter!
+Microsoft.OpenTelemetry.MultiInstance.TelemetryInstance.Name.get -> string!
+static Microsoft.OpenTelemetry.MultiInstance.MultiInstanceTelemetry.CreateAzureMonitorInstance(string! name, string! connectionString, params string![]! sharedSources) -> Microsoft.OpenTelemetry.MultiInstance.TelemetryInstance!

--- a/src/Microsoft.OpenTelemetry/MultiInstance/AmbientInstance.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/AmbientInstance.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.OpenTelemetry.MultiInstance;
+
+/// <summary>
+/// Holds the ambient "current telemetry instance" id for the executing async flow. This is the
+/// .NET analog of JavaScript's <c>AsyncLocalStorage</c> / Python's <c>ContextVar</c>.
+/// </summary>
+/// <remarks>
+/// The value flows with the logical call context (async/await, <c>Task.Run</c>, etc.) on the
+/// application thread. It is NOT available on the exporter's background thread, which is why
+/// activities are stamped with the instance id at start time (see <see cref="InstanceStampProcessor"/>)
+/// rather than read here at export time.
+/// </remarks>
+internal static class AmbientInstance
+{
+    private static readonly AsyncLocal<string?> Current = new();
+
+    /// <summary>The id of the instance bound to the current async flow, or <see langword="null"/>.</summary>
+    public static string? CurrentId => Current.Value;
+
+    /// <summary>Binds <paramref name="instanceId"/> as the current instance until the returned scope is disposed.</summary>
+    public static IDisposable Use(string instanceId)
+    {
+        var previous = Current.Value;
+        Current.Value = instanceId;
+        return new Scope(previous);
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private readonly string? _previous;
+        private bool _disposed;
+
+        public Scope(string? previous) => _previous = previous;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            Current.Value = _previous;
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/MultiInstance/AmbientInstance.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/AmbientInstance.cs
@@ -4,8 +4,7 @@
 namespace Microsoft.OpenTelemetry.MultiInstance;
 
 /// <summary>
-/// Holds the ambient "current telemetry instance" id for the executing async flow. This is the
-/// .NET analog of JavaScript's <c>AsyncLocalStorage</c> / Python's <c>ContextVar</c>.
+/// Holds the current telemetry-instance id for the executing async flow, using <see cref="AsyncLocal{T}"/>.
 /// </summary>
 /// <remarks>
 /// The value flows with the logical call context (async/await, <c>Task.Run</c>, etc.) on the

--- a/src/Microsoft.OpenTelemetry/MultiInstance/GatingActivityExportProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/GatingActivityExportProcessor.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace Microsoft.OpenTelemetry.MultiInstance;
+
+/// <summary>
+/// A <see cref="BatchActivityExportProcessor"/> that only forwards activities stamped with its own
+/// telemetry-instance id, dropping everything else. This is what prevents fan-out: when several
+/// isolated <c>TracerProvider</c>s listen to the same shared <c>ActivitySource</c>, each one sees
+/// every activity, but only the matching instance actually exports it.
+/// </summary>
+/// <remarks>
+/// We subclass the real batch processor rather than wrapping it because the OpenTelemetry SDK wires
+/// the registered processor directly via <c>SetParentProvider</c> (which is not overridable).
+/// Subclassing keeps that wiring intact, so the genuine Azure Monitor exporter still receives this
+/// instance's <c>Resource</c> — preserving the per-instance cloud role name.
+/// </remarks>
+internal sealed class GatingActivityExportProcessor : BatchActivityExportProcessor
+{
+    private readonly string _instanceId;
+    private readonly Action<Activity>? _onForwarded;
+
+    public GatingActivityExportProcessor(string instanceId, BaseExporter<Activity> exporter, Action<Activity>? onForwarded = null)
+        : base(exporter)
+    {
+        _instanceId = instanceId;
+        _onForwarded = onForwarded;
+    }
+
+    public override void OnEnd(Activity data)
+    {
+        if ((data.GetCustomProperty(InstanceStampProcessor.PropertyName) as string) == _instanceId)
+        {
+            _onForwarded?.Invoke(data);
+            base.OnEnd(data);
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/MultiInstance/GatingActivityExportProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/GatingActivityExportProcessor.cs
@@ -7,17 +7,11 @@ using OpenTelemetry;
 namespace Microsoft.OpenTelemetry.MultiInstance;
 
 /// <summary>
-/// A <see cref="BatchActivityExportProcessor"/> that only forwards activities stamped with its own
-/// telemetry-instance id, dropping everything else. This is what prevents fan-out: when several
-/// isolated <c>TracerProvider</c>s listen to the same shared <c>ActivitySource</c>, each one sees
-/// every activity, but only the matching instance actually exports it.
+/// A <see cref="BatchActivityExportProcessor"/> that forwards only activities stamped with its own
+/// instance id, dropping the rest. This prevents fan-out when several isolated providers listen to
+/// the same shared source. It subclasses the batch processor (rather than wrapping it) so the SDK's
+/// <c>SetParentProvider</c> wiring stays intact and the exporter keeps this instance's Resource.
 /// </summary>
-/// <remarks>
-/// We subclass the real batch processor rather than wrapping it because the OpenTelemetry SDK wires
-/// the registered processor directly via <c>SetParentProvider</c> (which is not overridable).
-/// Subclassing keeps that wiring intact, so the genuine Azure Monitor exporter still receives this
-/// instance's <c>Resource</c> — preserving the per-instance cloud role name.
-/// </remarks>
 internal sealed class GatingActivityExportProcessor : BatchActivityExportProcessor
 {
     private readonly string _instanceId;

--- a/src/Microsoft.OpenTelemetry/MultiInstance/InstanceStampProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/InstanceStampProcessor.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace Microsoft.OpenTelemetry.MultiInstance;
+
+/// <summary>
+/// Stamps each <see cref="Activity"/> with the owning telemetry-instance id at start time, so the
+/// id survives the hop to the exporter's background thread (where <see cref="AmbientInstance"/> is
+/// no longer available).
+/// </summary>
+/// <remarks>
+/// Runs on the application thread inside <c>ActivitySource.StartActivity</c>, where the ambient
+/// value is present. Two stamping rules apply:
+/// <list type="number">
+///   <item>Activities from this instance's own private source are always stamped with this
+///   instance id (direct-handle usage needs no ambient scope).</item>
+///   <item>Activities from shared sources are stamped with the ambient instance id, so the global
+///   OpenTelemetry API routes to whichever instance is current.</item>
+/// </list>
+/// Stamping is idempotent: the first writer wins, and concurrent instances writing the same ambient
+/// value is harmless.
+/// </remarks>
+internal sealed class InstanceStampProcessor : BaseProcessor<Activity>
+{
+    internal const string PropertyName = "msi.instance";
+
+    private readonly string _instanceId;
+    private readonly string _privateSourceName;
+
+    public InstanceStampProcessor(string instanceId, string privateSourceName)
+    {
+        _instanceId = instanceId;
+        _privateSourceName = privateSourceName;
+    }
+
+    public override void OnStart(Activity data)
+    {
+        if (data.GetCustomProperty(PropertyName) is not null)
+        {
+            return;
+        }
+
+        if (data.Source.Name == _privateSourceName)
+        {
+            // Direct-handle activity for this instance — always belongs to it.
+            data.SetCustomProperty(PropertyName, _instanceId);
+        }
+        else if (AmbientInstance.CurrentId is { } ambient)
+        {
+            // Shared-source activity routed by the active "run-with-instance" scope.
+            data.SetCustomProperty(PropertyName, ambient);
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/MultiInstance/InstanceStampProcessor.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/InstanceStampProcessor.cs
@@ -7,22 +7,11 @@ using OpenTelemetry;
 namespace Microsoft.OpenTelemetry.MultiInstance;
 
 /// <summary>
-/// Stamps each <see cref="Activity"/> with the owning telemetry-instance id at start time, so the
-/// id survives the hop to the exporter's background thread (where <see cref="AmbientInstance"/> is
-/// no longer available).
+/// Stamps each <see cref="Activity"/> with its owning telemetry-instance id at start, so the id
+/// survives the hop to the exporter's background thread (where <see cref="AmbientInstance"/> is
+/// unavailable). Activities from this instance's private source are always stamped with its id;
+/// activities from shared sources are stamped with the current scope's id. Stamping is idempotent.
 /// </summary>
-/// <remarks>
-/// Runs on the application thread inside <c>ActivitySource.StartActivity</c>, where the ambient
-/// value is present. Two stamping rules apply:
-/// <list type="number">
-///   <item>Activities from this instance's own private source are always stamped with this
-///   instance id (direct-handle usage needs no ambient scope).</item>
-///   <item>Activities from shared sources are stamped with the ambient instance id, so the global
-///   OpenTelemetry API routes to whichever instance is current.</item>
-/// </list>
-/// Stamping is idempotent: the first writer wins, and concurrent instances writing the same ambient
-/// value is harmless.
-/// </remarks>
 internal sealed class InstanceStampProcessor : BaseProcessor<Activity>
 {
     internal const string PropertyName = "msi.instance";
@@ -45,12 +34,12 @@ internal sealed class InstanceStampProcessor : BaseProcessor<Activity>
 
         if (data.Source.Name == _privateSourceName)
         {
-            // Direct-handle activity for this instance — always belongs to it.
+            // Direct-handle activity always belongs to this instance.
             data.SetCustomProperty(PropertyName, _instanceId);
         }
         else if (AmbientInstance.CurrentId is { } ambient)
         {
-            // Shared-source activity routed by the active "run-with-instance" scope.
+            // Shared-source activity routed by the active scope.
             data.SetCustomProperty(PropertyName, ambient);
         }
     }

--- a/src/Microsoft.OpenTelemetry/MultiInstance/MultiInstanceTelemetry.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/MultiInstanceTelemetry.cs
@@ -25,7 +25,8 @@ public static class MultiInstanceTelemetry
     /// </param>
     /// <returns>An isolated <see cref="TelemetryInstance"/> handle.</returns>
     /// <exception cref="ArgumentException">
-    /// <paramref name="name"/> or <paramref name="connectionString"/> is null or whitespace.
+    /// <paramref name="name"/> or <paramref name="connectionString"/> is null or whitespace, or a
+    /// <paramref name="sharedSources"/> entry is null or whitespace.
     /// </exception>
     public static TelemetryInstance CreateAzureMonitorInstance(
         string name,
@@ -42,6 +43,15 @@ public static class MultiInstanceTelemetry
             throw new ArgumentException("Connection string is required.", nameof(connectionString));
         }
 
-        return new TelemetryInstance(name, connectionString, sharedSources ?? Array.Empty<string>());
+        sharedSources ??= Array.Empty<string>();
+        foreach (var source in sharedSources)
+        {
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                throw new ArgumentException("Shared source names cannot be null or whitespace.", nameof(sharedSources));
+            }
+        }
+
+        return new TelemetryInstance(name, connectionString, sharedSources);
     }
 }

--- a/src/Microsoft.OpenTelemetry/MultiInstance/MultiInstanceTelemetry.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/MultiInstanceTelemetry.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.OpenTelemetry.MultiInstance;
+
+/// <summary>
+/// Factory for isolated <see cref="TelemetryInstance"/> pipelines, enabling multiple Azure Monitor
+/// resources to be targeted from a single process. This is the additive, opt-in entry point for the
+/// distro's multi-instance support; the single-instance <c>UseMicrosoftOpenTelemetry</c> path is
+/// unchanged.
+/// </summary>
+public static class MultiInstanceTelemetry
+{
+    /// <summary>
+    /// Creates an isolated telemetry instance that exports to a single Azure Monitor resource. The
+    /// instance builds its own standalone tracer, meter, and logging pipelines and is never
+    /// registered as the process-global provider.
+    /// </summary>
+    /// <param name="name">Friendly name; also used as the Azure Monitor cloud role name.</param>
+    /// <param name="connectionString">Azure Monitor connection string for this instance.</param>
+    /// <param name="sharedSources">
+    /// Names of <see cref="System.Diagnostics.ActivitySource"/>s shared across instances. Spans from
+    /// these sources route to this instance only while one of its <see cref="TelemetryInstance.BeginScope"/>
+    /// scopes is active.
+    /// </param>
+    /// <returns>An isolated <see cref="TelemetryInstance"/> handle.</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="name"/> or <paramref name="connectionString"/> is null or whitespace.
+    /// </exception>
+    public static TelemetryInstance CreateAzureMonitorInstance(
+        string name,
+        string connectionString,
+        params string[] sharedSources)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Instance name is required.", nameof(name));
+        }
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("Connection string is required.", nameof(connectionString));
+        }
+
+        return new TelemetryInstance(name, connectionString, sharedSources ?? Array.Empty<string>());
+    }
+}

--- a/src/Microsoft.OpenTelemetry/MultiInstance/TelemetryInstance.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/TelemetryInstance.cs
@@ -14,24 +14,16 @@ using OpenTelemetry.Trace;
 namespace Microsoft.OpenTelemetry.MultiInstance;
 
 /// <summary>
-/// A fully isolated telemetry pipeline (traces, logs, and metrics) that exports to one specific
-/// Azure Monitor resource. Multiple instances can coexist in the same process without clobbering
-/// each other, and none of them is registered as the process-global provider.
+/// A fully isolated telemetry pipeline (traces, logs, and metrics) that exports to one Azure
+/// Monitor resource. Multiple instances coexist in one process without clobbering each other, and
+/// none is registered as the process-global provider.
 /// </summary>
 /// <remarks>
-/// <para>
-/// .NET has no process-global provider that every telemetry call routes through (tracing flows
-/// through <see cref="ActivitySource"/> and <c>ActivityListener</c>), so a naive "one
-/// <c>TracerProvider</c> per instance" fans out — a single <see cref="Activity"/> is delivered to
-/// every provider listening to the source. This type prevents that by stamping each activity with
-/// the owning instance id at start (<see cref="InstanceStampProcessor"/>) and gating export so each
-/// instance only emits its own activities (<see cref="GatingActivityExportProcessor"/>).
-/// </para>
-/// <para>Two usage modes are supported:</para>
-/// <list type="bullet">
-///   <item>Global/shared <see cref="ActivitySource"/> routed by <see cref="BeginScope"/>.</item>
-///   <item>Direct handles via <see cref="ActivitySource"/>, <see cref="Logger"/>, and <see cref="Meter"/>.</item>
-/// </list>
+/// Because an <see cref="Activity"/> is a single shared object observed by every listener, a plain
+/// provider-per-instance fans out. This type stamps each activity with its owning instance id at
+/// start (<see cref="InstanceStampProcessor"/>) and gates export to that id
+/// (<see cref="GatingActivityExportProcessor"/>). Spans route via <see cref="BeginScope"/> (shared
+/// source) or via the direct <see cref="ActivitySource"/>, <see cref="Logger"/>, and <see cref="Meter"/>.
 /// </remarks>
 public sealed class TelemetryInstance : IDisposable
 {
@@ -44,22 +36,21 @@ public sealed class TelemetryInstance : IDisposable
     internal TelemetryInstance(string name, string connectionString, IReadOnlyList<string> sharedSources)
     {
         Name = name;
-        Id = name;
-        var privateSourceName = $"{name}.Direct";
+
+        // Unique id so two instances with the same name stay isolated (the id is what gets stamped
+        // and gated). The private source name embeds it so direct-handle spans never collide.
+        Id = Guid.NewGuid().ToString("N");
+        var privateSourceName = $"{name}.Direct.{Id}";
 
         ActivitySource = new ActivitySource(privateSourceName);
-        Meter = new Meter($"{name}.Meter");
+        Meter = new Meter($"{name}.Meter.{Id}");
 
-        // service.name -> Azure Monitor cloud role name, so each resource is clearly labelled.
+        // service.name -> Azure Monitor cloud role name.
         var resourceBuilder = ResourceBuilder.CreateDefault()
             .AddService(serviceName: name, serviceInstanceId: $"{name}-{Environment.MachineName}");
 
-        // ── Traces ──────────────────────────────────────────────────────────────────────
-        // Standalone TracerProvider (never set as the global default). Listens to this
-        // instance's private source plus any shared sources used for ambient routing. The
-        // stamp processor marks each activity with the owning instance id; the gating export
-        // processor drops anything not belonging to this instance, so a shared ActivitySource
-        // fans in to exactly one resource.
+        // Traces: standalone provider (never the global default). Stamp marks the owning instance;
+        // the gating processor drops activities belonging to other instances.
         var traceExporter = new AzureMonitorTraceExporter(new AzureMonitorExporterOptions
         {
             ConnectionString = connectionString,
@@ -67,7 +58,6 @@ public sealed class TelemetryInstance : IDisposable
 
         var tracerBuilder = Sdk.CreateTracerProviderBuilder()
             .SetResourceBuilder(resourceBuilder)
-            .SetSampler(new AlwaysOnSampler())
             .AddSource(privateSourceName)
             .AddProcessor(new InstanceStampProcessor(Id, privateSourceName))
             .AddProcessor(new GatingActivityExportProcessor(Id, traceExporter, _ => Interlocked.Increment(ref _exportedSpanCount)));
@@ -79,19 +69,14 @@ public sealed class TelemetryInstance : IDisposable
 
         _tracerProvider = tracerBuilder.Build();
 
-        // ── Metrics ─────────────────────────────────────────────────────────────────────
-        // Private MeterProvider listens only to this instance's Meter, so no fan-out and no
-        // gating is needed. (Meter measurements carry no ambient context, so ambient routing
-        // does not apply — each instance owns its own Meter.)
+        // Metrics: private MeterProvider listens only to this instance's Meter, so no gating needed.
         _meterProvider = Sdk.CreateMeterProviderBuilder()
             .SetResourceBuilder(resourceBuilder)
             .AddMeter(Meter.Name)
             .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString)
             .Build();
 
-        // ── Logs ────────────────────────────────────────────────────────────────────────
-        // Private LoggerFactory with its own OpenTelemetry logging pipeline and Azure Monitor
-        // log exporter. The app logs through Logger, so records go only here.
+        // Logs: private LoggerFactory with its own Azure Monitor log exporter.
         _loggerFactory = LoggerFactory.Create(logging =>
         {
             logging.AddOpenTelemetry(otel =>
@@ -112,7 +97,7 @@ public sealed class TelemetryInstance : IDisposable
     /// <summary>Gets the stable id used to route telemetry to this instance.</summary>
     internal string Id { get; }
 
-    /// <summary>Gets an <see cref="ActivitySource"/> bound directly to this instance — spans from it always export here.</summary>
+    /// <summary>Gets an <see cref="ActivitySource"/> bound directly to this instance.</summary>
     public ActivitySource ActivitySource { get; }
 
     /// <summary>Gets a logger that writes only to this instance's Azure Monitor resource.</summary>
@@ -121,16 +106,12 @@ public sealed class TelemetryInstance : IDisposable
     /// <summary>Gets a <see cref="Meter"/> whose measurements are exported only to this instance's resource.</summary>
     public Meter Meter { get; }
 
-    /// <summary>
-    /// Gets the number of spans this instance has forwarded to its exporter — i.e. the spans that
-    /// passed the instance gate. Used by tests to assert isolation.
-    /// </summary>
+    /// <summary>Gets the number of spans this instance forwarded to its exporter. Used by tests to assert isolation.</summary>
     internal long ExportedSpanCount => Interlocked.Read(ref _exportedSpanCount);
 
     /// <summary>
-    /// Binds this instance as the ambient "current instance" for the executing async flow. While
-    /// the returned scope is active, spans created from any shared <see cref="ActivitySource"/>
-    /// route to this instance's Azure Monitor resource.
+    /// Binds this instance as the current instance for the executing async flow. While the returned
+    /// scope is active, spans from any shared <see cref="ActivitySource"/> route to this instance.
     /// </summary>
     /// <returns>A scope that unbinds this instance when disposed.</returns>
     public IDisposable BeginScope() => AmbientInstance.Use(Id);

--- a/src/Microsoft.OpenTelemetry/MultiInstance/TelemetryInstance.cs
+++ b/src/Microsoft.OpenTelemetry/MultiInstance/TelemetryInstance.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.OpenTelemetry.MultiInstance;
+
+/// <summary>
+/// A fully isolated telemetry pipeline (traces, logs, and metrics) that exports to one specific
+/// Azure Monitor resource. Multiple instances can coexist in the same process without clobbering
+/// each other, and none of them is registered as the process-global provider.
+/// </summary>
+/// <remarks>
+/// <para>
+/// .NET has no process-global provider that every telemetry call routes through (tracing flows
+/// through <see cref="ActivitySource"/> and <c>ActivityListener</c>), so a naive "one
+/// <c>TracerProvider</c> per instance" fans out — a single <see cref="Activity"/> is delivered to
+/// every provider listening to the source. This type prevents that by stamping each activity with
+/// the owning instance id at start (<see cref="InstanceStampProcessor"/>) and gating export so each
+/// instance only emits its own activities (<see cref="GatingActivityExportProcessor"/>).
+/// </para>
+/// <para>Two usage modes are supported:</para>
+/// <list type="bullet">
+///   <item>Global/shared <see cref="ActivitySource"/> routed by <see cref="BeginScope"/>.</item>
+///   <item>Direct handles via <see cref="ActivitySource"/>, <see cref="Logger"/>, and <see cref="Meter"/>.</item>
+/// </list>
+/// </remarks>
+public sealed class TelemetryInstance : IDisposable
+{
+    private readonly TracerProvider _tracerProvider;
+    private readonly MeterProvider _meterProvider;
+    private readonly ILoggerFactory _loggerFactory;
+    private long _exportedSpanCount;
+    private bool _disposed;
+
+    internal TelemetryInstance(string name, string connectionString, IReadOnlyList<string> sharedSources)
+    {
+        Name = name;
+        Id = name;
+        var privateSourceName = $"{name}.Direct";
+
+        ActivitySource = new ActivitySource(privateSourceName);
+        Meter = new Meter($"{name}.Meter");
+
+        // service.name -> Azure Monitor cloud role name, so each resource is clearly labelled.
+        var resourceBuilder = ResourceBuilder.CreateDefault()
+            .AddService(serviceName: name, serviceInstanceId: $"{name}-{Environment.MachineName}");
+
+        // ── Traces ──────────────────────────────────────────────────────────────────────
+        // Standalone TracerProvider (never set as the global default). Listens to this
+        // instance's private source plus any shared sources used for ambient routing. The
+        // stamp processor marks each activity with the owning instance id; the gating export
+        // processor drops anything not belonging to this instance, so a shared ActivitySource
+        // fans in to exactly one resource.
+        var traceExporter = new AzureMonitorTraceExporter(new AzureMonitorExporterOptions
+        {
+            ConnectionString = connectionString,
+        });
+
+        var tracerBuilder = Sdk.CreateTracerProviderBuilder()
+            .SetResourceBuilder(resourceBuilder)
+            .SetSampler(new AlwaysOnSampler())
+            .AddSource(privateSourceName)
+            .AddProcessor(new InstanceStampProcessor(Id, privateSourceName))
+            .AddProcessor(new GatingActivityExportProcessor(Id, traceExporter, _ => Interlocked.Increment(ref _exportedSpanCount)));
+
+        foreach (var source in sharedSources)
+        {
+            tracerBuilder.AddSource(source);
+        }
+
+        _tracerProvider = tracerBuilder.Build();
+
+        // ── Metrics ─────────────────────────────────────────────────────────────────────
+        // Private MeterProvider listens only to this instance's Meter, so no fan-out and no
+        // gating is needed. (Meter measurements carry no ambient context, so ambient routing
+        // does not apply — each instance owns its own Meter.)
+        _meterProvider = Sdk.CreateMeterProviderBuilder()
+            .SetResourceBuilder(resourceBuilder)
+            .AddMeter(Meter.Name)
+            .AddAzureMonitorMetricExporter(o => o.ConnectionString = connectionString)
+            .Build();
+
+        // ── Logs ────────────────────────────────────────────────────────────────────────
+        // Private LoggerFactory with its own OpenTelemetry logging pipeline and Azure Monitor
+        // log exporter. The app logs through Logger, so records go only here.
+        _loggerFactory = LoggerFactory.Create(logging =>
+        {
+            logging.AddOpenTelemetry(otel =>
+            {
+                otel.SetResourceBuilder(resourceBuilder);
+                otel.IncludeFormattedMessage = true;
+                otel.IncludeScopes = true;
+                otel.AddAzureMonitorLogExporter(o => o.ConnectionString = connectionString);
+            });
+        });
+
+        Logger = _loggerFactory.CreateLogger(name);
+    }
+
+    /// <summary>Gets the friendly name; also used as the Azure Monitor cloud role name.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the stable id used to route telemetry to this instance.</summary>
+    internal string Id { get; }
+
+    /// <summary>Gets an <see cref="ActivitySource"/> bound directly to this instance — spans from it always export here.</summary>
+    public ActivitySource ActivitySource { get; }
+
+    /// <summary>Gets a logger that writes only to this instance's Azure Monitor resource.</summary>
+    public ILogger Logger { get; }
+
+    /// <summary>Gets a <see cref="Meter"/> whose measurements are exported only to this instance's resource.</summary>
+    public Meter Meter { get; }
+
+    /// <summary>
+    /// Gets the number of spans this instance has forwarded to its exporter — i.e. the spans that
+    /// passed the instance gate. Used by tests to assert isolation.
+    /// </summary>
+    internal long ExportedSpanCount => Interlocked.Read(ref _exportedSpanCount);
+
+    /// <summary>
+    /// Binds this instance as the ambient "current instance" for the executing async flow. While
+    /// the returned scope is active, spans created from any shared <see cref="ActivitySource"/>
+    /// route to this instance's Azure Monitor resource.
+    /// </summary>
+    /// <returns>A scope that unbinds this instance when disposed.</returns>
+    public IDisposable BeginScope() => AmbientInstance.Use(Id);
+
+    /// <summary>Flushes this instance's traces and metrics. Logs are flushed on <see cref="Dispose"/>.</summary>
+    /// <param name="timeoutMilliseconds">Maximum time to wait for the flush to complete.</param>
+    public void ForceFlush(int timeoutMilliseconds = 10000)
+    {
+        _tracerProvider.ForceFlush(timeoutMilliseconds);
+        _meterProvider.ForceFlush(timeoutMilliseconds);
+    }
+
+    /// <summary>Flushes and tears down this instance's traces, metrics, and logs.</summary>
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        ActivitySource.Dispose();
+        Meter.Dispose();
+        _tracerProvider.Dispose();
+        _meterProvider.Dispose();
+        _loggerFactory.Dispose(); // flushes and drains the logging pipeline
+    }
+}

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/MultiInstance/MultiInstanceTelemetryTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/MultiInstance/MultiInstanceTelemetryTests.cs
@@ -107,6 +107,37 @@ public class MultiInstanceTelemetryTests
             MultiInstanceTelemetry.CreateAzureMonitorInstance("Telemetry A", connectionString!));
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CreateAzureMonitorInstance_Throws_WhenSharedSourceEntryMissing(string? sharedSource)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            MultiInstanceTelemetry.CreateAzureMonitorInstance("Telemetry A", FakeConnectionString(1), "Valid.Source", sharedSource!));
+    }
+
+    [Fact]
+    public void CreateAzureMonitorInstance_WithSameName_StaysIsolated()
+    {
+        using var a = MultiInstanceTelemetry.CreateAzureMonitorInstance("Same", FakeConnectionString(1), SharedSource);
+        using var b = MultiInstanceTelemetry.CreateAzureMonitorInstance("Same", FakeConnectionString(2), SharedSource);
+        using var source = new ActivitySource(SharedSource);
+
+        using (a.BeginScope())
+        {
+            source.StartActivity("a1")?.Dispose();
+        }
+
+        using (b.BeginScope())
+        {
+            source.StartActivity("b1")?.Dispose();
+        }
+
+        Assert.Equal(1, a.ExportedSpanCount);
+        Assert.Equal(1, b.ExportedSpanCount);
+    }
+
     [Fact]
     public void CreateAzureMonitorInstance_ExposesIsolatedHandles()
     {
@@ -129,8 +160,8 @@ public class MultiInstanceTelemetryTests
             .AddProcessor(new GatingActivityExportProcessor(id, new InMemoryExporter<Activity>(sink)))
             .Build();
 
-    // Syntactically valid connection string pointing at an unused local endpoint — no network is
-    // required because the assertions rely on the in-process gate, not on successful egress.
+    // Valid connection string pointing at an unused local endpoint; no network is required because
+    // the assertions rely on the in-process gate, not on successful egress.
     private static string FakeConnectionString(int n)
         => $"InstrumentationKey=0000000{n}-0000-0000-0000-00000000000{n};IngestionEndpoint=https://localhost/";
 }

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/MultiInstance/MultiInstanceTelemetryTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/MultiInstance/MultiInstanceTelemetryTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using Microsoft.OpenTelemetry.MultiInstance;
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.MultiInstance;
+
+/// <summary>
+/// Verifies the distro's multi-instance support: isolated pipelines that route telemetry to
+/// distinct destinations from a single process, with no fan-out between instances.
+/// </summary>
+public class MultiInstanceTelemetryTests
+{
+    private const string SharedSource = "Test.Shared.Workload";
+
+    /// <summary>
+    /// The core mechanic, exercised offline with in-memory exporters: a shared ActivitySource is
+    /// routed to exactly one instance based on the active scope, and an unscoped span is dropped by
+    /// every instance (no fan-out, no cross-talk).
+    /// </summary>
+    [Fact]
+    public void StampAndGate_RouteSharedSourceSpansToActiveInstanceOnly()
+    {
+        var exportedA = new List<Activity>();
+        var exportedB = new List<Activity>();
+
+        using var providerA = BuildGatedProvider("A", exportedA);
+        using var providerB = BuildGatedProvider("B", exportedB);
+        using var source = new ActivitySource(SharedSource);
+
+        using (AmbientInstance.Use("A"))
+        {
+            source.StartActivity("alpha")?.Dispose();
+        }
+
+        using (AmbientInstance.Use("B"))
+        {
+            source.StartActivity("beta")?.Dispose();
+        }
+
+        // No active scope -> no instance owns it.
+        source.StartActivity("orphan")?.Dispose();
+
+        providerA.ForceFlush();
+        providerB.ForceFlush();
+
+        Assert.Equal(new[] { "alpha" }, exportedA.Select(a => a.DisplayName));
+        Assert.Equal(new[] { "beta" }, exportedB.Select(a => a.DisplayName));
+    }
+
+    /// <summary>
+    /// End-to-end through the public API: two Azure Monitor instances isolate their spans whether
+    /// routed by scope (shared source) or emitted via the direct handle. Asserted via the gate's
+    /// forwarded-span count, which does not depend on network egress.
+    /// </summary>
+    [Fact]
+    public void CreateAzureMonitorInstance_IsolatesSpansAcrossInstances()
+    {
+        using var a = MultiInstanceTelemetry.CreateAzureMonitorInstance("Telemetry A", FakeConnectionString(1), SharedSource);
+        using var b = MultiInstanceTelemetry.CreateAzureMonitorInstance("Telemetry B", FakeConnectionString(2), SharedSource);
+        using var source = new ActivitySource(SharedSource);
+
+        using (a.BeginScope())
+        {
+            source.StartActivity("a1")?.Dispose();
+            source.StartActivity("a2")?.Dispose();
+        }
+
+        using (b.BeginScope())
+        {
+            source.StartActivity("b1")?.Dispose();
+        }
+
+        // Unscoped shared-source span belongs to no instance.
+        source.StartActivity("orphan")?.Dispose();
+
+        // Direct handles always route to their own instance, no scope needed.
+        a.ActivitySource.StartActivity("a-direct")?.Dispose();
+        b.ActivitySource.StartActivity("b-direct")?.Dispose();
+
+        Assert.Equal(3, a.ExportedSpanCount); // a1, a2, a-direct
+        Assert.Equal(2, b.ExportedSpanCount); // b1, b-direct
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CreateAzureMonitorInstance_Throws_WhenNameMissing(string? name)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            MultiInstanceTelemetry.CreateAzureMonitorInstance(name!, FakeConnectionString(1)));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CreateAzureMonitorInstance_Throws_WhenConnectionStringMissing(string? connectionString)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            MultiInstanceTelemetry.CreateAzureMonitorInstance("Telemetry A", connectionString!));
+    }
+
+    [Fact]
+    public void CreateAzureMonitorInstance_ExposesIsolatedHandles()
+    {
+        using var a = MultiInstanceTelemetry.CreateAzureMonitorInstance("Telemetry A", FakeConnectionString(1));
+        using var b = MultiInstanceTelemetry.CreateAzureMonitorInstance("Telemetry B", FakeConnectionString(2));
+
+        Assert.Equal("Telemetry A", a.Name);
+        Assert.Equal("Telemetry B", b.Name);
+        Assert.NotSame(a.ActivitySource, b.ActivitySource);
+        Assert.NotSame(a.Meter, b.Meter);
+        Assert.NotNull(a.Logger);
+        Assert.NotNull(b.Logger);
+    }
+
+    private static TracerProvider BuildGatedProvider(string id, ICollection<Activity> sink)
+        => Sdk.CreateTracerProviderBuilder()
+            .SetSampler(new AlwaysOnSampler())
+            .AddSource(SharedSource)
+            .AddProcessor(new InstanceStampProcessor(id, $"{id}.Direct"))
+            .AddProcessor(new GatingActivityExportProcessor(id, new InMemoryExporter<Activity>(sink)))
+            .Build();
+
+    // Syntactically valid connection string pointing at an unused local endpoint — no network is
+    // required because the assertions rely on the in-process gate, not on successful egress.
+    private static string FakeConnectionString(int n)
+        => $"InstrumentationKey=0000000{n}-0000-0000-0000-00000000000{n};IngestionEndpoint=https://localhost/";
+}


### PR DESCRIPTION
## Summary

Adds **opt-in multi-instance support** so a single process can export telemetry to **multiple Azure Monitor resources with full isolation**. The existing single-instance UseMicrosoftOpenTelemetry path is unchanged.

## Why .NET needs a different design

.NET has **no process-global provider** that every telemetry call routes through — tracing flows through ActivitySource → ActivityListener. So the parent/child *delegating-provider* model used by the JS/Python distros does not translate, and a naive *one `TracerProvider` per instance* **fans out**: a single `Activity` is delivered to (and exported by) every provider listening to the source.

## Design

| Piece | Role |
| --- | --- |
| `AmbientInstance` | `AsyncLocal<string>` current-instance id (the .NET analog of AsyncLocalStorage / ContextVar). |
| `InstanceStampProcessor` | Stamps the owning instance id onto each `Activity` at `OnStart` (app thread), so it survives the exporter's background thread where `AsyncLocal` is gone. |
| `GatingActivityExportProcessor` | A `BatchActivityExportProcessor` **subclass** that forwards only its instance's stamped activities. Subclassing (not wrapping) keeps the SDK's `Resource` wiring intact, so each resource keeps its own cloud role name. |
| `TelemetryInstance` / `MultiInstanceTelemetry` | Build a standalone tracer + meter + logging pipeline per instance wired to one connection string; none registered as the process global. |

Two usage modes:
1. **Global/shared `ActivitySource` routed by `BeginScope()`** — spans route to whichever instance is current.
2. **Direct handles** — `instance.ActivitySource` / `Logger` / `Meter` always go to that instance.

## Public API

- `MultiInstanceTelemetry.CreateAzureMonitorInstance(name, connectionString, params sharedSources)`
- `TelemetryInstance` (`Name`, `ActivitySource`, `Logger`, `Meter`, `BeginScope()`, `ForceFlush()`, `Dispose()`)

## Testing

xUnit tests in `Microsoft.OpenTelemetry.AzureMonitor.Tests` verify isolation (shared source routed to exactly one instance, unscoped spans dropped, no fan-out) and the public API guards. All pass (9/9).

This design was also validated end-to-end against two live Application Insights resources (traces, metrics, and logs each landed only in their own resource).

## Caveats / notes

- Sampling is process-global in .NET (a property of the shared `Activity`), so instances use a consistent sampler.
- Metrics and logs are per-instance direct (own `Meter` / `ILogger`), since metric measurements carry no ambient context.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
