### PR TITLE
Emit Network SDK Stats for the Agent365 (a365) exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Make the `invoke_agent` span compliant with OpenTelemetry GenAI semantic conventions v1.42: add request/response GenAI attributes (`gen_ai.request.*`, `gen_ai.data_source.id`, `gen_ai.output.type`, `gen_ai.system_instructions`, `gen_ai.response.finish_reasons`, `gen_ai.usage.*`) via reusable `GenAiRequestParameters`/`GenAiResponseParameters`, and emit `gen_ai.provider.name` on spans that carry agent details (e.g. `invoke_agent`, inference). Token usage is now emitted as integers and `gen_ai.response.finish_reasons` as a string array across all spans ([#120](https://github.com/microsoft/opentelemetry-distro-dotnet/pull/120))
 - Throttle distro Feature SDK Stats to a 24-hour emission cadence. The exporter now collects Feature SDK Stats on the shared 15-minute Network SDK Stats reader, so the observable gauge applies an emission-ticks throttle (mirroring the Attach gauge) to avoid emitting every 15 minutes.
+- Emit Network SDK Stats for the Agent365 (`a365`) exporter. When the Agent365 exporter is active, the distro records `Request_Success_Count`, `Request_Failure_Count`, `Request_Duration`, `Retry_Count`, `Throttle_Count`, and `Exception_Count` (with `endpoint=a365`) for its export requests via a distro-owned meter that the Azure Monitor exporter's Statsbeat `MeterProvider` subscribes to — mirroring the long-interval Feature SDK Stats path so Network stats ship even when the Azure Monitor exporter is not selected. Honors `APPLICATIONINSIGHTS_STATSBEAT_DISABLED=true`.
 
 ## 1.0.5 - 2026-06-12
 

--- a/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
+++ b/src/Microsoft.OpenTelemetry/Agent365/Runtime/Tracing/Exporters/Agent365ExporterCore.cs
@@ -5,6 +5,7 @@ using Microsoft.Agents.A365.Observability.Runtime.Tracing.Contracts;
 using Microsoft.Agents.A365.Observability.Runtime.Tracing.Scopes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.OpenTelemetry.AzureMonitor.SdkStats;
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using System;
@@ -181,6 +182,11 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                 var endpointPath = BuildEndpointPath(tenantId, agentId, options.UseS2SEndpoint);
                 var requestUri = BuildRequestUri(endpoint, endpointPath);
 
+                // Host used for the a365 Network SDKStats 'host' dimension (stamp is extracted
+                // by the recorder). Resolved once per identity group; null when the URI is
+                // malformed, in which case the recorder falls back to "unknown".
+                string? requestHost = Uri.TryCreate(requestUri, UriKind.Absolute, out var parsedUri) ? parsedUri.Host : null;
+
                 string? token = null;
                 try
                 {
@@ -234,7 +240,16 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
 
                     try
                     {
+                        var networkStats = DistroNetworkSdkStats.Instance;
+                        var stopwatch = networkStats != null ? Stopwatch.StartNew() : null;
+
                         using var resp = await sendAsync(request).ConfigureAwait(false);
+
+                        if (networkStats != null)
+                        {
+                            networkStats.TrackResponse(requestHost, (int)resp.StatusCode, stopwatch!.Elapsed.TotalMilliseconds);
+                        }
+
                         var correlationId = resp.Headers.Contains(CorrelationIdHeaderKey) ? resp.Headers.GetValues(CorrelationIdHeaderKey).FirstOrDefault() : null;
                         this._logger?.LogDebug("Agent365ExporterCore: HTTP {StatusCode} exporting spans. '{HeaderKey}': '{CorrelationId}'.", (int)resp.StatusCode, CorrelationIdHeaderKey, correlationId);
                         if (!resp.IsSuccessStatusCode)
@@ -247,11 +262,13 @@ namespace Microsoft.Agents.A365.Observability.Runtime.Tracing.Exporters
                     }
                     catch (HttpRequestException ex)
                     {
+                        DistroNetworkSdkStats.Instance?.TrackException(requestHost, ex.GetType().FullName);
                         this._logger?.LogError(ex, "Agent365ExporterCore: Exception exporting spans.");
                         return ExportResult.Failure;
                     }
                     catch (TaskCanceledException ex)
                     {
+                        DistroNetworkSdkStats.Instance?.TrackException(requestHost, ex.GetType().FullName);
                         this._logger?.LogError(ex, "Agent365ExporterCore: Exception exporting spans.");
                         return ExportResult.Failure;
                     }

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroNetworkSdkStats.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroNetworkSdkStats.cs
@@ -1,0 +1,307 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using Microsoft.OpenTelemetry.AzureMonitor.Internals;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
+{
+    /// <summary>
+    /// Owns the distro's short-interval Network SDKStats meter and instruments for telemetry
+    /// the distro itself ships to the Agent365 (<c>a365</c>) ingestion endpoint. The Azure
+    /// Monitor exporter's Statsbeat <c>MeterProvider</c> subscribes to <see cref="MeterName"/>
+    /// (see <c>StatsbeatConstants.DistroNetworkSdkStatsMeterName</c> in the exporter), so these
+    /// measurements flow out on the shared 15-minute reader even when the Azure Monitor
+    /// exporter is not selected.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the Network analog of <see cref="DistroFeatureSdkStats"/>. The exporter only
+    /// records Network SDKStats for its own Breeze transmitter; when a customer runs the distro
+    /// with the Agent365 exporter (and no Azure Monitor exporter), the distro owns the
+    /// <c>a365</c> Network signal and records it here. Instrument names follow the SDKStats
+    /// specification; the <c>endpoint</c> dimension is <c>a365</c> and <c>version</c> is the
+    /// distro package version.
+    /// </para>
+    /// <para>
+    /// The class is a process-wide singleton because the underlying <see cref="Meter"/> is a
+    /// process-wide resource and the exporter's MeterProvider subscribes by name. Recording is
+    /// imperative (per request) rather than via an observable gauge, so per-request
+    /// <c>host</c> / <c>statusCode</c> / <c>exceptionType</c> dimensions can be attached.
+    /// </para>
+    /// </remarks>
+    internal sealed class DistroNetworkSdkStats : IDisposable
+    {
+        /// <summary>
+        /// Meter name owned by the distro for Network SDKStats. Must match the constant
+        /// subscribed by the Azure Monitor exporter's Statsbeat <see cref="Meter"/> provider.
+        /// </summary>
+        internal const string MeterName = "MicrosoftOpenTelemetryNetworkSdkStatsMeter";
+
+        /// <summary>Meter version reported alongside <see cref="MeterName"/>.</summary>
+        internal const string MeterVersion = "1.0";
+
+        /// <summary>Value of the <c>endpoint</c> dimension for telemetry sent to Agent365.</summary>
+        internal const string EndpointA365 = "a365";
+
+        private const string Language = "dotnet";
+
+        // HTTP status codes that the per-request classification treats specially. 200 is the
+        // only success code per spec; 206/307/308 are handled by the pipeline and ignored.
+        private const int StatusSuccess = 200;
+        private const int StatusPartialSuccess = 206;
+        private const int StatusTemporaryRedirect = 307;
+        private const int StatusPermanentRedirect = 308;
+
+        private static DistroNetworkSdkStats? s_instance;
+        private static readonly object s_lock = new();
+
+        private static readonly string s_runtimeVersion = ResolveRuntimeVersion();
+
+        private readonly Meter _meter;
+        private readonly Counter<long> _requestSuccessCount;
+        private readonly Counter<long> _requestFailureCount;
+        private readonly Histogram<double> _requestDuration;
+        private readonly Counter<long> _retryCount;
+        private readonly Counter<long> _throttleCount;
+        private readonly Counter<long> _exceptionCount;
+
+        private string _customerInstrumentationKey;
+        private string _distroVersion;
+
+        private DistroNetworkSdkStats(string customerInstrumentationKey, string distroVersion)
+        {
+            _customerInstrumentationKey = customerInstrumentationKey;
+            _distroVersion = distroVersion;
+            _meter = new Meter(MeterName, MeterVersion);
+
+            _requestSuccessCount = _meter.CreateCounter<long>(
+                "Request_Success_Count",
+                description: "Count of requests accepted by the destination ingestion endpoint.");
+            _requestFailureCount = _meter.CreateCounter<long>(
+                "Request_Failure_Count",
+                description: "Count of requests that returned a non-retryable, non-throttling failure from the destination ingestion endpoint.");
+            _requestDuration = _meter.CreateHistogram<double>(
+                "Request_Duration",
+                unit: "ms",
+                description: "Duration of requests to the destination ingestion endpoint.");
+            _retryCount = _meter.CreateCounter<long>(
+                "Retry_Count",
+                description: "Count of requests for which the destination ingestion endpoint returned a retryable response.");
+            _throttleCount = _meter.CreateCounter<long>(
+                "Throttle_Count",
+                description: "Count of requests for which the destination ingestion endpoint returned a quota / rate-limit response.");
+            _exceptionCount = _meter.CreateCounter<long>(
+                "Exception_Count",
+                description: "Count of requests that failed with an exception (no response code received).");
+        }
+
+        /// <summary>The active singleton, if <see cref="Initialize"/> has been called.</summary>
+        internal static DistroNetworkSdkStats? Instance => s_instance;
+
+        /// <summary>
+        /// Registers (or updates) the distro Network SDKStats producer. Safe to call repeatedly;
+        /// the most recent customer iKey / distro version wins.
+        /// </summary>
+        /// <param name="customerInstrumentationKey">
+        /// Customer instrumentation key, or <c>"N/A"</c> when no Azure Monitor connection string
+        /// is configured (the common Agent365-only case).
+        /// </param>
+        /// <param name="distroVersion">Distro package version reported as the <c>version</c> dimension.</param>
+        internal static DistroNetworkSdkStats Initialize(string customerInstrumentationKey, string distroVersion)
+        {
+            lock (s_lock)
+            {
+                if (s_instance is null)
+                {
+                    s_instance = new DistroNetworkSdkStats(customerInstrumentationKey, distroVersion);
+                }
+                else
+                {
+                    Volatile.Write(ref s_instance._customerInstrumentationKey, customerInstrumentationKey);
+                    Volatile.Write(ref s_instance._distroVersion, distroVersion);
+                }
+
+                return s_instance;
+            }
+        }
+
+        /// <summary>
+        /// Releases the singleton instance and disposes the underlying meter. Test-only;
+        /// production code keeps the singleton alive for the lifetime of the process.
+        /// </summary>
+        internal static void ResetForTesting()
+        {
+            lock (s_lock)
+            {
+                s_instance?.Dispose();
+                s_instance = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            _meter.Dispose();
+        }
+
+        /// <summary>
+        /// Records the outcome of a single Agent365 export request given the HTTP status code
+        /// and elapsed time. Classifies the status code per the SDKStats spec and records the
+        /// matching instrument(s) plus <c>Request_Duration</c>.
+        /// </summary>
+        /// <param name="requestHost">Host portion of the request URI; the stamp segment is extracted.</param>
+        /// <param name="statusCode">HTTP status code returned by the Agent365 endpoint.</param>
+        /// <param name="durationMs">Elapsed request time in milliseconds.</param>
+        internal void TrackResponse(string? requestHost, int statusCode, double durationMs)
+        {
+            TrackDuration(requestHost, durationMs);
+
+            if (statusCode == StatusSuccess)
+            {
+                TrackSuccess(requestHost);
+                return;
+            }
+
+            // 206 (per-envelope partial) and 307/308 redirects are not terminal outcomes and
+            // are not counted as success or failure (matches the exporter's Breeze handling).
+            if (statusCode == StatusPartialSuccess
+                || statusCode == StatusTemporaryRedirect
+                || statusCode == StatusPermanentRedirect)
+            {
+                return;
+            }
+
+            if (DistroNetworkSdkStatsHelper.IsRetryable(statusCode))
+            {
+                TrackRetry(requestHost, statusCode);
+            }
+            else if (DistroNetworkSdkStatsHelper.IsThrottle(statusCode))
+            {
+                TrackThrottle(requestHost, statusCode);
+            }
+            else
+            {
+                TrackFailure(requestHost, statusCode);
+            }
+        }
+
+        /// <summary>Record a successful (HTTP 200) transmission. Backs <c>Request_Success_Count</c>.</summary>
+        internal void TrackSuccess(string? requestHost)
+        {
+            try
+            {
+                _requestSuccessCount.Add(1, BuildBaseTags(requestHost));
+            }
+            catch
+            {
+                // SDKStats are best-effort internal telemetry; never surface a recording failure.
+            }
+        }
+
+        /// <summary>Record request duration regardless of outcome. Backs <c>Request_Duration</c>.</summary>
+        internal void TrackDuration(string? requestHost, double durationMs)
+        {
+            try
+            {
+                _requestDuration.Record(durationMs, BuildBaseTags(requestHost));
+            }
+            catch
+            {
+                // See TrackSuccess.
+            }
+        }
+
+        /// <summary>Record a non-retryable, non-throttling failure. Backs <c>Request_Failure_Count</c>.</summary>
+        internal void TrackFailure(string? requestHost, int statusCode)
+        {
+            try
+            {
+                _requestFailureCount.Add(1, BuildStatusCodeTags(requestHost, statusCode));
+            }
+            catch
+            {
+                // See TrackSuccess.
+            }
+        }
+
+        /// <summary>Record a retryable response. Backs <c>Retry_Count</c>.</summary>
+        internal void TrackRetry(string? requestHost, int statusCode)
+        {
+            try
+            {
+                _retryCount.Add(1, BuildStatusCodeTags(requestHost, statusCode));
+            }
+            catch
+            {
+                // See TrackSuccess.
+            }
+        }
+
+        /// <summary>Record a throttling response. Backs <c>Throttle_Count</c>.</summary>
+        internal void TrackThrottle(string? requestHost, int statusCode)
+        {
+            try
+            {
+                _throttleCount.Add(1, BuildStatusCodeTags(requestHost, statusCode));
+            }
+            catch
+            {
+                // See TrackSuccess.
+            }
+        }
+
+        /// <summary>Record an exception during the HTTP call (no response code). Backs <c>Exception_Count</c>.</summary>
+        internal void TrackException(string? requestHost, string? exceptionType)
+        {
+            try
+            {
+                var tags = BuildBaseTags(requestHost);
+                tags.Add("exceptionType", exceptionType ?? "unknown");
+                _exceptionCount.Add(1, tags);
+            }
+            catch
+            {
+                // See TrackSuccess.
+            }
+        }
+
+        private TagList BuildBaseTags(string? requestHost)
+        {
+            return new TagList
+            {
+                { "rp", ResourceProviderHelper.GetResourceProvider() },
+                { "attach", ResourceProviderHelper.GetAttachMode() },
+                { "cikey", Volatile.Read(ref _customerInstrumentationKey) },
+                { "runtimeVersion", s_runtimeVersion },
+                { "os", ResourceProviderHelper.GetOperatingSystem() },
+                { "language", Language },
+                { "version", Volatile.Read(ref _distroVersion) },
+                { "endpoint", EndpointA365 },
+                { "host", DistroNetworkSdkStatsHelper.ExtractStampHost(requestHost) },
+            };
+        }
+
+        private TagList BuildStatusCodeTags(string? requestHost, int statusCode)
+        {
+            var tags = BuildBaseTags(requestHost);
+            tags.Add("statusCode", statusCode);
+            return tags;
+        }
+
+        private static string ResolveRuntimeVersion()
+        {
+            try
+            {
+                // Mirrors the exporter's runtimeVersion (assembly version of System.Private.CoreLib).
+                return typeof(object).Assembly.GetName().Version?.ToString() ?? "unknown";
+            }
+            catch (Exception)
+            {
+                return "unknown";
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroNetworkSdkStatsHelper.cs
+++ b/src/Microsoft.OpenTelemetry/AzureMonitor/SdkStats/DistroNetworkSdkStatsHelper.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.SdkStats
+{
+    /// <summary>
+    /// Stateless helpers for distro-owned Network SDKStats: stamp-host extraction and the
+    /// response-status classification (retryable / throttling) used by the failure / retry /
+    /// throttle instruments. The Agent365 (<c>a365</c>) endpoint follows the same HTTP status
+    /// semantics as Breeze per the SDKStats specification.
+    /// </summary>
+    internal static class DistroNetworkSdkStatsHelper
+    {
+        /// <summary>
+        /// Extract the stamp-specific host segment from an ingestion endpoint host name
+        /// (e.g. <c>westus2-1.in.applicationinsights.azure.com</c> → <c>westus2-1</c>).
+        /// </summary>
+        internal static string ExtractStampHost(string? requestHost)
+        {
+            if (string.IsNullOrEmpty(requestHost))
+            {
+                return "unknown";
+            }
+
+            const string wwwPrefix = "www.";
+            string host = requestHost!;
+            if (host.StartsWith(wwwPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                host = host.Substring(wwwPrefix.Length);
+            }
+
+            int firstDot = host.IndexOf('.');
+            return firstDot > 0 ? host.Substring(0, firstDot) : host;
+        }
+
+        /// <summary>
+        /// Whether a status code is retryable per the Network SDKStats spec
+        /// (<c>a365</c> uses the Breeze code set): 401, 403, 408, 429, 500, 502, 503, or 504.
+        /// </summary>
+        internal static bool IsRetryable(int statusCode) =>
+            statusCode == 401
+            || statusCode == 403
+            || statusCode == 408
+            || statusCode == 429
+            || statusCode == 500
+            || statusCode == 502
+            || statusCode == 503
+            || statusCode == 504;
+
+        /// <summary>
+        /// Whether a status code is a throttling response per the Network SDKStats spec
+        /// (<c>a365</c> uses the Breeze code set): 402 or 439.
+        /// </summary>
+        internal static bool IsThrottle(int statusCode) =>
+            statusCode == 402
+            || statusCode == 439;
+    }
+}

--- a/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
+++ b/src/Microsoft.OpenTelemetry/MicrosoftOpenTelemetryBuilderExtensions.cs
@@ -400,6 +400,16 @@ public static class MicrosoftOpenTelemetryBuilderExtensions
                 // above) already brought up SDK Stats; nothing left for this callback to do
                 // on the pin side.
                 DistroFeatureSdkStats.Initialize(snapshot);
+
+                // Network SDKStats: the Azure Monitor exporter only records Network stats for
+                // its own Breeze transmitter. When the Agent365 exporter is active, the distro
+                // owns the a365 Network signal and records it itself (see Agent365ExporterCore).
+                // Other languages don't yet support Network SDKStats for OTLP, so this is scoped
+                // to Agent365 only.
+                if (effectiveExporters.HasFlag(ExportTarget.Agent365))
+                {
+                    DistroNetworkSdkStats.Initialize(snapshot.CustomerInstrumentationKey, snapshot.DistroVersion);
+                }
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroNetworkSdkStatsTests.cs
+++ b/test/Microsoft.OpenTelemetry.AzureMonitor.Tests/SdkStats/DistroNetworkSdkStatsTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using Microsoft.OpenTelemetry.AzureMonitor.SdkStats;
+using Xunit;
+
+namespace Microsoft.OpenTelemetry.AzureMonitor.Tests.SdkStats
+{
+    [Collection(nameof(DistroNetworkSdkStatsCollection))]
+    public class DistroNetworkSdkStatsTests
+    {
+        public DistroNetworkSdkStatsTests()
+        {
+            DistroNetworkSdkStats.ResetForTesting();
+        }
+
+        [Fact]
+        public void TrackResponse_Success_RecordsRequestSuccessWithExpectedTags()
+        {
+            DistroNetworkSdkStats.Initialize("N/A", "9.9.9-test");
+
+            var measurements = Collect(() =>
+                DistroNetworkSdkStats.Instance!.TrackResponse(
+                    "westus2-1.in.applicationinsights.azure.com", statusCode: 200, durationMs: 12.5));
+
+            var success = Assert.Single(measurements, m => m.instrument == "Request_Success_Count");
+            Assert.Equal(1, success.value);
+            Assert.Equal("a365", success.tags["endpoint"]);
+            Assert.Equal("9.9.9-test", success.tags["version"]);
+            Assert.Equal("N/A", success.tags["cikey"]);
+            Assert.Equal("dotnet", success.tags["language"]);
+            Assert.Equal("westus2-1", success.tags["host"]);
+            Assert.True(success.tags.ContainsKey("rp"));
+            Assert.True(success.tags.ContainsKey("attach"));
+            Assert.True(success.tags.ContainsKey("os"));
+            Assert.True(success.tags.ContainsKey("runtimeVersion"));
+
+            // Duration is always recorded alongside the outcome.
+            Assert.Contains(measurements, m => m.instrument == "Request_Duration");
+        }
+
+        [Theory]
+        [InlineData(500, "Retry_Count")]
+        [InlineData(429, "Retry_Count")]
+        [InlineData(402, "Throttle_Count")]
+        [InlineData(439, "Throttle_Count")]
+        [InlineData(400, "Request_Failure_Count")]
+        [InlineData(404, "Request_Failure_Count")]
+        public void TrackResponse_ClassifiesStatusCodes(int statusCode, string expectedInstrument)
+        {
+            DistroNetworkSdkStats.Initialize("N/A", "9.9.9-test");
+
+            var measurements = Collect(() =>
+                DistroNetworkSdkStats.Instance!.TrackResponse("host.example.com", statusCode, durationMs: 1.0));
+
+            var match = Assert.Single(measurements, m => m.instrument == expectedInstrument);
+            Assert.Equal(1, match.value);
+            Assert.Equal(statusCode, match.tags["statusCode"]);
+            // Failure/retry/throttle never report a success for the same call.
+            Assert.DoesNotContain(measurements, m => m.instrument == "Request_Success_Count");
+        }
+
+        [Theory]
+        [InlineData(206)]
+        [InlineData(307)]
+        [InlineData(308)]
+        public void TrackResponse_IgnoresPartialAndRedirects(int statusCode)
+        {
+            DistroNetworkSdkStats.Initialize("N/A", "9.9.9-test");
+
+            var measurements = Collect(() =>
+                DistroNetworkSdkStats.Instance!.TrackResponse("host.example.com", statusCode, durationMs: 1.0));
+
+            // Only duration is recorded; no success/failure/retry/throttle.
+            Assert.DoesNotContain(measurements, m => m.instrument == "Request_Success_Count");
+            Assert.DoesNotContain(measurements, m => m.instrument == "Request_Failure_Count");
+            Assert.DoesNotContain(measurements, m => m.instrument == "Retry_Count");
+            Assert.DoesNotContain(measurements, m => m.instrument == "Throttle_Count");
+            Assert.Contains(measurements, m => m.instrument == "Request_Duration");
+        }
+
+        [Fact]
+        public void TrackException_RecordsExceptionWithType()
+        {
+            DistroNetworkSdkStats.Initialize("ikey-123", "9.9.9-test");
+
+            var measurements = Collect(() =>
+                DistroNetworkSdkStats.Instance!.TrackException(
+                    requestHost: null, exceptionType: "System.Net.Http.HttpRequestException"));
+
+            var ex = Assert.Single(measurements, m => m.instrument == "Exception_Count");
+            Assert.Equal(1, ex.value);
+            Assert.Equal("System.Net.Http.HttpRequestException", ex.tags["exceptionType"]);
+            Assert.Equal("ikey-123", ex.tags["cikey"]);
+            // Null host falls back to "unknown" per the helper.
+            Assert.Equal("unknown", ex.tags["host"]);
+        }
+
+        [Fact]
+        public void Initialize_IsIdempotent_AndUpdatesContext()
+        {
+            var first = DistroNetworkSdkStats.Initialize("N/A", "1.0.0");
+            var second = DistroNetworkSdkStats.Initialize("ikey-xyz", "2.0.0");
+
+            Assert.Same(first, second);
+
+            var measurements = Collect(() =>
+                DistroNetworkSdkStats.Instance!.TrackSuccess("host.example.com"));
+
+            var success = Assert.Single(measurements, m => m.instrument == "Request_Success_Count");
+            Assert.Equal("ikey-xyz", success.tags["cikey"]);
+            Assert.Equal("2.0.0", success.tags["version"]);
+        }
+
+        private static List<(string instrument, long value, Dictionary<string, object?> tags)> Collect(System.Action record)
+        {
+            var results = new List<(string instrument, long value, Dictionary<string, object?> tags)>();
+
+            using var listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == DistroNetworkSdkStats.MeterName)
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+
+            listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+                results.Add((instrument.Name, value, ToDict(tags))));
+            listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+                results.Add((instrument.Name, (long)value, ToDict(tags))));
+            listener.Start();
+
+            record();
+            return results;
+        }
+
+        private static Dictionary<string, object?> ToDict(System.ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var dict = new Dictionary<string, object?>(tags.Length);
+            for (int i = 0; i < tags.Length; i++)
+            {
+                dict[tags[i].Key] = tags[i].Value;
+            }
+
+            return dict;
+        }
+    }
+
+    [CollectionDefinition(nameof(DistroNetworkSdkStatsCollection), DisableParallelization = true)]
+    public class DistroNetworkSdkStatsCollection
+    {
+        // The DistroNetworkSdkStats singleton is process-wide; serialize tests that touch it.
+    }
+}


### PR DESCRIPTION
## Summary

When a customer runs the Microsoft .NET distro with the **Agent365 exporter** (e.g. Agent365-only or OTLP/Agent365, without the Azure Monitor exporter), Network SDK Stats were never recorded — the exporter only records Network stats for its own Breeze transmitter. This PR makes the distro emit **Network SDK Stats for the Agent365 (`a365`) endpoint**, following the same pattern as the long-interval Feature SDK Stats (`DistroFeatureSdkStats`).

Scoped to **Agent365 only** — OTLP Network SDK Stats are not yet supported across the other language distros.

## What it does

- **`DistroNetworkSdkStats`** — distro-owned singleton meter `MicrosoftOpenTelemetryNetworkSdkStatsMeter` with the six spec instruments: `Request_Success_Count`, `Request_Failure_Count`, `Request_Duration`, `Retry_Count`, `Throttle_Count`, `Exception_Count`. Base dimensions per the SDKStats spec: `rp`, `attach`, `cikey`, `runtimeVersion`, `os`, `language`, `version` (distro version), `endpoint=a365`, `host` (+ `statusCode` / `exceptionType`).
- **`DistroNetworkSdkStatsHelper`** — stamp-host extraction + retry/throttle status classification (`a365` uses the Breeze HTTP code set per the spec).
- **`Agent365ExporterCore`** — records the outcome of each export request around the single `sendAsync` chokepoint (covers both the sync and async exporters); HTTP exceptions are recorded as `Exception_Count`.
- **`MicrosoftOpenTelemetryBuilderExtensions`** — initializes the recorder in the deferred MeterProvider callback, gated on the Agent365 exporter being active, honoring the `APPLICATIONINSIGHTS_STATSBEAT_DISABLED` kill switch (shared with Feature SDK Stats).

The Azure Monitor exporter's Statsbeat `MeterProvider` subscribes to this distro-owned meter by name, so the stats ship even when no Azure Monitor exporter is selected — exactly like `DistroFeatureSdkStats`.

## Status classification (`endpoint=a365`, Breeze code set)

- `200` → `Request_Success_Count`
- `401/403/408/429/500/502/503/504` → `Retry_Count`
- `402/439` → `Throttle_Count`
- `206/307/308` → ignored (not a terminal outcome)
- everything else → `Request_Failure_Count`
- HTTP exception (no response) → `Exception_Count`

## Cross-repo dependency

This relies on the Azure Monitor exporter's Statsbeat `MeterProvider` subscribing to `MicrosoftOpenTelemetryNetworkSdkStatsMeter` (a one-line `.AddMeter(...)` + constant, mirroring `DistroFeatureSdkStatsMeterName`). That change goes into the exporter alongside the existing Network SDK Stats work; the distro pin in `Directory.Packages.props` must be bumped to an exporter build containing it before the end-to-end flow is active — the same cross-repo dependency as the original `DistroFeatureSdkStats` work.

## Testing

- Distro builds clean (netstandard2.0 + net8.0).
- New `DistroNetworkSdkStatsTests` (12 tests) cover tag population, status classification, partial/redirect handling, exceptions, and idempotent re-init.
- Full SdkStats suite (48) and Agent365 suite (108) pass.
